### PR TITLE
Expand stress scenarios and add changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Studies can now answer questions that a single backtest cannot: "how does my strategy hold up during the worst historical crises?" or "which parameter values produce the most consistent results?" The new `study` command runs a strategy across multiple configurations concurrently and produces a combined analysis report. Parameter sweeps let you vary lookback periods, universe composition, presets, or any other strategy parameter and see how each affects performance.
-- The first built-in study is the stress test (`study stress-test`), which evaluates a strategy against six named historical crises -- the 2008 Financial Crisis, COVID Crash, Dot-com Bust, 2022 Rate Hiking Cycle, 2015-2017 Low-Volatility Grind, and 2011 Debt Ceiling Crisis. It reports per-scenario drawdown, recovery speed, worst single day, and how the strategy performed relative to its benchmark during each episode. Custom scenarios can be added programmatically.
+- The first built-in study is the stress test (`study stress-test`), which evaluates a strategy against six named historical crises -- 17 named historical episodes spanning five decades, from the 1973 oil embargo through the 2023 regional banking crisis. It reports per-scenario drawdown, recovery speed, worst single day, and how the strategy performed relative to its benchmark during each episode. Custom scenarios can be added programmatically.
 
 ### Changed
 

--- a/docs/studies.md
+++ b/docs/studies.md
@@ -100,12 +100,23 @@ The stress test runs a strategy against named historical market scenarios and an
 
 | Scenario | Period |
 |----------|--------|
+| 1973-74 Oil Embargo Bear Market | Jan 1973 -- Oct 1974 |
+| Volcker Tightening | Jan 1980 -- Aug 1982 |
+| 1987 Black Monday | Oct 1987 -- Dec 1987 |
+| 1994 Bond Massacre | Feb 1994 -- Nov 1994 |
+| 1998 LTCM / Russian Crisis | Aug 1998 -- Oct 1998 |
+| Dot-com Bubble | Jan 1998 -- Mar 2000 |
+| Dot-com Bust | Mar 2000 -- Oct 2002 |
+| 9/11 | Sep 2001 -- Oct 2001 |
 | 2008 Financial Crisis | Sep 2008 -- Mar 2009 |
+| 2010 Flash Crash | May 2010 -- Jun 2010 |
+| Euro Debt Crisis | Apr 2010 -- Oct 2011 |
+| 2011 Debt Ceiling Crisis | Jul 2011 -- Oct 2011 |
+| 2015-2017 Low-Volatility Grind | Jan 2015 -- Dec 2017 |
+| 2018 Q4 Selloff | Oct 2018 -- Dec 2018 |
 | COVID Crash | Feb 2020 -- Mar 2020 |
 | 2022 Rate Hiking Cycle | Jan 2022 -- Oct 2022 |
-| Dot-com Bust | Mar 2000 -- Oct 2002 |
-| 2015-2017 Low-Volatility Grind | Jan 2015 -- Dec 2017 |
-| 2011 Debt Ceiling Crisis | Jul 2011 -- Oct 2011 |
+| 2023 Regional Banking Crisis | Mar 2023 -- May 2023 |
 
 The stress test runs the engine once over the full date range spanning all scenarios, then slices the equity curve into scenario windows for analysis. This avoids redundant engine runs when only the analysis window varies.
 

