### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-04-06
+
 ### Added
 
 - Schedules support `@daily`, `@quarterbegin`, and `@quarterend` directives for daily and quarterly trading schedules.
@@ -172,7 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotate portfolio decisions with justifications for audit trails.
 - Save and reload complete backtest results between sessions.
 
-[unreleased]: https://github.com/penny-vault/pvbt/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/penny-vault/pvbt/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/penny-vault/pvbt/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/penny-vault/pvbt/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/penny-vault/pvbt/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/penny-vault/pvbt/compare/v0.2.0...v0.3.0


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md to stamp the Unreleased section as v0.6.0 (2026-04-06)
- Update comparison links