### PR TITLE
Use strategy shortcode in backtest output filename

### DIFF
--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -101,7 +101,13 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 	}
 
 	if outputPath == "" {
-		outputPath = defaultOutputPath(strategy.Name(), start, end, shortID)
+		info := engine.DescribeStrategy(strategy)
+		filePrefix := info.ShortCode
+		if filePrefix == "" {
+			filePrefix = strategy.Name()
+		}
+
+		outputPath = defaultOutputPath(filePrefix, start, end, shortID)
 	}
 
 	log.Info().


### PR DESCRIPTION
## Summary

- Backtest output filenames now use the strategy's shortcode (e.g. `momrot-backtest-...db`) instead of the full name, producing shorter, cleaner filenames without spaces
- Falls back to `strategy.Name()` when no shortcode is defined via the `Descriptor` interface