--- a/study/stress/scenarios.go
+++ b/study/stress/scenarios.go
@@ -31,10 +31,88 @@ type Scenario struct {
 func DefaultScenarios() []Scenario {
 	return []Scenario{
 		{
+			Name:        "1973-74 Oil Embargo Bear Market",
+			Description: "Prolonged bear market driven by the OPEC oil embargo and stagflation",
+			Start:       time.Date(1973, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(1974, 10, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "Volcker Tightening",
+			Description: "Federal Reserve raised rates to 20% to break double-digit inflation",
+			Start:       time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(1982, 8, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "1987 Black Monday",
+			Description: "Single-day market crash of 22%, the largest one-day percentage decline in history",
+			Start:       time.Date(1987, 10, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(1987, 12, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "1994 Bond Massacre",
+			Description: "Unexpected Federal Reserve rate hikes caused the worst bond market losses in decades",
+			Start:       time.Date(1994, 2, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(1994, 11, 30, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "1998 LTCM / Russian Crisis",
+			Description: "Russian debt default and Long-Term Capital Management collapse triggered a global liquidity crisis",
+			Start:       time.Date(1998, 8, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(1998, 10, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "Dot-com Bubble",
+			Description: "Speculative mania in technology stocks; strategies not chasing momentum appeared to underperform",
+			Start:       time.Date(1998, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2000, 3, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "Dot-com Bust",
+			Description: "Collapse of the dot-com bubble",
+			Start:       time.Date(2000, 3, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2002, 10, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "9/11",
+			Description: "Markets closed for four trading days then reopened to sharp declines",
+			Start:       time.Date(2001, 9, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2001, 10, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
 			Name:        "2008 Financial Crisis",
 			Description: "Global financial crisis triggered by subprime mortgage collapse",
 			Start:       time.Date(2008, 9, 1, 0, 0, 0, 0, time.UTC),
 			End:         time.Date(2009, 3, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "2010 Flash Crash",
+			Description: "Dow dropped nearly 1,000 points intraday before recovering within minutes",
+			Start:       time.Date(2010, 5, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2010, 6, 30, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "Euro Debt Crisis",
+			Description: "Sovereign debt contagion across Greece, Ireland, Portugal, Spain, and Italy",
+			Start:       time.Date(2010, 4, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2011, 10, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "2011 Debt Ceiling Crisis",
+			Description: "US debt ceiling standoff and S&P downgrade",
+			Start:       time.Date(2011, 7, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2011, 10, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "2015-2017 Low-Volatility Grind",
+			Description: "Extended low-volatility period with no clear trends",
+			Start:       time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2017, 12, 31, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			Name:        "2018 Q4 Selloff",
+			Description: "Sharp equity decline driven by Fed tightening fears and trade war escalation",
+			Start:       time.Date(2018, 10, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2018, 12, 31, 0, 0, 0, 0, time.UTC),
 		},
 		{
 			Name:        "COVID Crash",
@@ -49,22 +127,10 @@ func DefaultScenarios() []Scenario {
 			End:         time.Date(2022, 10, 31, 0, 0, 0, 0, time.UTC),
 		},
 		{
-			Name:        "Dot-com Bust",
-			Description: "Collapse of the dot-com bubble",
-			Start:       time.Date(2000, 3, 1, 0, 0, 0, 0, time.UTC),
-			End:         time.Date(2002, 10, 31, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			Name:        "2015-2017 Low-Volatility Grind",
-			Description: "Extended low-volatility period with no clear trends",
-			Start:       time.Date(2015, 1, 1, 0, 0, 0, 0, time.UTC),
-			End:         time.Date(2017, 12, 31, 0, 0, 0, 0, time.UTC),
-		},
-		{
-			Name:        "2011 Debt Ceiling Crisis",
-			Description: "US debt ceiling standoff and S&P downgrade",
-			Start:       time.Date(2011, 7, 1, 0, 0, 0, 0, time.UTC),
-			End:         time.Date(2011, 10, 31, 0, 0, 0, 0, time.UTC),
+			Name:        "2023 Regional Banking Crisis",
+			Description: "Collapse of Silicon Valley Bank and Signature Bank triggered fears of systemic contagion",
+			Start:       time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC),
+			End:         time.Date(2023, 5, 31, 0, 0, 0, 0, time.UTC),
 		},
 	}
 }

--- a/study/stress/scenarios_test.go
+++ b/study/stress/scenarios_test.go
@@ -27,9 +27,9 @@ import (
 )
 
 var _ = Describe("DefaultScenarios", func() {
-	It("returns exactly 6 named scenarios", func() {
+	It("returns exactly 17 named scenarios", func() {
 		scenarios := stress.DefaultScenarios()
-		Expect(scenarios).To(HaveLen(6))
+		Expect(scenarios).To(HaveLen(17))
 	})
 
 	It("includes all expected scenario names", func() {
@@ -41,12 +41,23 @@ var _ = Describe("DefaultScenarios", func() {
 		}
 
 		Expect(names).To(ContainElements(
+			"1973-74 Oil Embargo Bear Market",
+			"Volcker Tightening",
+			"1987 Black Monday",
+			"1994 Bond Massacre",
+			"1998 LTCM / Russian Crisis",
+			"Dot-com Bubble",
+			"Dot-com Bust",
+			"9/11",
 			"2008 Financial Crisis",
+			"2010 Flash Crash",
+			"Euro Debt Crisis",
+			"2011 Debt Ceiling Crisis",
+			"2015-2017 Low-Volatility Grind",
+			"2018 Q4 Selloff",
 			"COVID Crash",
 			"2022 Rate Hiking Cycle",
-			"Dot-com Bust",
-			"2015-2017 Low-Volatility Grind",
-			"2011 Debt Ceiling Crisis",
+			"2023 Regional Banking Crisis",
 		))
 	})
 


### PR DESCRIPTION
## Summary

- Expand default stress test scenarios from 6 to 17 historical episodes, spanning from the 1973 oil embargo through the 2023 regional banking crisis. New scenarios include Black Monday, the Dot-com Bubble run-up, 9/11, the LTCM crisis, the 1994 Bond Massacre, Volcker tightening, the Euro debt crisis, the 2010 Flash Crash, and the 2018 Q4 selloff.
- Add changelog entries for the study runner framework and report refactoring from PR #56.