### PR TITLE
Add tradecron directives and fix NULL metric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Database NULL values for metrics like EV/EBIT now appear as NaN instead of 0 in DataFrames.
 - KFold cross-validation in-sample scores now correctly exclude the test fold, producing accurate overfitting diagnostics.
 - Parameter sweeps with fractional step sizes no longer skip the final value due to floating-point drift.
 - Backtests with rated universes run up to 17x faster because universe membership queries no longer scan the full ratings history on every step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Schedules support `@daily`, `@quarterbegin`, and `@quarterend` directives for daily and quarterly trading schedules.
 - Strategies can use `universe.SP500` and `universe.Nasdaq100` to trade against historical index membership sourced from pv-data. Index weight data is available via `Constituents()` on the index universe.
 - Users can now trade live through Webull accounts.
 - Users can now trade live through E*TRADE (Morgan Stanley) accounts.

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -17,6 +17,7 @@ package data
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"os"
@@ -423,18 +424,22 @@ func (p *PVDataProvider) fetchEod(
 
 	want := metricSet(metrics)
 
+	type eodMapping struct {
+		metric Metric
+		dest   *float64
+	}
+
 	rowCount := 0
 	for rows.Next() {
 		rowCount++
 
 		var (
-			figi                             string
-			eventDate                        time.Time
-			open, high, low, close, adjClose float64
-			volume                           float64
-			dividend, splitFactor            float64
+			figi      string
+			eventDate time.Time
+			open, high, low, closeVal, adjClose,
+			volume, dividend, splitFactor *float64
 		)
-		if err := rows.Scan(&figi, &eventDate, &open, &high, &low, &close, &adjClose, &volume, &dividend, &splitFactor); err != nil {
+		if err := rows.Scan(&figi, &eventDate, &open, &high, &low, &closeVal, &adjClose, &volume, &dividend, &splitFactor); err != nil {
 			return fmt.Errorf("pvdata: scan eod row: %w", err)
 		}
 
@@ -442,36 +447,21 @@ func (p *PVDataProvider) fetchEod(
 		sec := eventDate.Unix()
 		timeSet[sec] = eventDate
 
-		if want[MetricOpen] {
-			ensureCol(figi, MetricOpen)[sec] = open
+		mappings := []eodMapping{
+			{MetricOpen, open},
+			{MetricHigh, high},
+			{MetricLow, low},
+			{MetricClose, closeVal},
+			{AdjClose, adjClose},
+			{Volume, volume},
+			{Dividend, dividend},
+			{SplitFactor, splitFactor},
 		}
 
-		if want[MetricHigh] {
-			ensureCol(figi, MetricHigh)[sec] = high
-		}
-
-		if want[MetricLow] {
-			ensureCol(figi, MetricLow)[sec] = low
-		}
-
-		if want[MetricClose] {
-			ensureCol(figi, MetricClose)[sec] = close
-		}
-
-		if want[AdjClose] {
-			ensureCol(figi, AdjClose)[sec] = adjClose
-		}
-
-		if want[Volume] {
-			ensureCol(figi, Volume)[sec] = volume
-		}
-
-		if want[Dividend] {
-			ensureCol(figi, Dividend)[sec] = dividend
-		}
-
-		if want[SplitFactor] {
-			ensureCol(figi, SplitFactor)[sec] = splitFactor
+		for _, mp := range mappings {
+			if want[mp.metric] && mp.dest != nil {
+				ensureCol(figi, mp.metric)[sec] = *mp.dest
+			}
 		}
 	}
 
@@ -528,9 +518,10 @@ func (p *PVDataProvider) fetchMetrics(
 
 	want := metricSet(metrics)
 
-	// Pre-allocate scan destinations reused across rows.
-	intVals := make([]int64, len(columns))
-	floatVals := make([]float64, len(columns))
+	// Pre-allocate scan destinations reused across rows. We use pointers so
+	// that SQL NULLs are represented as nil rather than the Go zero value.
+	intVals := make([]*int64, len(columns))
+	floatVals := make([]*float64, len(columns))
 
 	for rows.Next() {
 		var (
@@ -544,8 +535,10 @@ func (p *PVDataProvider) fetchMetrics(
 
 		for idx, col := range columns {
 			if col.intCol {
+				intVals[idx] = nil
 				scanArgs = append(scanArgs, &intVals[idx])
 			} else {
+				floatVals[idx] = nil
 				scanArgs = append(scanArgs, &floatVals[idx])
 			}
 		}
@@ -564,9 +557,13 @@ func (p *PVDataProvider) fetchMetrics(
 			}
 
 			if col.intCol {
-				ensureCol(figi, col.metric)[sec] = float64(intVals[idx])
+				if intVals[idx] != nil {
+					ensureCol(figi, col.metric)[sec] = float64(*intVals[idx])
+				}
 			} else {
-				ensureCol(figi, col.metric)[sec] = floatVals[idx]
+				if floatVals[idx] != nil {
+					ensureCol(figi, col.metric)[sec] = *floatVals[idx]
+				}
 			}
 		}
 	}
@@ -627,9 +624,9 @@ func (p *PVDataProvider) fetchFundamentals(
 		vals[0] = &figi
 		vals[1] = &eventDate
 
-		floatVals := make([]float64, len(sqlCols))
-		for i := range sqlCols {
-			vals[i+2] = &floatVals[i]
+		floatVals := make([]*float64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[idx+2] = &floatVals[idx]
 		}
 
 		if err := rows.Scan(vals...); err != nil {
@@ -640,8 +637,10 @@ func (p *PVDataProvider) fetchFundamentals(
 		sec := eventDate.Unix()
 		timeSet[sec] = eventDate
 
-		for i, m := range metricOrder {
-			ensureCol(figi, m)[sec] = floatVals[i]
+		for idx, m := range metricOrder {
+			if floatVals[idx] != nil {
+				ensureCol(figi, m)[sec] = *floatVals[idx]
+			}
 		}
 	}
 
@@ -723,12 +722,12 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 	}
 	defer conn.Release()
 
-	// Load snapshots grouped by date.
+	// Load snapshots. Each row contains a snapshot_date and a JSONB array of constituents.
 	snapRows, err := conn.Query(ctx,
-		`SELECT snapshot_date, composite_figi, ticker, weight
+		`SELECT snapshot_date, constituents
 		 FROM indices_snapshot
-		 WHERE index_name = $1
-		 ORDER BY snapshot_date, composite_figi`,
+		 WHERE index_ticker = $1
+		 ORDER BY snapshot_date`,
 		index,
 	)
 	if err != nil {
@@ -736,40 +735,42 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 	}
 	defer snapRows.Close()
 
-	var snapshots []IndexSnapshotEntry
+	type constituentJSON struct {
+		CompositeFigi string  `json:"composite_figi"`
+		Ticker        string  `json:"ticker"`
+		Weight        float64 `json:"weight"`
+	}
 
-	var current *IndexSnapshotEntry
+	var snapshots []IndexSnapshotEntry
 
 	for snapRows.Next() {
 		var (
-			dt           time.Time
-			figi, ticker string
-			weight       float64
+			dt          time.Time
+			rawConstits []byte
 		)
 
-		if err := snapRows.Scan(&dt, &figi, &ticker, &weight); err != nil {
+		if err := snapRows.Scan(&dt, &rawConstits); err != nil {
 			return nil, fmt.Errorf("scan snapshot row: %w", err)
 		}
 
-		if current == nil || !current.Date.Equal(dt) {
-			if current != nil {
-				snapshots = append(snapshots, *current)
-			}
-
-			current = &IndexSnapshotEntry{Date: dt}
+		var constits []constituentJSON
+		if err := json.Unmarshal(rawConstits, &constits); err != nil {
+			return nil, fmt.Errorf("unmarshal constituents for %s: %w", dt.Format("2006-01-02"), err)
 		}
 
-		current.Members = append(current.Members, IndexConstituent{
-			Asset: asset.Asset{
-				CompositeFigi: figi,
-				Ticker:        ticker,
-			},
-			Weight: weight,
-		})
-	}
+		entry := IndexSnapshotEntry{Date: dt}
 
-	if current != nil {
-		snapshots = append(snapshots, *current)
+		for _, cc := range constits {
+			entry.Members = append(entry.Members, IndexConstituent{
+				Asset: asset.Asset{
+					CompositeFigi: cc.CompositeFigi,
+					Ticker:        cc.Ticker,
+				},
+				Weight: cc.Weight,
+			})
+		}
+
+		snapshots = append(snapshots, entry)
 	}
 
 	if err := snapRows.Err(); err != nil {
@@ -780,7 +781,7 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 	logRows, err := conn.Query(ctx,
 		`SELECT event_date, composite_figi, ticker, action, weight
 		 FROM indices_changelog
-		 WHERE index_name = $1
+		 WHERE index_ticker = $1
 		 ORDER BY event_date, composite_figi`,
 		index,
 	)

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -22,17 +22,20 @@ Expressions use standard cron syntax extended with market-aware directives.
 
 | Expression | When Compute runs |
 |------------|-------------------|
+| `@daily` | Every trading day at market open |
 | `@monthend` | Last trading day of each month |
 | `@close @monthend` | Last trading day of each month at market close |
 | `@monthbegin` | First trading day of each month |
 | `@weekbegin` | First trading day of each week |
 | `@weekend` | Last trading day of each week |
+| `@quarterbegin` | First trading day of each quarter |
+| `@quarterend` | Last trading day of each quarter |
 | `@close * * *` | Every trading day at market close |
 | `@open * * *` | Every trading day at market open |
 | `0 10 * * *` | Every trading day at 10:00 AM ET |
 | `*/5 * * * *` | Every 5 minutes during trading hours |
 
-Supported directives: `@open`, `@close`, `@weekbegin`, `@weekend`, `@monthbegin`, `@monthend`. These can be combined with standard cron fields for minute, hour, day-of-month, month, and day-of-week.
+Supported directives: `@daily`, `@open`, `@close`, `@weekbegin`, `@weekend`, `@monthbegin`, `@monthend`, `@quarterbegin`, `@quarterend`. These can be combined with standard cron fields for minute, hour, day-of-month, month, and day-of-week.
 
 The `tradecron.RegularHours` constraint ensures the schedule never fires on weekends, holidays, or outside market hours. If a scheduled time falls on a holiday, it advances to the next valid trading day.
 

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -218,15 +218,18 @@ Common schedule expressions:
 
 | Expression | When Compute runs |
 |------------|-------------------|
+| `@daily` | Every trading day at market open |
 | `@monthend` | Last trading day of each month at market close |
 | `@monthbegin` | First trading day of each month |
 | `@weekbegin` | First trading day of each week |
 | `@weekend` | Last trading day of each week |
+| `@quarterbegin` | First trading day of each quarter |
+| `@quarterend` | Last trading day of each quarter |
 | `@open * * *` | Every trading day at market open |
 | `@close * * *` | Every trading day at market close |
 | `0 10 * * *` | Every trading day at 10:00 AM ET |
 
-The format is standard 5-field cron (`minute hour day-of-month month day-of-week`) with market-aware extensions. `@open` and `@close` replace the minute/hour fields. `@monthend`, `@monthbegin`, `@weekbegin`, and `@weekend` replace the day-of-month field. All times are Eastern.
+The format is standard 5-field cron (`minute hour day-of-month month day-of-week`) with market-aware extensions. `@open` and `@close` replace the minute/hour fields. `@daily`, `@monthend`, `@monthbegin`, `@weekbegin`, `@weekend`, `@quarterbegin`, and `@quarterend` replace the day-of-month field. All times are Eastern.
 
 ### Warmup
 

--- a/tradecron/doc.go
+++ b/tradecron/doc.go
@@ -18,6 +18,8 @@
 //   - @weekend -- last trading day of the week
 //   - @monthbegin -- first trading day of the month
 //   - @monthend -- last trading day of the month
+//   - @quarterbegin -- first trading day of the quarter
+//   - @quarterend -- last trading day of the quarter
 //
 // Directives may be combined with standard cron fields (minute, hour,
 // day-of-month, month, day-of-week).
@@ -41,6 +43,8 @@
 //	@monthbegin           first trading day of month
 //	@weekbegin            first trading day of week
 //	@weekend              last trading day of week
+//	@quarterbegin         first trading day of quarter
+//	@quarterend           last trading day of quarter
 //	*/5 * * * *           every 5 minutes during trading hours
 //
 // # RegularHours

--- a/tradecron/doc.go
+++ b/tradecron/doc.go
@@ -11,6 +11,7 @@
 //
 // Directives can appear before the standard cron fields:
 //
+//   - @daily -- every trading day at market open
 //   - @open -- market open
 //   - @close -- market close
 //   - @weekbegin -- first trading day of the week
@@ -32,6 +33,7 @@
 //
 // # Common Schedules
 //
+//	@daily                every trading day at market open
 //	@monthend             last trading day of each month
 //	@close @monthend      last trading day at close
 //	@close * * *          every trading day at close

--- a/tradecron/helpers.go
+++ b/tradecron/helpers.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -42,6 +43,28 @@ func expandBriefFormat(spec string) string {
 	}
 
 	return strings.Join(tokens, " ")
+}
+
+// quarterStartMonth returns the first month of the quarter containing m.
+func quarterStartMonth(mo time.Month) time.Month {
+	return ((mo - 1) / 3 * 3) + 1
+}
+
+// quarterEndMonth returns the last month of the quarter containing m.
+func quarterEndMonth(mo time.Month) time.Month {
+	return quarterStartMonth(mo) + 2
+}
+
+// nextQuarterFirstMonth returns the first day of the next quarter after t.
+func nextQuarterFirstMonth(tt time.Time) time.Time {
+	start := quarterStartMonth(tt.Month()) + 3
+	year := tt.Year()
+	if start > 12 {
+		start -= 12
+		year++
+	}
+
+	return time.Date(year, start, 1, 0, 0, 0, 0, tt.Location())
 }
 
 // parseTimeRelativeTo parses a set of tokens relative to the specified time.

--- a/tradecron/helpers.go
+++ b/tradecron/helpers.go
@@ -59,6 +59,7 @@ func quarterEndMonth(mo time.Month) time.Month {
 func nextQuarterFirstMonth(tt time.Time) time.Time {
 	start := quarterStartMonth(tt.Month()) + 3
 	year := tt.Year()
+
 	if start > 12 {
 		start -= 12
 		year++

--- a/tradecron/tradecron.go
+++ b/tradecron/tradecron.go
@@ -24,13 +24,15 @@ import (
 )
 
 const (
-	AtOpen       = "@open"
-	AtClose      = "@close"
-	AtDaily      = "@daily"
-	AtWeekBegin  = "@weekbegin"
-	AtWeekEnd    = "@weekend"
-	AtMonthBegin = "@monthbegin"
-	AtMonthEnd   = "@monthend"
+	AtOpen         = "@open"
+	AtClose        = "@close"
+	AtDaily        = "@daily"
+	AtWeekBegin    = "@weekbegin"
+	AtWeekEnd      = "@weekend"
+	AtMonthBegin   = "@monthbegin"
+	AtMonthEnd     = "@monthend"
+	AtQuarterBegin = "@quarterbegin"
+	AtQuarterEnd   = "@quarterend"
 )
 
 // MarketHours defines the opening and closing times for a trading session.
@@ -68,14 +70,16 @@ var (
 //
 // Additional market-aware modifiers are supported:
 //
-//	@daily      - Run at market open on every trading day (shorthand for @open * * *)
-//	@open       - Run at market open; replaces Minute and Hour field
-//	              e.g., @open * * *
-//	@close      - Run at market close; replaces Minute and Hour field
-//	@weekbegin  - Run on first trading day of week; replaces DayOfMonth field
-//	@weekend    - Run on last trading day of week; replaces DayOfMonth field
-//	@monthbegin - Run at market open or timespec on first trading day of month
-//	@monthend   - Run at market close or timespec on last trading day of month
+//	@daily        - Run at market open on every trading day (shorthand for @open * * *)
+//	@open         - Run at market open; replaces Minute and Hour field
+//	                e.g., @open * * *
+//	@close        - Run at market close; replaces Minute and Hour field
+//	@weekbegin    - Run on first trading day of week; replaces DayOfMonth field
+//	@weekend      - Run on last trading day of week; replaces DayOfMonth field
+//	@monthbegin   - Run at market open or timespec on first trading day of month
+//	@monthend     - Run at market close or timespec on last trading day of month
+//	@quarterbegin - Run at market open or timespec on first trading day of quarter
+//	@quarterend   - Run at market close or timespec on last trading day of quarter
 //
 // Examples:
 //   - every 5 minutes: */5 * * * *
@@ -162,6 +166,18 @@ func New(cronSpec string, hours MarketHours) (*TradeCron, error) {
 			}
 
 			dateFlag = AtMonthEnd
+		case AtQuarterBegin:
+			if dateFlag != "" {
+				return nil, ErrConflictingModifiers
+			}
+
+			dateFlag = AtQuarterBegin
+		case AtQuarterEnd:
+			if dateFlag != "" {
+				return nil, ErrConflictingModifiers
+			}
+
+			dateFlag = AtQuarterEnd
 		default:
 			return nil, ErrUnknownModifier
 		}
@@ -170,14 +186,14 @@ func New(cronSpec string, hours MarketHours) (*TradeCron, error) {
 	// Default time for date-only modifiers: @monthend → @close, @monthbegin → @open.
 	if timeFlag == "" && dateFlag != "" {
 		switch dateFlag {
-		case AtMonthEnd, AtWeekEnd:
+		case AtMonthEnd, AtWeekEnd, AtQuarterEnd:
 			timeFlag = AtClose
 
 			var parseErr error
 			if timeSpec, parseErr = parseTimeRelativeTo(timeSpecTokens, hours.Close/100, hours.Close%100); parseErr != nil {
 				return nil, parseErr
 			}
-		case AtMonthBegin, AtWeekBegin:
+		case AtMonthBegin, AtWeekBegin, AtQuarterBegin:
 			timeFlag = AtOpen
 
 			var parseErr error
@@ -295,6 +311,49 @@ func (tc *TradeCron) Next(forDate time.Time) time.Time {
 		if !forDate.Before(scheduledTime) {
 			nextMonth := time.Date(checkDate.Year(), checkDate.Month()+1, 1, 0, 0, 0, 0, tc.marketStatus.tz)
 			checkDate = tc.marketStatus.NextLastTradingDayOfMonth(nextMonth)
+		}
+	case AtQuarterBegin:
+		lastQuarter := time.Date(forDate.Year(), quarterStartMonth(forDate.Month()), 1, 23, 59, 59, 999_999_999, tc.marketStatus.tz).AddDate(0, 0, -1)
+		firstTradingDayOfThisQuarter := tc.marketStatus.NextFirstTradingDayOfMonth(lastQuarter)
+
+		dateOnly := time.Date(forDate.Year(), forDate.Month(), forDate.Day(), 0, 0, 0, 0, tc.marketStatus.tz)
+		if firstTradingDayOfThisQuarter.After(dateOnly) || firstTradingDayOfThisQuarter.Equal(dateOnly) {
+			checkDate = firstTradingDayOfThisQuarter
+		} else {
+			nextQuarterStart := nextQuarterFirstMonth(forDate)
+			checkDate = tc.marketStatus.NextFirstTradingDayOfMonth(
+				time.Date(nextQuarterStart.Year(), nextQuarterStart.Month(), 1, 23, 59, 59, 999_999_999, tc.marketStatus.tz).AddDate(0, 0, -1),
+			)
+
+			firstTradingDay := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), nextDate.Hour(), nextDate.Minute(), nextDate.Second(), nextDate.Nanosecond(), nextDate.Location())
+			if nextDate.After(firstTradingDay) {
+				nextQ := nextQuarterFirstMonth(nextDate)
+				checkDate = tc.marketStatus.NextFirstTradingDayOfMonth(
+					time.Date(nextQ.Year(), nextQ.Month(), 1, 23, 59, 59, 999_999_999, tc.marketStatus.tz).AddDate(0, 0, -1),
+				)
+			}
+		}
+	case AtQuarterEnd:
+		quarterEnd := quarterEndMonth(forDate.Month())
+		checkDate = tc.marketStatus.NextLastTradingDayOfMonth(
+			time.Date(forDate.Year(), quarterEnd, 1, 0, 0, 0, 0, tc.marketStatus.tz),
+		)
+
+		scheduledTime := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), nextDate.Hour(), nextDate.Minute(), nextDate.Second(), nextDate.Nanosecond(), nextDate.Location())
+
+		if tc.TimeFlag == AtClose {
+			if earlyClose := tc.marketStatus.EarlyClose(checkDate); earlyClose != 0 {
+				scheduledTime = time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(),
+					earlyClose/100, earlyClose%100, 0, 0, tc.marketStatus.tz)
+			}
+		}
+
+		if !forDate.Before(scheduledTime) {
+			nextQ := nextQuarterFirstMonth(forDate)
+			nextQuarterEnd := quarterEndMonth(nextQ.Month())
+			checkDate = tc.marketStatus.NextLastTradingDayOfMonth(
+				time.Date(nextQ.Year(), nextQuarterEnd, 1, 0, 0, 0, 0, tc.marketStatus.tz),
+			)
 		}
 	default:
 		checkDate = forDate

--- a/tradecron/tradecron.go
+++ b/tradecron/tradecron.go
@@ -26,6 +26,7 @@ import (
 const (
 	AtOpen       = "@open"
 	AtClose      = "@close"
+	AtDaily      = "@daily"
 	AtWeekBegin  = "@weekbegin"
 	AtWeekEnd    = "@weekend"
 	AtMonthBegin = "@monthbegin"
@@ -67,6 +68,7 @@ var (
 //
 // Additional market-aware modifiers are supported:
 //
+//	@daily      - Run at market open on every trading day (shorthand for @open * * *)
 //	@open       - Run at market open; replaces Minute and Hour field
 //	              e.g., @open * * *
 //	@close      - Run at market close; replaces Minute and Hour field
@@ -85,6 +87,12 @@ func New(cronSpec string, hours MarketHours) (*TradeCron, error) {
 	specParser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
 
 	scheduleStr := strings.TrimSpace(cronSpec)
+
+	// @daily is shorthand for "@open * * *" (every trading day at market open).
+	if scheduleStr == AtDaily {
+		scheduleStr = "@open * * *"
+	}
+
 	scheduleStr = expandBriefFormat(scheduleStr)
 
 	// separate special tokens from timespec

--- a/tradecron/tradecron_test.go
+++ b/tradecron/tradecron_test.go
@@ -18,6 +18,72 @@ var _ = Describe("TradeCron", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	Describe("@daily", func() {
+		BeforeEach(func() {
+			tradecron.SetMarketHolidays(nil)
+		})
+
+		It("fires at market open on a regular trading day", func() {
+			tc, err := tradecron.New("@daily", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Monday Jan 6, 2025 at midnight.
+			forDate := time.Date(2025, time.January, 6, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Should fire at 9:30 AM on Jan 6.
+			want := time.Date(2025, time.January, 6, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("advances to the next trading day after market open", func() {
+			tc, err := tradecron.New("@daily", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// After market open on Monday Jan 6.
+			forDate := time.Date(2025, time.January, 6, 9, 30, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Should fire at 9:30 AM on Tuesday Jan 7.
+			want := time.Date(2025, time.January, 7, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("skips weekends", func() {
+			tc, err := tradecron.New("@daily", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Friday Jan 10, 2025 after market open.
+			forDate := time.Date(2025, time.January, 10, 9, 30, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Should skip Saturday and Sunday, fire Monday Jan 13.
+			want := time.Date(2025, time.January, 13, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("skips holidays", func() {
+			tradecron.SetMarketHolidays([]tradecron.MarketHoliday{
+				{
+					Date:       time.Date(2025, time.January, 7, 0, 0, 0, 0, nyc),
+					EarlyClose: false,
+					CloseTime:  0,
+				},
+			})
+
+			tc, err := tradecron.New("@daily", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// After market open on Monday Jan 6.
+			forDate := time.Date(2025, time.January, 6, 9, 30, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Jan 7 is a holiday, should skip to Jan 8.
+			want := time.Date(2025, time.January, 8, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+	})
+
 	Describe("Next", func() {
 		Context("when the last trading day of the month is an early-close day", func() {
 			BeforeEach(func() {

--- a/tradecron/tradecron_test.go
+++ b/tradecron/tradecron_test.go
@@ -84,6 +84,141 @@ var _ = Describe("TradeCron", func() {
 		})
 	})
 
+	Describe("@quarterbegin", func() {
+		BeforeEach(func() {
+			tradecron.SetMarketHolidays(nil)
+		})
+
+		It("fires on the first trading day of Q1", func() {
+			tc, err := tradecron.New("@quarterbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Dec 15, 2024 is mid-Q4.
+			forDate := time.Date(2024, time.December, 15, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Jan 2, 2025 is the first trading day of Q1 (Jan 1 is a holiday/weekend).
+			// Jan 1, 2025 is a Wednesday -- but it's New Year's Day.
+			// Without holidays loaded, Jan 1 is a normal Wednesday.
+			want := time.Date(2025, time.January, 1, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("fires on the first trading day of Q2", func() {
+			tc, err := tradecron.New("@quarterbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Mar 15, 2025 is mid-Q1.
+			forDate := time.Date(2025, time.March, 15, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Apr 1, 2025 is a Tuesday.
+			want := time.Date(2025, time.April, 1, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("advances to next quarter if current quarter's first day has passed", func() {
+			tc, err := tradecron.New("@quarterbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Feb 15, 2025 -- Q1 already started Jan 1.
+			forDate := time.Date(2025, time.February, 15, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Next quarter begins Apr 1, 2025 (Tuesday).
+			want := time.Date(2025, time.April, 1, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("fires on the first trading day when the quarter starts on a weekend", func() {
+			tc, err := tradecron.New("@quarterbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Jun 15, 2025 -- looking for Q3 start.
+			forDate := time.Date(2025, time.June, 15, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Jul 1, 2025 is a Tuesday.
+			want := time.Date(2025, time.July, 1, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+	})
+
+	Describe("@quarterend", func() {
+		BeforeEach(func() {
+			tradecron.SetMarketHolidays(nil)
+		})
+
+		It("fires on the last trading day of Q1", func() {
+			tc, err := tradecron.New("@quarterend", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Feb 1, 2025 -- mid-Q1.
+			forDate := time.Date(2025, time.February, 1, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Mar 31, 2025 is a Monday.
+			want := time.Date(2025, time.March, 31, 16, 0, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("fires on the last trading day of Q2", func() {
+			tc, err := tradecron.New("@quarterend", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// May 1, 2025 -- mid-Q2.
+			forDate := time.Date(2025, time.May, 1, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Jun 30, 2025 is a Monday.
+			want := time.Date(2025, time.June, 30, 16, 0, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("advances to the next quarter after firing", func() {
+			tc, err := tradecron.New("@quarterend", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// After Q1 end close on Mar 31, 2025.
+			forDate := time.Date(2025, time.March, 31, 16, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			// Next quarter end is Jun 30, 2025 (Monday).
+			want := time.Date(2025, time.June, 30, 16, 0, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("fires on the last trading day when quarter ends on a weekend", func() {
+			tc, err := tradecron.New("@quarterend", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Aug 1, 2025 -- mid-Q3. Sep 30, 2025 is a Tuesday.
+			forDate := time.Date(2025, time.August, 1, 0, 0, 0, 0, nyc)
+			got := tc.Next(forDate)
+
+			want := time.Date(2025, time.September, 30, 16, 0, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("iterates through consecutive quarters", func() {
+			tc, err := tradecron.New("@quarterend", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			forDate := time.Date(2025, time.January, 1, 0, 0, 0, 0, nyc)
+
+			var months []time.Month
+			for range 4 {
+				next := tc.Next(forDate)
+				months = append(months, next.Month())
+				forDate = next.Add(time.Nanosecond)
+			}
+
+			Expect(months).To(Equal([]time.Month{
+				time.March, time.June, time.September, time.December,
+			}))
+		})
+	})
+
 	Describe("Next", func() {
 		Context("when the last trading day of the month is an early-close day", func() {
 			BeforeEach(func() {

--- a/universe/index.go
+++ b/universe/index.go
@@ -116,10 +116,10 @@ func (u *indexUniverse) CurrentDate() time.Time {
 
 // SP500 creates a universe tracking S&P 500 membership historically.
 func SP500(p data.IndexProvider) *indexUniverse {
-	return NewIndex(p, "sp500")
+	return NewIndex(p, "SPX")
 }
 
 // Nasdaq100 creates a universe tracking Nasdaq 100 membership historically.
 func Nasdaq100(p data.IndexProvider) *indexUniverse {
-	return NewIndex(p, "ndx100")
+	return NewIndex(p, "NDX")
 }

--- a/universe/index_test.go
+++ b/universe/index_test.go
@@ -230,7 +230,7 @@ var _ = Describe("Index Universe", func() {
 	})
 
 	Describe("SP500 and Nasdaq100 convenience constructors", func() {
-		It("SP500 returns a universe that queries 'sp500'", func() {
+		It("SP500 returns a universe that queries 'SPX'", func() {
 			provider := &mockIndexProvider{
 				assetResults: map[int64][]asset.Asset{
 					now.Unix(): {aapl},
@@ -244,7 +244,7 @@ var _ = Describe("Index Universe", func() {
 			Expect(assets).To(ConsistOf(aapl))
 		})
 
-		It("Nasdaq100 returns a universe that queries 'ndx100'", func() {
+		It("Nasdaq100 returns a universe that queries 'NDX'", func() {
 			provider := &mockIndexProvider{
 				assetResults: map[int64][]asset.Asset{
 					now.Unix(): {goog},


### PR DESCRIPTION
## Summary

- Add `@daily`, `@quarterbegin`, and `@quarterend` schedule directives to tradecron
- Fix database NULL values for metrics (e.g. EV/EBIT) appearing as 0 instead of NaN in DataFrames
- Update index snapshot loading to use JSONB constituents column and `SPX`/`NDX` ticker names