### PR TITLE
Remove unused Unemployment metric constant

### DIFF
--- a/data/metric.go
+++ b/data/metric.go
@@ -284,12 +284,6 @@ const (
 	MarketCapFundamental Metric = "MarketCapFundamental"
 )
 
-// Economic indicator metrics.
-const (
-	// Unemployment is the civilian unemployment rate.
-	Unemployment Metric = "Unemployment"
-)
-
 // Computed aggregate metrics.
 const (
 	// Count is the metric used by CountWhere to store per-timestep counts.

--- a/data/metric_registry.go
+++ b/data/metric_registry.go
@@ -76,8 +76,6 @@ var metricRegistry = map[string]Metric{
 	"InvestedCapital": InvestedCapital, "InvestedCapitalAvg": InvestedCapitalAvg,
 	"TangibleAssetValue": TangibleAssetValue, "WorkingCapital": WorkingCapital,
 	"MarketCapFundamental": MarketCapFundamental,
-	// Economic
-	"Unemployment": Unemployment,
 }
 
 // MetricByName looks up a Metric constant by its registry name.


### PR DESCRIPTION
## Summary

- Remove the unused `Unemployment` metric constant and its registry entry -- economic indicators are accessed via the `FRED:` ticker prefix (e.g. `FRED:UNRATE`) through universes and data providers, making this dedicated constant dead code.