### PR TITLE
Fix code review findings for factor analysis

### DIFF
--- a/portfolio/factor_regression.go
+++ b/portfolio/factor_regression.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/penny-vault/pvbt/asset"
@@ -47,11 +48,11 @@ type StepwiseResult struct {
 	Steps []FactorRegression // one per round (each adds one factor)
 }
 
-// OLSRegress runs ordinary least squares regression of the response vector
+// olsRegress runs ordinary least squares regression of the response vector
 // (portfolio excess returns) against the factor columns in the DataFrame.
 // The DataFrame must have asset.Factor as its sole asset; each metric is a
 // factor. Returns alpha (intercept), per-factor betas, R-squared, and AIC.
-func OLSRegress(response []float64, factors *data.DataFrame) (*FactorRegression, error) {
+func olsRegress(response []float64, factors *data.DataFrame) (*FactorRegression, error) {
 	metrics := factors.MetricList()
 	if len(metrics) == 0 {
 		return nil, ErrNoFactors
@@ -139,12 +140,18 @@ func OLSRegress(response []float64, factors *data.DataFrame) (*FactorRegression,
 	}, nil
 }
 
-// FactorAnalysis regresses the portfolio's excess returns against the factor
-// return series in the provided DataFrame. The DataFrame must use asset.Factor
-// as its asset, with one metric per factor return series. The method aligns
-// dates between the portfolio and factor time axes, using only overlapping
-// dates for the regression.
-func (a *Account) FactorAnalysis(factors *data.DataFrame) (*FactorRegression, error) {
+// alignedFactors holds the result of aligning portfolio excess returns with
+// factor return series on overlapping dates.
+type alignedFactors struct {
+	response   []float64                 // aligned portfolio excess returns
+	factorCols map[data.Metric][]float64 // metric -> aligned factor returns
+	times      []time.Time               // dummy time axis for DataFrame construction
+}
+
+// alignWithFactors extracts portfolio excess returns from the Account, aligns
+// them with the factor DataFrame on overlapping dates, and filters out NaN
+// values (e.g. the first row produced by Pct()).
+func (a *Account) alignWithFactors(factors *data.DataFrame) (*alignedFactors, error) {
 	ctx := context.Background()
 
 	excessDF := a.ExcessReturns(ctx, nil)
@@ -156,21 +163,24 @@ func (a *Account) FactorAnalysis(factors *data.DataFrame) (*FactorRegression, er
 	excessCol := excessDF.Column(portfolioAsset, excessMetrics[0])
 	excessTimes := excessDF.Times()
 
-	// Build a date -> index map for the factor DataFrame.
 	factorTimes := factors.Times()
 
 	factorDateIdx := make(map[time.Time]int, len(factorTimes))
-
 	for ii, tt := range factorTimes {
 		factorDateIdx[tt] = ii
 	}
 
-	// Align: walk the excess returns time axis and collect matching factor rows.
-	metrics := factors.MetricList()
+	allMetrics := factors.MetricList()
 
-	var alignedResponse []float64
+	// Pre-fetch factor columns to avoid repeated lookups.
+	rawFactorCols := make(map[data.Metric][]float64, len(allMetrics))
+	for _, metric := range allMetrics {
+		rawFactorCols[metric] = factors.Column(asset.Factor, metric)
+	}
 
-	alignedFactorCols := make([][]float64, len(metrics))
+	var response []float64
+
+	factorCols := make(map[data.Metric][]float64, len(allMetrics))
 
 	for ii, tt := range excessTimes {
 		fi, ok := factorDateIdx[tt]
@@ -178,35 +188,60 @@ func (a *Account) FactorAnalysis(factors *data.DataFrame) (*FactorRegression, er
 			continue
 		}
 
-		alignedResponse = append(alignedResponse, excessCol[ii])
+		if math.IsNaN(excessCol[ii]) {
+			continue
+		}
 
-		for jj, metric := range metrics {
-			col := factors.Column(asset.Factor, metric)
-			alignedFactorCols[jj] = append(alignedFactorCols[jj], col[fi])
+		response = append(response, excessCol[ii])
+		for _, metric := range allMetrics {
+			factorCols[metric] = append(factorCols[metric], rawFactorCols[metric][fi])
 		}
 	}
 
-	// Build an aligned factor DataFrame for OLSRegress.
-	nn := len(alignedResponse)
+	nn := len(response)
 
-	alignedTimes := make([]time.Time, nn)
-
+	dummyTimes := make([]time.Time, nn)
 	for ii := range nn {
-		alignedTimes[ii] = time.Date(2000+ii, 1, 1, 0, 0, 0, 0, time.UTC) // dummy dates
+		dummyTimes[ii] = time.Date(2000+ii, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	return &alignedFactors{
+		response:   response,
+		factorCols: factorCols,
+		times:      dummyTimes,
+	}, nil
+}
+
+// FactorAnalysis regresses the portfolio's excess returns against the factor
+// return series in the provided DataFrame. The DataFrame must use asset.Factor
+// as its asset, with one metric per factor return series. The method aligns
+// dates between the portfolio and factor time axes, using only overlapping
+// dates for the regression.
+func (a *Account) FactorAnalysis(factors *data.DataFrame) (*FactorRegression, error) {
+	aligned, err := a.alignWithFactors(factors)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := factors.MetricList()
+
+	cols := make([][]float64, len(metrics))
+	for jj, metric := range metrics {
+		cols[jj] = aligned.factorCols[metric]
 	}
 
 	alignedDF, err := data.NewDataFrame(
-		alignedTimes,
+		aligned.times,
 		[]asset.Asset{asset.Factor},
 		metrics,
 		data.Daily,
-		alignedFactorCols,
+		cols,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("building aligned factor DataFrame: %w", err)
 	}
 
-	return OLSRegress(alignedResponse, alignedDF)
+	return olsRegress(aligned.response, alignedDF)
 }
 
 // StepwiseFactorAnalysis uses forward stepwise AIC selection to find the best
@@ -214,98 +249,71 @@ func (a *Account) FactorAnalysis(factors *data.DataFrame) (*FactorRegression, er
 // remaining factor and keeps the one that produces the lowest AIC, stopping
 // when no addition improves the model.
 func (a *Account) StepwiseFactorAnalysis(factors *data.DataFrame) (*StepwiseResult, error) {
-	ctx := context.Background()
-
-	excessDF := a.ExcessReturns(ctx, nil)
-	if excessDF == nil {
-		return nil, fmt.Errorf("no excess returns available: portfolio may lack price history or risk-free data")
-	}
-
 	allMetrics := factors.MetricList()
 	if len(allMetrics) == 0 {
 		return nil, ErrNoFactors
 	}
 
-	// Align portfolio excess returns with factor dates.
-	excessMetrics := excessDF.MetricList()
-	excessCol := excessDF.Column(portfolioAsset, excessMetrics[0])
-	excessTimes := excessDF.Times()
-
-	factorTimes := factors.Times()
-
-	factorDateIdx := make(map[time.Time]int, len(factorTimes))
-	for ii, tt := range factorTimes {
-		factorDateIdx[tt] = ii
-	}
-
-	var alignedResponse []float64
-
-	alignedFactorCols := make(map[data.Metric][]float64)
-
-	for ii, tt := range excessTimes {
-		fi, ok := factorDateIdx[tt]
-		if !ok {
-			continue
-		}
-
-		alignedResponse = append(alignedResponse, excessCol[ii])
-
-		for _, metric := range allMetrics {
-			col := factors.Column(asset.Factor, metric)
-			alignedFactorCols[metric] = append(alignedFactorCols[metric], col[fi])
-		}
-	}
-
-	nn := len(alignedResponse)
-
-	alignedTimes := make([]time.Time, nn)
-	for ii := range nn {
-		alignedTimes[ii] = time.Date(2000+ii, 1, 1, 0, 0, 0, 0, time.UTC)
+	aligned, err := a.alignWithFactors(factors)
+	if err != nil {
+		return nil, err
 	}
 
 	// Track which factors are selected and which remain.
 	selected := make([]data.Metric, 0, len(allMetrics))
-
-	remaining := make(map[data.Metric]bool, len(allMetrics))
-	for _, metric := range allMetrics {
-		remaining[metric] = true
-	}
+	remaining := make([]data.Metric, len(allMetrics))
+	copy(remaining, allMetrics)
 
 	var steps []FactorRegression
 
 	bestAIC := math.Inf(1)
 
 	for len(remaining) > 0 {
-		var bestCandidate data.Metric
-
-		var bestResult *FactorRegression
+		var (
+			bestCandidate data.Metric
+			bestResult    *FactorRegression
+			bestIdx       int
+		)
 
 		candidateAIC := math.Inf(1)
 
+		// Sort remaining candidates for deterministic tie-breaking.
+		slices.SortFunc(remaining, func(aa, bb data.Metric) int {
+			if aa < bb {
+				return -1
+			}
+
+			if aa > bb {
+				return 1
+			}
+
+			return 0
+		})
+
 		// Try adding each remaining factor.
-		for metric := range remaining {
+		for idx, metric := range remaining {
 			trial := make([]data.Metric, len(selected)+1)
 			copy(trial, selected)
 			trial[len(selected)] = metric
 
 			trialCols := make([][]float64, len(trial))
 			for jj, mm := range trial {
-				trialCols[jj] = alignedFactorCols[mm]
+				trialCols[jj] = aligned.factorCols[mm]
 			}
 
-			trialDF, err := data.NewDataFrame(
-				alignedTimes,
+			trialDF, dfErr := data.NewDataFrame(
+				aligned.times,
 				[]asset.Asset{asset.Factor},
 				trial,
 				data.Daily,
 				trialCols,
 			)
-			if err != nil {
-				return nil, fmt.Errorf("building trial DataFrame: %w", err)
+			if dfErr != nil {
+				return nil, fmt.Errorf("building trial DataFrame: %w", dfErr)
 			}
 
-			result, err := OLSRegress(alignedResponse, trialDF)
-			if err != nil {
+			result, regErr := olsRegress(aligned.response, trialDF)
+			if regErr != nil {
 				continue
 			}
 
@@ -313,6 +321,7 @@ func (a *Account) StepwiseFactorAnalysis(factors *data.DataFrame) (*StepwiseResu
 				candidateAIC = result.AIC
 				bestCandidate = metric
 				bestResult = result
+				bestIdx = idx
 			}
 		}
 
@@ -324,7 +333,7 @@ func (a *Account) StepwiseFactorAnalysis(factors *data.DataFrame) (*StepwiseResu
 		bestAIC = candidateAIC
 
 		selected = append(selected, bestCandidate)
-		delete(remaining, bestCandidate)
+		remaining = slices.Delete(remaining, bestIdx, bestIdx+1)
 
 		steps = append(steps, *bestResult)
 	}

--- a/portfolio/factor_regression_test.go
+++ b/portfolio/factor_regression_test.go
@@ -1,6 +1,7 @@
 package portfolio_test
 
 import (
+	"math"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -11,24 +12,83 @@ import (
 	"github.com/penny-vault/pvbt/portfolio"
 )
 
-var _ = Describe("FactorRegression", func() {
-	// Known regression: y = 0.02 + 0.8*x1 + 0.4*x2 + noise
-	// Using a simple deterministic dataset where we know the answer.
-	//
-	// Factor returns (20 observations):
-	//   MktRF: [0.01, -0.02, 0.03, -0.01, 0.02, 0.01, -0.03, 0.04, -0.02, 0.01,
-	//           0.02, -0.01, 0.03, -0.02, 0.01, 0.02, -0.01, 0.03, -0.03, 0.02]
-	//   SMB:   [0.005, -0.01, 0.02, -0.005, 0.01, 0.005, -0.015, 0.025, -0.01, 0.005,
-	//           0.01, -0.005, 0.015, -0.01, 0.005, 0.01, -0.005, 0.02, -0.02, 0.01]
-	//
-	// Portfolio excess returns = 0.02 + 0.8*MktRF + 0.4*SMB (no noise, perfect fit)
+// buildFactorAccount constructs an Account whose portfolio excess returns
+// are a linear combination of mktRF and smb:
+//
+//	excess_ret[i] = alpha + betaMkt*mktRF[i] + betaSMB*smb[i] + noise[i]
+//
+// Returns the account and 21 weekday timestamps (day 0 + 20 return days).
+func buildFactorAccount(
+	alpha, betaMkt, betaSMB float64,
+	mktRF, smb, noise []float64,
+) (*portfolio.Account, []time.Time) {
+	spy := asset.Asset{CompositeFigi: "SPY", Ticker: "SPY"}
+	bil := asset.Asset{CompositeFigi: "BIL", Ticker: "BIL"}
+	days := daySeq(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), 21)
 
+	acct := portfolio.New(
+		portfolio.WithCash(10_000, time.Time{}),
+		portfolio.WithBenchmark(spy),
+	)
+
+	rfDaily := 0.0001
+	equity := make([]float64, 21)
+	equity[0] = 10_000.0
+
+	rfEquity := make([]float64, 21)
+	rfEquity[0] = 100.0
+
+	benchEquity := make([]float64, 21)
+	benchEquity[0] = 100.0
+
+	for ii := 1; ii <= 20; ii++ {
+		excessRet := alpha + betaMkt*mktRF[ii-1] + betaSMB*smb[ii-1]
+		if noise != nil {
+			excessRet += noise[ii-1]
+		}
+
+		portRet := excessRet + rfDaily
+		equity[ii] = equity[ii-1] * (1 + portRet)
+		rfEquity[ii] = rfEquity[ii-1] * (1 + rfDaily)
+		benchEquity[ii] = benchEquity[ii-1] * (1 + 0.005)
+	}
+
+	acct.Record(portfolio.Transaction{
+		Date:   days[0],
+		Asset:  spy,
+		Type:   asset.BuyTransaction,
+		Qty:    100,
+		Price:  100.0,
+		Amount: -10_000.0,
+	})
+
+	for ii, dd := range days {
+		spyPrice := equity[ii] / 100.0
+		cols := [][]float64{
+			{spyPrice}, {spyPrice},
+			{benchEquity[ii]}, {benchEquity[ii]},
+		}
+
+		df, err := data.NewDataFrame(
+			[]time.Time{dd},
+			[]asset.Asset{spy, bil},
+			[]data.Metric{data.MetricClose, data.AdjClose},
+			data.Daily,
+			cols,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		acct.SetRiskFreeValue(rfEquity[ii])
+		acct.UpdatePrices(df)
+	}
+
+	return acct, days
+}
+
+var _ = Describe("FactorRegression", func() {
 	var (
-		factorDF   *data.DataFrame
-		excessRets []float64
-		times      []time.Time
-		mktRF      []float64
-		smb        []float64
+		mktRF []float64
+		smb   []float64
 	)
 
 	BeforeEach(func() {
@@ -40,124 +100,11 @@ var _ = Describe("FactorRegression", func() {
 			0.005, -0.01, 0.02, -0.005, 0.01, 0.005, -0.015, 0.025, -0.01, 0.005,
 			0.01, -0.005, 0.015, -0.01, 0.005, 0.01, -0.005, 0.02, -0.02, 0.01,
 		}
-
-		// y = 0.02 + 0.8*MktRF + 0.4*SMB
-		excessRets = make([]float64, 20)
-		for ii := range 20 {
-			excessRets[ii] = 0.02 + 0.8*mktRF[ii] + 0.4*smb[ii]
-		}
-
-		times = daySeq(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), 20)
-
-		var err error
-		factorDF, err = data.NewDataFrame(
-			times,
-			[]asset.Asset{asset.Factor},
-			[]data.Metric{data.Metric("MktRF"), data.Metric("SMB")},
-			data.Daily,
-			[][]float64{mktRF, smb},
-		)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	Describe("olsRegress", func() {
-		It("recovers known alpha and betas with perfect fit", func() {
-			result, err := portfolio.OLSRegress(excessRets, factorDF)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(result.Alpha).To(BeNumerically("~", 0.02, 1e-10))
-			Expect(result.Betas["MktRF"]).To(BeNumerically("~", 0.8, 1e-10))
-			Expect(result.Betas["SMB"]).To(BeNumerically("~", 0.4, 1e-10))
-			Expect(result.RSquared).To(BeNumerically("~", 1.0, 1e-10))
-		})
-
-		It("returns error when fewer than 12 observations", func() {
-			shortTimes := daySeq(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), 5)
-			shortDF, err := data.NewDataFrame(
-				shortTimes,
-				[]asset.Asset{asset.Factor},
-				[]data.Metric{data.Metric("MktRF")},
-				data.Daily,
-				[][]float64{mktRF[:5]},
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			_, err = portfolio.OLSRegress(excessRets[:5], shortDF)
-			Expect(err).To(MatchError(portfolio.ErrTooFewObservations))
-		})
-
-		It("returns error when factor DataFrame has no metrics", func() {
-			emptyDF, err := data.NewDataFrame(
-				nil,
-				[]asset.Asset{asset.Factor},
-				[]data.Metric{},
-				data.Daily,
-				nil,
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			_, err = portfolio.OLSRegress(excessRets, emptyDF)
-			Expect(err).To(MatchError(portfolio.ErrNoFactors))
-		})
 	})
 
 	Describe("FactorAnalysis", func() {
-		It("regresses portfolio excess returns against factors", func() {
-			spy := asset.Asset{CompositeFigi: "SPY", Ticker: "SPY"}
-			bil := asset.Asset{CompositeFigi: "BIL", Ticker: "BIL"}
-			days := daySeq(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), 21)
-
-			acct := portfolio.New(
-				portfolio.WithCash(10_000, time.Time{}),
-				portfolio.WithBenchmark(spy),
-			)
-
-			rfDaily := 0.0001
-			equity := make([]float64, 21)
-			equity[0] = 10_000.0
-
-			rfEquity := make([]float64, 21)
-			rfEquity[0] = 100.0
-
-			benchEquity := make([]float64, 21)
-			benchEquity[0] = 100.0
-
-			for ii := 1; ii <= 20; ii++ {
-				excessRet := 0.001 + 0.8*mktRF[ii-1] + 0.4*smb[ii-1]
-				portRet := excessRet + rfDaily
-				equity[ii] = equity[ii-1] * (1 + portRet)
-				rfEquity[ii] = rfEquity[ii-1] * (1 + rfDaily)
-				benchEquity[ii] = benchEquity[ii-1] * (1 + 0.005)
-			}
-
-			acct.Record(portfolio.Transaction{
-				Date:   days[0],
-				Asset:  spy,
-				Type:   asset.BuyTransaction,
-				Qty:    100,
-				Price:  100.0,
-				Amount: -10_000.0,
-			})
-
-			for ii, dd := range days {
-				spyPrice := equity[ii] / 100.0
-				cols := [][]float64{
-					{spyPrice}, {spyPrice},
-					{benchEquity[ii]}, {benchEquity[ii]},
-				}
-
-				df, err := data.NewDataFrame(
-					[]time.Time{dd},
-					[]asset.Asset{spy, bil},
-					[]data.Metric{data.MetricClose, data.AdjClose},
-					data.Daily,
-					cols,
-				)
-				Expect(err).NotTo(HaveOccurred())
-
-				acct.SetRiskFreeValue(rfEquity[ii])
-				acct.UpdatePrices(df)
-			}
+		It("recovers known alpha and betas", func() {
+			acct, days := buildFactorAccount(0.001, 0.8, 0.4, mktRF, smb, nil)
 
 			factorDF, err := data.NewDataFrame(
 				days[1:],
@@ -176,32 +123,54 @@ var _ = Describe("FactorRegression", func() {
 			Expect(result.Betas["SMB"]).To(BeNumerically("~", 0.4, 0.05))
 			Expect(result.RSquared).To(BeNumerically(">", 0.95))
 		})
+
+		It("works with a single factor", func() {
+			acct, days := buildFactorAccount(0.002, 0.6, 0.0, mktRF, smb, nil)
+
+			factorDF, err := data.NewDataFrame(
+				days[1:],
+				[]asset.Asset{asset.Factor},
+				[]data.Metric{data.Metric("MktRF")},
+				data.Daily,
+				[][]float64{mktRF},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := acct.FactorAnalysis(factorDF)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Betas["MktRF"]).To(BeNumerically("~", 0.6, 0.05))
+			Expect(result.RSquared).To(BeNumerically(">", 0.90))
+		})
+
+		It("handles NaN in excess returns without corruption", func() {
+			acct, days := buildFactorAccount(0.001, 0.8, 0.4, mktRF, smb, nil)
+
+			// Factor data includes days[0] (same as portfolio first observation),
+			// so the NaN from Pct() at position 0 overlaps with factor data.
+			// The method should skip it and still produce valid (non-NaN) results.
+			factorDF, err := data.NewDataFrame(
+				days[:20],
+				[]asset.Asset{asset.Factor},
+				[]data.Metric{data.Metric("MktRF"), data.Metric("SMB")},
+				data.Daily,
+				[][]float64{mktRF, smb},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := acct.FactorAnalysis(factorDF)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(math.IsNaN(result.Alpha)).To(BeFalse())
+			Expect(math.IsNaN(result.RSquared)).To(BeFalse())
+			for _, beta := range result.Betas {
+				Expect(math.IsNaN(beta)).To(BeFalse())
+			}
+		})
 	})
 
 	Describe("StepwiseFactorAnalysis", func() {
 		It("selects factors that improve AIC and rejects noise", func() {
-			spy := asset.Asset{CompositeFigi: "SPY", Ticker: "SPY"}
-			bil := asset.Asset{CompositeFigi: "BIL", Ticker: "BIL"}
-			days := daySeq(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), 21)
-
-			acct := portfolio.New(
-				portfolio.WithCash(10_000, time.Time{}),
-				portfolio.WithBenchmark(spy),
-			)
-
-			rfDaily := 0.0001
-			equity := make([]float64, 21)
-			equity[0] = 10_000.0
-
-			rfEquity := make([]float64, 21)
-			rfEquity[0] = 100.0
-
-			benchEquity := make([]float64, 21)
-			benchEquity[0] = 100.0
-
-			// Add small idiosyncratic noise uncorrelated with the factors so
-			// the model is not a perfect fit (prevents floating-point artifacts
-			// in AIC from dominating selection).
 			idioNoise := []float64{
 				0.0002, -0.0003, 0.0001, -0.0002, 0.0003,
 				-0.0001, 0.0002, -0.0003, 0.0001, -0.0002,
@@ -209,45 +178,8 @@ var _ = Describe("FactorRegression", func() {
 				-0.0002, 0.0003, -0.0001, 0.0002, -0.0003,
 			}
 
-			for ii := 1; ii <= 20; ii++ {
-				excessRet := 0.001 + 0.8*mktRF[ii-1] + 0.4*smb[ii-1] + idioNoise[ii-1]
-				portRet := excessRet + rfDaily
-				equity[ii] = equity[ii-1] * (1 + portRet)
-				rfEquity[ii] = rfEquity[ii-1] * (1 + rfDaily)
-				benchEquity[ii] = benchEquity[ii-1] * (1 + 0.005)
-			}
+			acct, days := buildFactorAccount(0.001, 0.8, 0.4, mktRF, smb, idioNoise)
 
-			acct.Record(portfolio.Transaction{
-				Date:   days[0],
-				Asset:  spy,
-				Type:   asset.BuyTransaction,
-				Qty:    100,
-				Price:  100.0,
-				Amount: -10_000.0,
-			})
-
-			for ii, dd := range days {
-				spyPrice := equity[ii] / 100.0
-				cols := [][]float64{
-					{spyPrice}, {spyPrice},
-					{benchEquity[ii]}, {benchEquity[ii]},
-				}
-
-				df, err := data.NewDataFrame(
-					[]time.Time{dd},
-					[]asset.Asset{spy, bil},
-					[]data.Metric{data.MetricClose, data.AdjClose},
-					data.Daily,
-					cols,
-				)
-				Expect(err).NotTo(HaveOccurred())
-
-				acct.SetRiskFreeValue(rfEquity[ii])
-				acct.UpdatePrices(df)
-			}
-
-			// Noise factor constructed to be orthogonal to MktRF and SMB
-			// (via Gram-Schmidt projection), ensuring zero explanatory power.
 			noise := []float64{
 				0.004779, 0.002363, -0.003715, 0.001151, -0.002484,
 				-0.001272, 0.003574, 0.002335, -0.004899, 0.001148,
@@ -267,19 +199,48 @@ var _ = Describe("FactorRegression", func() {
 			result, err := acct.StepwiseFactorAnalysis(factorDF)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Best model should include MktRF and SMB but not Noise.
 			Expect(result.Best.Betas).To(HaveKey("MktRF"))
 			Expect(result.Best.Betas).To(HaveKey("SMB"))
 			Expect(result.Best.Betas).NotTo(HaveKey("Noise"))
 
-			// Should have 2 steps (one per selected factor).
 			Expect(result.Steps).To(HaveLen(2))
-
-			// First step picks one factor (single-factor model).
 			Expect(result.Steps[0].Betas).To(HaveLen(1))
-
-			// Second step adds the other real factor.
 			Expect(result.Steps[1].Betas).To(HaveLen(2))
+		})
+
+		It("stops after one factor when second does not improve AIC", func() {
+			// Portfolio driven by MktRF only; noise factor is uncorrelated.
+			// Stepwise should select MktRF and stop at 1 step.
+			idioNoise := []float64{
+				0.0002, -0.0003, 0.0001, -0.0002, 0.0003,
+				-0.0001, 0.0002, -0.0003, 0.0001, -0.0002,
+				0.0003, -0.0001, 0.0002, -0.0003, 0.0001,
+				-0.0002, 0.0003, -0.0001, 0.0002, -0.0003,
+			}
+			acct, days := buildFactorAccount(0.001, 0.8, 0.0, mktRF, smb, idioNoise)
+
+			noise := []float64{
+				0.004779, 0.002363, -0.003715, 0.001151, -0.002484,
+				-0.001272, 0.003574, 0.002335, -0.004899, 0.001148,
+				-0.001273, 0.003572, -0.002485, -0.003689, 0.004779,
+				0.001147, -0.002480, 0.002336, -0.001247, -0.003694,
+			}
+
+			factorDF, err := data.NewDataFrame(
+				days[1:],
+				[]asset.Asset{asset.Factor},
+				[]data.Metric{data.Metric("MktRF"), data.Metric("Noise")},
+				data.Daily,
+				[][]float64{mktRF, noise},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := acct.StepwiseFactorAnalysis(factorDF)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(result.Steps).To(HaveLen(1))
+			Expect(result.Best.Betas).To(HaveKey("MktRF"))
+			Expect(result.Best.Betas).NotTo(HaveKey("Noise"))
 		})
 	})
 
@@ -324,7 +285,6 @@ var _ = Describe("FactorRegression", func() {
 				acct.UpdatePrices(df)
 			}
 
-			// Factor data on completely different dates.
 			farDays := daySeq(time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC), 20)
 			factorDF, err := data.NewDataFrame(
 				farDays,
@@ -337,6 +297,22 @@ var _ = Describe("FactorRegression", func() {
 
 			_, err = acct.FactorAnalysis(factorDF)
 			Expect(err).To(MatchError(portfolio.ErrTooFewObservations))
+		})
+
+		It("StepwiseFactorAnalysis returns error with no factors", func() {
+			acct, _ := buildFactorAccount(0.001, 0.8, 0.4, mktRF, smb, nil)
+
+			emptyDF, err := data.NewDataFrame(
+				nil,
+				[]asset.Asset{asset.Factor},
+				[]data.Metric{},
+				data.Daily,
+				nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = acct.StepwiseFactorAnalysis(emptyDF)
+			Expect(err).To(MatchError(portfolio.ErrNoFactors))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Fix NaN leakage bug where the first row from Pct() could corrupt regression results when factor dates overlap with portfolio start date
- Extract shared `alignWithFactors` helper to eliminate duplicated date alignment code between `FactorAnalysis` and `StepwiseFactorAnalysis`
- Make stepwise selection deterministic by sorting remaining candidates before iterating
- Unexport `olsRegress` since it is not part of the public API
- Add missing test coverage: single-factor regression, NaN handling, stepwise early-stop at 1 factor, no-factors error