### PR TITLE
docs: rewrite README performance section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Breaking:** The DataFrame and metric computation internals were redesigned for performance. `NewDataFrame` accepts per-column slices instead of a flat slab, and metrics now compute against a `PortfolioStats` interface rather than a concrete `*Account`. These changes improve runtime by 9x and reduce memory by 14x over v0.3.0 -- a 20-year backtest of Accelerating Dual Momentum now takes approximately 4 seconds.
+- **Breaking:** The DataFrame and metric computation internals were redesigned for performance. `NewDataFrame` accepts per-column slices instead of a flat slab, and metrics now compute against a `PortfolioStats` interface rather than a concrete `*Account`. These changes improve runtime by 9x and reduce memory by 14x over v0.3.0 -- a 30-year backtest of Accelerating Dual Momentum now takes approximately 4 seconds.
 
 ## [0.3.0] - 2026-03-21
 

--- a/README.md
+++ b/README.md
@@ -100,31 +100,11 @@ The engine runs in three phases:
 
 ## Performance
 
-The DataFrame engine and metric computation pipeline are optimized for
-throughput. A full 20-year backtest of the Accelerating Dual Momentum strategy
-(85+ metrics, 7 windows per metric, daily rebalancing checks) runs in ~4
-seconds on an M-series MacBook.
+Good strategy research means running backtests often -- tweaking a parameter, testing a variant, checking a hunch. The engine is designed to keep that loop tight so you spend your time thinking, not waiting. A 30-year backtest of Accelerating Dual Momentum finishes in about 4 seconds on an M-series MacBook.
 
-Key optimizations:
-
-- **Per-column DataFrame storage.** Each (asset, metric) pair is its own
-  `[]float64`. Time-axis, metric-axis, and asset-axis slicing are zero-copy
-  view operations -- sub-slicing column references instead of copying data.
-- **Lazy integer date keys.** Daily-frequency DataFrames cache YYYYMMDD integer
-  keys for binary search, eliminating timezone lookups during time-index
-  operations.
-- **Per-window metric caching.** The `PortfolioStats` interface caches derived
-  series (returns, excess returns, drawdown, benchmark returns) per window.
-  When 26 metrics request the same windowed returns, the computation runs once.
-- **Allocation-conscious design.** `removeNaN` on extracted `[]float64` columns
-  instead of `DataFrame.Drop(NaN)` on entire frames. `AppendRow` uses
-  per-column `append()` instead of rebuilding the data slab. `Window(nil)`
-  returns a view instead of a deep copy.
-
-| Metric | Value |
-|--------|-------|
-| 20-year ADM backtest | ~4s |
-| Total allocations per run | 4.1 GB |
+- **Zero-copy DataFrame views.** Windowing, filtering by metric, and selecting assets share the underlying data instead of copying it, keeping chained transformations cheap over decades of daily history.
+- **Shared metric computation.** The 85+ built-in metrics share intermediate results -- when 26 metrics all need the same windowed returns, they compute them once.
+- **Low allocation pressure.** Per-column storage and view-based slicing minimize GC pauses, so performance stays consistent across long backtests.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrote the Performance section to match the README's voice -- leads with why fast iteration matters, follows with scannable bullets for key capabilities, closes with the benchmark number
- Fixed backtest duration from 20 years to 30 years in both README and changelog