### PR TITLE
Align parameter naming between engine and CLI, refresh strategy docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Strategies can use `universe.USTradable` as a daily-refreshed investable universe of liquid US stocks. Membership is sourced from pv-data and filters by market cap, dollar volume, price floor, and data completeness, mirroring the criteria of Quantopian's QTradableStocksUS. This is the recommended default universe for broad US equity strategies.
 
+### Fixed
+
+- `--preset` silently skipped strategy fields like `RiskOn` when they had no `pvbt` tag. It now applies them.
+- The strategy guide and overview examples did not compile — they called `Universe.At(ctx, date, metrics...)`, which was removed in 0.6.0.
+- The strategy guide wrongly documented `Mean`, `Sum`, `Variance`, and `Std` as reducing across assets. They reduce across time and preserve the asset axis.
+
 ## [0.6.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Strategies can use `universe.USTradable` as a daily-refreshed investable universe of liquid US stocks. Membership is sourced from pv-data and filters by market cap, dollar volume, price floor, and data completeness, mirroring the criteria of Quantopian's QTradableStocksUS. This is the recommended default universe for broad US equity strategies.
+
 ## [0.6.0] - 2026-04-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Changes to the public API are breaking and must appear in the changelog. Everyth
 - `DataFrame` (construction via `NewDataFrame`, querying, `Correlation`, `Covariance`, `Std`, etc.)
 - Broker options (`WithFractionalShares`, etc.)
 - Middleware configuration (`risk.Conservative`, `risk.Moderate`, `tax.TaxEfficient`, etc.) and TOML config file (`pvbt.toml`)
-- Weighting functions, universe declarations, parameter/preset definitions
+- Weighting functions, universe declarations (`USTradable`, `SP500`, `Nasdaq100`, `NewStatic`), parameter/preset definitions
 
 ## Code Conventions
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -114,32 +114,6 @@ var _ = Describe("defaultOutputPath", func() {
 	})
 })
 
-var _ = Describe("toKebabCase", func() {
-	It("converts PascalCase to kebab-case", func() {
-		Expect(toKebabCase("LookbackPeriod")).To(Equal("lookback-period"))
-	})
-
-	It("converts consecutive uppercase letters", func() {
-		Expect(toKebabCase("URL")).To(Equal("u-r-l"))
-	})
-
-	It("leaves lowercase unchanged", func() {
-		Expect(toKebabCase("fast")).To(Equal("fast"))
-	})
-
-	It("handles single character", func() {
-		Expect(toKebabCase("A")).To(Equal("a"))
-	})
-
-	It("handles empty string", func() {
-		Expect(toKebabCase("")).To(Equal(""))
-	})
-
-	It("converts camelCase", func() {
-		Expect(toKebabCase("myField")).To(Equal("my-field"))
-	})
-})
-
 var _ = Describe("registerStrategyFlags", func() {
 	It("registers flags from struct tags with correct defaults", func() {
 		cmd := &cobra.Command{Use: "test"}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -40,10 +40,7 @@ func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			continue
 		}
 
-		name := field.Tag.Get("pvbt")
-		if name == "" {
-			name = toKebabCase(field.Name)
-		}
+		name := engine.ParameterName(field)
 
 		desc := field.Tag.Get("desc")
 		defaultStr := field.Tag.Get("default")
@@ -133,10 +130,7 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			continue
 		}
 
-		name := field.Tag.Get("pvbt")
-		if name == "" {
-			name = toKebabCase(field.Name)
-		}
+		name := engine.ParameterName(field)
 
 		fieldValue := val.Field(ii)
 		if !fieldValue.CanSet() {
@@ -237,10 +231,7 @@ func collectParamSweeps(cmd *cobra.Command, strategy engine.Strategy) []study.Pa
 			continue
 		}
 
-		name := field.Tag.Get("pvbt")
-		if name == "" {
-			name = toKebabCase(field.Name)
-		}
+		name := engine.ParameterName(field)
 
 		fl := cmd.Flags().Lookup(name)
 		if fl == nil {
@@ -253,19 +244,4 @@ func collectParamSweeps(cmd *cobra.Command, strategy engine.Strategy) []study.Pa
 	}
 
 	return sweeps
-}
-
-// toKebabCase converts a PascalCase or camelCase name to kebab-case.
-func toKebabCase(s string) string {
-	var result strings.Builder
-
-	for i, r := range s {
-		if i > 0 && r >= 'A' && r <= 'Z' {
-			result.WriteByte('-')
-		}
-
-		result.WriteRune(r)
-	}
-
-	return strings.ToLower(result.String())
 }

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,6 +26,7 @@ package main
 
 import (
     "context"
+    "fmt"
     "time"
 
     "github.com/penny-vault/pvbt/data"
@@ -33,7 +34,6 @@ import (
     "github.com/penny-vault/pvbt/portfolio"
     "github.com/penny-vault/pvbt/signal"
     "github.com/penny-vault/pvbt/universe"
-    "github.com/rs/zerolog/log"
 )
 
 type ADM struct {
@@ -60,26 +60,25 @@ func (s *ADM) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Po
     // Average the three momentum scores across all risk-on assets.
     momentum := mom1.Add(mom3).Add(mom6).DivScalar(3)
     if err := momentum.Err(); err != nil {
-        log.Error().Err(err).Msg("signal computation failed")
-        return err
+        return fmt.Errorf("signal computation: %w", err)
     }
 
     // Pick the risk-on asset with the highest positive momentum.
     // If none are positive, fall back to the risk-off asset (TLT).
-    riskOffDF, err := s.RiskOff.At(ctx, eng.CurrentDate(), data.MetricClose)
+    riskOffDF, err := s.RiskOff.At(ctx, data.MetricClose)
     if err != nil {
-        log.Error().Err(err).Msg("risk-off data fetch failed")
-        return err
+        return fmt.Errorf("risk-off snapshot fetch: %w", err)
     }
     portfolio.MaxAboveZero(data.MetricClose, riskOffDF).Select(momentum)
 
     // Build an equal-weight plan and rebalance into it.
     plan, err := portfolio.EqualWeight(momentum)
     if err != nil {
-        log.Error().Err(err).Msg("EqualWeight failed")
-        return err
+        return fmt.Errorf("equal-weight plan: %w", err)
     }
-    batch.RebalanceTo(ctx, plan...)
+    if err := batch.RebalanceTo(ctx, plan...); err != nil {
+        return fmt.Errorf("rebalance: %w", err)
+    }
     return nil
 }
 
@@ -141,7 +140,7 @@ The `Schedule` field sets the trading schedule. The tradecron expression `@month
 
 The `Benchmark` field tells the engine which asset to compare against in performance reports. The risk-free rate used by metrics like Sharpe and Sortino is DGS3MO (3-month treasury yield), resolved automatically by the engine when available.
 
-Setup is also where a strategy would register universes it creates itself (e.g., `universe.SP500(provider)`) or do any other one-time initialization.
+Setup is also where a strategy would register universes it creates itself (e.g., `eng.IndexUniverse("us-tradable")` for the recommended broad US equity universe, or `eng.IndexUniverse("SPX")` for the S&P 500) or do any other one-time initialization.
 
 ### Compute
 
@@ -154,26 +153,25 @@ func (s *ADM) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Po
     // Average the three momentum scores across all risk-on assets.
     momentum := mom1.Add(mom3).Add(mom6).DivScalar(3)
     if err := momentum.Err(); err != nil {
-        log.Error().Err(err).Msg("signal computation failed")
-        return err
+        return fmt.Errorf("signal computation: %w", err)
     }
 
     // Pick the risk-on asset with the highest positive momentum.
     // If none are positive, fall back to the risk-off asset (TLT).
-    riskOffDF, err := s.RiskOff.At(ctx, eng.CurrentDate(), data.MetricClose)
+    riskOffDF, err := s.RiskOff.At(ctx, data.MetricClose)
     if err != nil {
-        log.Error().Err(err).Msg("risk-off data fetch failed")
-        return err
+        return fmt.Errorf("risk-off snapshot fetch: %w", err)
     }
     portfolio.MaxAboveZero(data.MetricClose, riskOffDF).Select(momentum)
 
     // Build an equal-weight plan and rebalance into it.
     plan, err := portfolio.EqualWeight(momentum)
     if err != nil {
-        log.Error().Err(err).Msg("EqualWeight failed")
-        return err
+        return fmt.Errorf("equal-weight plan: %w", err)
     }
-    batch.RebalanceTo(ctx, plan...)
+    if err := batch.RebalanceTo(ctx, plan...); err != nil {
+        return fmt.Errorf("rebalance: %w", err)
+    }
     return nil
 }
 ```

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -50,7 +50,7 @@ func (s *ADM) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Po
     mom6 := signal.Momentum(ctx, s.RiskOn, portfolio.Months(6))
 
     momentum := mom1.Add(mom3).Add(mom6).DivScalar(3)
-    riskOffDF, _ := s.RiskOff.At(ctx, eng.CurrentDate(), data.MetricClose)
+    riskOffDF, _ := s.RiskOff.At(ctx, data.MetricClose)
     portfolio.MaxAboveZero(data.MetricClose, riskOffDF).Select(momentum)
     plan, _ := portfolio.EqualWeight(momentum)
     batch.RebalanceTo(ctx, plan...)

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -25,12 +25,12 @@ package main
 
 import (
     "context"
+    "fmt"
 
     "github.com/penny-vault/pvbt/cli"
     "github.com/penny-vault/pvbt/data"
     "github.com/penny-vault/pvbt/engine"
     "github.com/penny-vault/pvbt/portfolio"
-    "github.com/penny-vault/pvbt/tradecron"
     "github.com/penny-vault/pvbt/universe"
     "github.com/rs/zerolog"
 )
@@ -59,11 +59,11 @@ func (s *MomentumRotation) Compute(ctx context.Context, eng *engine.Engine, port
     // Fetch close prices for the lookback period.
     df, err := s.RiskOn.Window(ctx, portfolio.Months(s.Lookback), data.MetricClose)
     if err != nil {
-        log.Error().Err(err).Msg("Window fetch failed")
-        return nil
+        return fmt.Errorf("risk-on window fetch: %w", err)
     }
 
     if df.Len() < 2 {
+        log.Debug().Int("len", df.Len()).Msg("insufficient risk-on history; skipping tick")
         return nil
     }
 
@@ -71,10 +71,9 @@ func (s *MomentumRotation) Compute(ctx context.Context, eng *engine.Engine, port
     momentum := df.Pct(df.Len() - 1).Last()
 
     // Fallback DataFrame for when no risk-on asset has positive momentum.
-    riskOffDF, err := s.RiskOff.At(ctx, eng.CurrentDate(), data.MetricClose)
+    riskOffDF, err := s.RiskOff.At(ctx, data.MetricClose)
     if err != nil {
-        log.Error().Err(err).Msg("risk-off data fetch failed")
-        return nil
+        return fmt.Errorf("risk-off snapshot fetch: %w", err)
     }
 
     // Select the asset with the highest positive return; fall back to risk-off.
@@ -83,13 +82,12 @@ func (s *MomentumRotation) Compute(ctx context.Context, eng *engine.Engine, port
     // Convert selection to equal-weight allocation.
     plan, err := portfolio.EqualWeight(momentum)
     if err != nil {
-        log.Error().Err(err).Msg("EqualWeight failed")
-        return nil
+        return fmt.Errorf("equal-weight plan: %w", err)
     }
 
     // Execute the rebalance.
     if err := batch.RebalanceTo(ctx, plan...); err != nil {
-        log.Error().Err(err).Msg("rebalance failed")
+        return fmt.Errorf("rebalance: %w", err)
     }
 
     return nil
@@ -295,15 +293,26 @@ func (s *MyStrategy) Setup(eng *engine.Engine) {
 
 ### Index universe
 
-Tracks historical index membership. Members change over time (additions and removals), which avoids survivorship bias:
+Tracks historical index membership. Members change over time (additions and removals), which avoids survivorship bias.
+
+For broad US equity strategies, the recommended starting point is `us-tradable`, a daily-refreshed investable universe of liquid US common stocks (market cap above the 25th percentile, $2.5M median dollar volume, $5+ price, 200 days of clean data):
 
 ```go
 func (s *MyStrategy) Setup(eng *engine.Engine) {
-    s.sp500 = eng.IndexUniverse("SP500")
+    s.stocks = eng.IndexUniverse("us-tradable")
 }
 ```
 
-At each date, `s.sp500.Assets(t)` returns the index members as of that date.
+For specific market indexes:
+
+```go
+func (s *MyStrategy) Setup(eng *engine.Engine) {
+    s.sp500 = eng.IndexUniverse("SPX")
+    s.ndx   = eng.IndexUniverse("NDX")
+}
+```
+
+At each date, `s.stocks.Assets(t)` returns the universe members as of that date.
 
 ### Rated universe
 
@@ -323,8 +332,8 @@ Both methods are available in `Compute`:
 // Window: lookback period ending at the current simulation date.
 df, err := s.Assets.Window(ctx, data.Months(6), data.MetricClose, data.AdjClose)
 
-// At: single point in time.
-df, err := s.Assets.At(ctx, eng.CurrentDate(), data.MetricClose)
+// At: single row at the current simulation date.
+df, err := s.Assets.At(ctx, data.MetricClose)
 ```
 
 The returned DataFrame contains one column per (asset, metric) pair and one row per trading day.
@@ -414,15 +423,25 @@ df.Covariance()         // cross-asset covariance matrix
 
 ### Aggregations
 
-Aggregate across assets at each timestamp:
+Two families of aggregation.
+
+**Per-column aggregations** collapse the *time* dimension and return a single-row DataFrame with one value per (asset, metric). These preserve the asset axis, so they are the right tool for computing per-asset summary statistics over a window:
 
 ```go
-df.Mean()               // average across assets -> synthetic "MEAN" asset
-df.Sum()                // sum across assets -> "SUM"
-df.MaxAcrossAssets()    // max across assets -> "MAX"
-df.MinAcrossAssets()    // min across assets -> "MIN"
-df.Variance()           // variance across timestamps per column
-df.Std()                // standard deviation
+df.Mean()               // time-mean per (asset, metric); single-row DataFrame
+df.Sum()                // time-sum per column
+df.Variance()           // time-variance per column
+df.Std()                // time-standard-deviation per column
+df.Covariance()         // cross-asset covariance matrix
+```
+
+**Cross-asset reductions** collapse the *asset* dimension and return a DataFrame with a single synthetic asset column per metric. Use these when the signal should summarize the universe at each timestamp:
+
+```go
+df.MaxAcrossAssets()    // per-row max -> synthetic "MAX" asset
+df.MinAcrossAssets()    // per-row min -> synthetic "MIN" asset
+df.IdxMaxAcrossAssets() // per-row argmax (ticker string per row)
+df.CountWhere(m, pred)  // per-row count -> synthetic "COUNT" asset
 ```
 
 ### Rolling windows

--- a/docs/superpowers/plans/2026-04-07-pvbt-strategy-author-plugin.md
+++ b/docs/superpowers/plans/2026-04-07-pvbt-strategy-author-plugin.md
@@ -1,0 +1,1243 @@
+# pvbt-strategy-author Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Claude Code plugin that helps authors design, write, and review pvbt quantitative trading strategies, then publish it to the marketplace.
+
+**Architecture:** Standalone plugin repository with one agent (pvbt-strategy-reviewer), one skill (pvbt-strategy-design), and nine curated reference documents. The agent and skill are thin orchestrators; all pvbt-specific knowledge lives in the references and is loaded on demand.
+
+**Tech Stack:** Markdown, JSON, YAML frontmatter. No build system. Git for version control. The plugin is validated by installing and dogfooding it against the Claude Code CLI.
+
+**Working directory:** This plan executes against a **new, empty sibling directory** of the pvbt checkout: `/Users/jdf/Developer/penny-vault/pvbt-strategy-author/`. All relative paths below are relative to that directory. Paths prefixed with `pvbt:` refer to the authoritative pvbt source tree at `/Users/jdf/Developer/penny-vault/pvbt/`.
+
+**Reference style:** Each reference file starts with a version header line: `_Last verified against pvbt 0.6.0._` Content is written for Claude, not humans — prefer working code examples over prose, omit narrative framing, include exact type and function names. Cross-link between files with relative paths.
+
+**Commit cadence:** One commit per phase, not per task. This avoids nuisance commits while keeping history meaningful.
+
+---
+
+## Phase 1: Scaffold the repository
+
+### Task 1: Initialize plugin repository
+
+**Files:**
+- Create: `.gitignore`
+- Create: `LICENSE`
+- Create: `README.md` (stub)
+- Create: `.claude-plugin/plugin.json`
+
+- [ ] **Step 1: Create the repository directory and initialize git**
+
+```bash
+mkdir -p /Users/jdf/Developer/penny-vault/pvbt-strategy-author
+cd /Users/jdf/Developer/penny-vault/pvbt-strategy-author
+git init -b main
+```
+
+- [ ] **Step 2: Create `.gitignore`**
+
+```
+.DS_Store
+*.swp
+.claude/settings.local.json
+```
+
+- [ ] **Step 3: Copy the Apache 2.0 LICENSE from pvbt**
+
+```bash
+cp /Users/jdf/Developer/penny-vault/pvbt/LICENSE /Users/jdf/Developer/penny-vault/pvbt-strategy-author/LICENSE
+```
+
+- [ ] **Step 4: Create `.claude-plugin/plugin.json`**
+
+```json
+{
+  "name": "pvbt-strategy-author",
+  "version": "0.1.0",
+  "description": "Design and review pvbt quantitative trading strategies. Activates when writing Go code that imports github.com/penny-vault/pvbt.",
+  "author": {
+    "name": "penny-vault"
+  },
+  "homepage": "https://github.com/penny-vault/pvbt-strategy-author",
+  "keywords": ["pvbt", "penny-vault", "quantitative-trading", "backtesting", "go"]
+}
+```
+
+- [ ] **Step 5: Create stub `README.md`**
+
+```markdown
+# pvbt-strategy-author
+
+A Claude Code plugin for authoring and reviewing [pvbt](https://github.com/penny-vault/pvbt) quantitative trading strategies.
+
+Full documentation lives in [README.md](./README.md) after Phase 5 is complete.
+```
+
+- [ ] **Step 6: Validate plugin.json is valid JSON**
+
+Run: `python3 -c 'import json; json.load(open(".claude-plugin/plugin.json"))' && echo OK`
+Expected output: `OK`
+
+- [ ] **Step 7: Commit Phase 1**
+
+```bash
+git add .
+git commit -m "chore: scaffold plugin repository"
+```
+
+---
+
+## Phase 2: Reference documents
+
+Each reference task follows the same shape:
+1. Write the acceptance criteria (questions the doc must answer).
+2. Read the authoritative upstream pvbt docs for the topic.
+3. Write the reference file with the structured outline.
+4. Verify every acceptance question is answered.
+
+Do not commit between reference tasks. Phase 2 commits once at the end.
+
+### Task 2: `references/strategy-api.md`
+
+**Files:**
+- Create: `references/strategy-api.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+The doc must answer:
+- What is the `engine.Strategy` interface? What three methods does it require?
+- What does `Setup` do vs. `Compute`? When is each called?
+- What is `Describe()`? What fields does `engine.StrategyDescription` contain?
+- How does a minimal `main()` look? What does `cli.Run` provide?
+- How are parameters declared via struct tags (`pvbt`, `desc`, `default`, `suggest`)?
+- What import paths are canonical?
+- What types is `Compute` given? Which are read-only?
+
+- [ ] **Step 2: Read upstream**
+
+Read:
+- `pvbt:engine/strategy.go`
+- `pvbt:docs/strategy-guide.md` (full file)
+- `pvbt:docs/overview.md`
+
+- [ ] **Step 3: Write `references/strategy-api.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Strategy API
+
+## Interface
+[Strategy interface verbatim with a one-line description]
+
+## Lifecycle
+[Setup once, Compute per scheduled tick, Describe declarative. Order of calls.]
+
+## Minimal strategy
+[A complete minimal strategy: package, imports, struct with one param, Name/Setup/Describe/Compute, main. Copy-paste ready.]
+
+## StrategyDescription
+[Schedule, Benchmark, Warmup, RiskFreeAsset fields with one-line semantics each.]
+
+## Parameters
+[Struct tags table: pvbt, desc, default, suggest. One example per tag.]
+
+## What you get from cli.Run
+[Subcommands: backtest, live, snapshot, describe, study, config. One line each.]
+
+## Read-only vs. mutable
+[portfolio.Portfolio is read-only. portfolio.Batch is the only way to place orders.]
+
+## See also
+[Links to scheduling.md, universes.md, portfolio-and-batch.md, parameters-and-presets.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+Re-read the file. Tick off each question from step 1. If any is missing, extend the file until all are answered.
+
+### Task 3: `references/scheduling.md`
+
+**Files:**
+- Create: `references/scheduling.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+The doc must answer:
+- What is a tradecron expression? What fields does it have?
+- What are the common named schedules (`@daily`, `@monthend`, `@monthbegin`, `@weekend`, `@weekbegin`, `@quarterend`, `@quarterbegin`)?
+- What are `@open` and `@close`?
+- What time zone does tradecron use? (Eastern)
+- How is warmup declared? How is it measured? (trading days)
+- What happens if an asset lacks enough warmup history? (strict vs. permissive mode)
+- When is `Compute` called relative to the schedule?
+
+- [ ] **Step 2: Read upstream**
+
+Read:
+- `pvbt:docs/scheduling.md`
+- `pvbt:docs/strategy-guide.md` (scheduling and warmup sections)
+- `pvbt:tradecron/*.go` (skim for directive names if doc is unclear)
+
+- [ ] **Step 3: Write `references/scheduling.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Scheduling and Warmup
+
+## tradecron expressions
+[5-field cron with market-aware extensions. Table of common schedules with exact strings.]
+
+## Time zone
+[Eastern time, always. Implications for data providers.]
+
+## Warmup
+[Declared in Describe().Warmup as integer trading days. Engine validates before first Compute.]
+
+## Strict vs. permissive mode
+[Default is strict: fails fast if warmup is insufficient. Permissive shifts start date forward.]
+
+## When Compute is called
+[Scheduled tick time. For @monthend, that's the close of the last trading day of the month.]
+
+## Common pitfalls
+[Using @daily when you mean @monthend, underestimating warmup, mismatched time zones between schedule and data provider.]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+Tick off each question. Extend as needed.
+
+### Task 4: `references/universes.md`
+
+**Files:**
+- Create: `references/universes.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- What is a Universe?
+- How do you build a static universe? As a CLI field vs. in `Setup`?
+- What is `USTradable()`? When should an author use it?
+- What are index universes (`eng.IndexUniverse("SPX")`, etc.)? What indexes are available?
+- What is a rated universe?
+- How do `Window` and `At` differ?
+- How does a universe handle historical membership changes? Why does this matter for survivorship?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/universes.md`
+- `pvbt:universe/doc.go`
+- `pvbt:universe/*.go` (scan for public API)
+- `pvbt:docs/strategy-guide.md` (universe section)
+
+- [ ] **Step 3: Write `references/universes.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Universes
+
+## What a universe is
+[One line: a group of assets, possibly time-varying.]
+
+## Kinds
+### Static
+[Fixed asset list. CLI flag form and Setup form. Example of each.]
+
+### Index-tracking
+[eng.IndexUniverse with index code. List of supported indexes (SPX, NDX, DJI, RUT...). Handles historical membership.]
+
+### USTradable convenience
+[universe.USTradable() returns a curated daily-refreshed universe of liquid US stocks. Use this as the starting point for broad US equity strategies.]
+
+### Rated
+[eng.RatedUniverse with provider and rating predicate. Example.]
+
+## Fetching data
+### Window
+[Signature, semantics, example. Returns a DataFrame spanning [t-window, t].]
+
+### At
+[Single point in time. Example.]
+
+## Survivorship bias
+[Why static universes are dangerous for long backtests. Index universes are the fix.]
+
+## See also
+[data-frames.md, common-pitfalls.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 5: `references/data-frames.md`
+
+**Files:**
+- Create: `references/data-frames.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- What is a `data.DataFrame` indexed by?
+- How do you read a single value? A column? Most recent row?
+- What slicing operations exist?
+- What arithmetic operations exist? How does alignment work?
+- What financial calculations are built in? (`Pct`, `RiskAdjustedPct`, `Diff`, `Log`, `CumSum`, `CumMax`, `Shift`, `Covariance`)
+- What aggregations are available? (`Mean`, `Sum`, `MaxAcrossAssets`, `MinAcrossAssets`, `Variance`, `Std`)
+- What rolling windows and resampling operations exist?
+- How is error propagation handled through chains?
+- When should you prefer `RiskAdjustedPct` over `Pct`?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/data.md`
+- `pvbt:docs/strategy-guide.md` (DataFrame section)
+- `pvbt:data/dataframe.go` (skim public methods)
+
+- [ ] **Step 3: Write `references/data-frames.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# DataFrames
+
+## Shape
+[Indexed by (time, asset, metric). Column-major.]
+
+## Reading values
+[Value, ValueAt, Column, Times, AssetList, MetricList examples.]
+
+## Slicing
+[Assets, Metrics, Between, Last, At, Filter. Chaining and Err().]
+
+## Arithmetic
+[Add, Sub, Mul, Div, AddScalar, MulScalar. Broadcasting rules.]
+
+## Financial calculations
+[Pct, RiskAdjustedPct, Diff, Log, CumSum, CumMax, Shift, Covariance. One-line semantics each.]
+
+## Aggregations
+[Mean, Sum, MaxAcrossAssets, MinAcrossAssets, Variance, Std. How each reshapes the DataFrame.]
+
+## Rolling windows
+[df.Rolling(n).Mean() and friends.]
+
+## Resampling
+[Downsample, Upsample.]
+
+## Error propagation
+[Operations return a new DataFrame. Errors propagate; check Err() before using the result.]
+
+## When to use RiskAdjustedPct vs. Pct
+[RiskAdjustedPct subtracts the risk-free return. Use it when the signal should not reward raw duration.]
+
+## See also
+[signals-and-weighting.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 6: `references/portfolio-and-batch.md`
+
+**Files:**
+- Create: `references/portfolio-and-batch.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- What is `portfolio.Portfolio`? What methods are exposed?
+- What is `portfolio.Batch`? What methods does it expose?
+- How does `RebalanceTo` work? What is an `Allocation`?
+- How does `batch.Order` work? What modifiers are supported (`Limit`, `Stop`, `GoodTilCancel`, `OnTheOpen`, `OnTheClose`, `WithBracket`, `OCO`, etc.)?
+- How do you short? How do negative weights in `RebalanceTo` work?
+- How do you read margin state (`MarginRatio`, `MarginDeficiency`, `BuyingPower`)?
+- What is `MarginCallHandler`?
+- Why is Portfolio read-only in `Compute`?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/portfolio.md`
+- `pvbt:docs/strategy-guide.md` (trading section)
+- `pvbt:portfolio/*.go` (skim public API)
+
+- [ ] **Step 3: Write `references/portfolio-and-batch.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Portfolio and Batch
+
+## Portfolio (read-only)
+[Cash, Value, Position, PositionValue, Holdings, MarginRatio, MarginDeficiency, BuyingPower. One line each.]
+
+## Batch
+[RebalanceTo (declarative) and Order (imperative). Never write to Portfolio directly; the engine does that from accumulated batch operations.]
+
+## Declarative: RebalanceTo
+[Three-step pipeline: select, weight, execute. Selector examples (MaxAboveZero, TopN, BottomN, CountWhere). Weighting (EqualWeight). Execute (batch.RebalanceTo).]
+
+## Imperative: Order
+[Signature. Modifier table copied from upstream. Bracket/OCO examples.]
+
+## Short selling
+[Declarative: negative weights in Allocation. Imperative: Sell when holding zero/negative. Cover: Buy to close.]
+
+## Margin
+[MarginRatio, MarginDeficiency, BuyingPower semantics. When a margin call triggers. Default auto-liquidation.]
+
+## MarginCallHandler
+[Interface. Example that covers all shorts. Note: OnMarginCall batch bypasses risk middleware.]
+
+## Allocation
+[Struct definition. Members map, weights sum to 1.0 for long-only, can exceed for leverage, can be negative for shorts.]
+
+## See also
+[signals-and-weighting.md, common-pitfalls.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 7: `references/signals-and-weighting.md`
+
+**Files:**
+- Create: `references/signals-and-weighting.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- What is a Selector? Which built-in selectors exist (`MaxAboveZero`, `TopN`, `BottomN`, `CountWhere`)?
+- How does a selector mark chosen assets? (inserts a `Selected` column)
+- What weighting functions exist? (`EqualWeight` for now; list any others)
+- How do you hand-roll a signal when the built-ins don't fit?
+- When should you reach for `portfolio.Months(n)` vs. raw integer days?
+- What's the recommended pattern for a lookback-based momentum signal?
+- How do you combine multiple metrics into one score?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/signals.md` (if present)
+- `pvbt:portfolio/select*.go`, `pvbt:portfolio/weight*.go`
+- `pvbt:docs/strategy-guide.md` (signals and weighting sections)
+
+- [ ] **Step 3: Write `references/signals-and-weighting.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Signals and Weighting
+
+## Pipeline
+[select -> weight -> execute]
+
+## Built-in selectors
+### MaxAboveZero
+[Signature, behavior, example. Note the fallback DataFrame parameter.]
+
+### TopN, BottomN
+[Signatures and examples.]
+
+### CountWhere
+[For canary-style signals. Example with NaN filtering.]
+
+## Built-in weighting
+### EqualWeight
+[Signature and example.]
+
+## Writing a custom signal
+[When to hand-roll. Example: normalized z-score of a custom metric. Emphasize reuse of DataFrame methods rather than raw loops.]
+
+## Recommended idioms
+[Momentum: df.Pct(n).Last(). Risk-adjusted: df.RiskAdjustedPct(n).Last(). Rank: df.Rolling(n).Mean() then TopN.]
+
+## Lookback helpers
+[portfolio.Months(n) vs raw integers. Prefer the helper.]
+
+## Combining metrics
+[Arithmetic across DataFrames is aligned by (asset, metric). Example: 60% momentum + 40% low-vol.]
+
+## See also
+[data-frames.md, portfolio-and-batch.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 8: `references/parameters-and-presets.md`
+
+**Files:**
+- Create: `references/parameters-and-presets.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- Which Go types can become CLI parameters?
+- What struct tags are recognized (`pvbt`, `desc`, `default`, `suggest`)?
+- How do you declare a preset? What does `describe --json` emit for presets?
+- How do you pick a preset at runtime? (`--preset Name`)
+- How should you name parameters for readability?
+- When should you expose a parameter at all vs. hard-coding it?
+- How does overfitting risk relate to parameter count?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/strategy-guide.md` (parameters section)
+- `pvbt:docs/configuration.md`
+- `pvbt:cli/*.go` (skim for tag parsing)
+
+- [ ] **Step 3: Write `references/parameters-and-presets.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Parameters and Presets
+
+## Supported types
+[Table: int, float64, string, bool, time.Duration, universe.Universe. CLI example for each.]
+
+## Struct tags
+[pvbt, desc, default, suggest. Example block with all four.]
+
+## Naming
+[Kebab-case at the CLI, exported in Go. pvbt tag overrides the derived name.]
+
+## Presets
+[Declared via suggest tag. Multiple presets per field. Resolved by --preset flag.]
+
+## When to expose a parameter
+[Expose only values the user will plausibly tune: lookback, universe, rebalance threshold. Do not expose internal magic numbers.]
+
+## Overfitting and parameter count
+[Every exposed parameter is a tuning knob and a potential source of overfitting. Prefer fewer parameters with sensible defaults and well-named presets over many parameters with no guidance.]
+
+## describe output
+[./strategy describe and describe --json. Use these to verify parameter declarations.]
+
+## See also
+[strategy-api.md, common-pitfalls.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 9: `references/testing-strategies.md`
+
+**Files:**
+- Create: `references/testing-strategies.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- How do you capture a snapshot file with `./strategy snapshot`?
+- How do you replay a snapshot in a unit test?
+- What Ginkgo patterns are conventional for strategy tests?
+- How do you write a regression test that runs a short backtest and asserts on the final equity curve?
+- How do you mock external data providers? (answer: use snapshots, not mocks)
+- How do you structure tests so they don't hit the internet?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/strategy-guide.md` (testing with snapshots section)
+- `pvbt:engine/*_test.go` (scan for patterns)
+- pvbt CLAUDE.md (Ginkgo conventions)
+
+- [ ] **Step 3: Write `references/testing-strategies.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Testing Strategies
+
+## Snapshot-based testing
+[Capture with ./strategy snapshot. Store the resulting .db under testdata/.]
+
+## Replaying a snapshot
+[Use data.NewSnapshotProvider or equivalent to replay. Concrete code example.]
+
+## Ginkgo conventions
+[BDD style. _suite_test.go per package. Redirect zerolog to GinkgoWriter. Example Describe/Context/It.]
+
+## Regression test pattern
+[Short backtest over a fixed window, assert on final NAV within a tolerance.]
+
+## Do not mock data providers
+[Use snapshots. Mocks diverge from reality.]
+
+## Offline guarantee
+[Tests must never touch the network. Snapshot files are committed to the repo (or fetched by a Makefile target before tests run).]
+
+## See also
+[common-pitfalls.md]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 10: `references/common-pitfalls.md`
+
+**Files:**
+- Create: `references/common-pitfalls.md`
+
+- [ ] **Step 1: Acceptance criteria**
+
+- What is survivorship bias and how does it manifest in pvbt strategies?
+- What is lookahead bias and how does it manifest?
+- What are the symptoms of leaked state between Compute calls?
+- What are common warmup mistakes?
+- What are common schedule / time zone mistakes?
+- What does over-parameterization look like?
+- What silent failures should authors avoid?
+- What logging mistakes are common?
+
+- [ ] **Step 2: Read upstream**
+
+- `pvbt:docs/strategy-guide.md` (any pitfalls section)
+- pvbt CLAUDE.md (error handling rules)
+- `pvbt:docs/common-pitfalls.md` (if present)
+
+- [ ] **Step 3: Write `references/common-pitfalls.md`**
+
+Structure:
+```
+_Last verified against pvbt 0.6.0._
+
+# Common Pitfalls
+
+## Survivorship bias
+Symptom: static universe with a curated ticker list used for historical backtests. Fix: use eng.IndexUniverse or USTradable.
+
+## Lookahead bias
+Symptom: the strategy runs at @monthend and uses data that has not settled by the close. Fix: move the schedule to @monthbegin (next month) or use metrics that are final at close.
+
+## Leaked state between Compute calls
+Symptom: strategy struct fields hold stateful accumulators that were never reset. Compute must be idempotent given the same (portfolio, batch) inputs. Fix: prefer deriving everything from the portfolio query API. If you must hold state, document why and reset it explicitly.
+
+## Insufficient warmup
+Symptom: the lookback is 252 trading days but Warmup is 126. The engine may run but the signal is zero or NaN at the start. Fix: Warmup should be at least as large as the longest lookback.
+
+## Time zone mismatches
+Symptom: schedule fires at the wrong time. All schedules are Eastern. Data providers must also be Eastern.
+
+## Over-parameterization
+Symptom: dozens of knobs that were added during backtest tuning. Every knob is an overfitting opportunity. Fix: remove any parameter you cannot justify from first principles.
+
+## Silent failures
+Symptom: errors in Compute are logged and nil is returned, letting the backtest continue with stale or missing data. Fix: return the error. The engine handles it.
+
+## Logging
+Symptom: fmt.Println or log package instead of zerolog. Fix: zerolog.Ctx(ctx) inside Compute.
+
+## See also
+[All other reference files cross-link here.]
+```
+
+- [ ] **Step 4: Verify acceptance**
+
+### Task 11: Commit Phase 2
+
+- [ ] **Step 1: Verify all nine reference files exist and start with a version header**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt-strategy-author
+ls references/
+head -1 references/*.md
+```
+
+Expected: nine files, each beginning with `_Last verified against pvbt 0.6.0._`.
+
+- [ ] **Step 2: Commit Phase 2**
+
+```bash
+git add references/
+git commit -m "docs: add curated pvbt reference material"
+```
+
+---
+
+## Phase 3: Design skill
+
+### Task 12: `pvbt-strategy-design` skill
+
+**Files:**
+- Create: `skills/pvbt-strategy-design/SKILL.md`
+
+- [ ] **Step 1: Acceptance scenarios**
+
+Write down three natural-language strategy descriptions and what the skill should do with each. These become the validation bar.
+
+Scenario A (complete description, no gaps):
+> "Monthly momentum rotation across SPY, EFA, EEM, 6-month lookback, fall back to SHY."
+
+Expected: extract all slots, flag no gaps, one warning about the default risk-free asset not being explicitly stated (informational, not blocking).
+
+Scenario B (partial description, one real gap):
+> "I want to buy the cheapest 10% of US stocks by P/E and rebalance quarterly."
+
+Expected: extract universe (USTradable), schedule (@quarterend), signal (PE ratio), selection (BottomN at 10% of universe size), weighting (EqualWeight default), warmup (derived). Gap to ask: lookback for the P/E measure? Daily snapshot? Trailing 12-month? Red flag: must check lookahead if using trailing fundamentals.
+
+Scenario C (description with a red flag):
+> "Historical backtest of holding AAPL, MSFT, GOOG, and AMZN equal-weighted from 2000 to today."
+
+Expected: extract everything cleanly. Red flag: survivorship bias — the asset list was selected with knowledge of their future performance. Flag this before proceeding.
+
+- [ ] **Step 2: Write `skills/pvbt-strategy-design/SKILL.md`**
+
+Structure:
+```yaml
+---
+name: pvbt-strategy-design
+description: Use when designing, brainstorming, or drafting a pvbt quantitative trading strategy. Extracts strategy intent from the author's description, fills in sensible defaults, and only pauses the brainstorm for genuine ambiguity or risk.
+---
+```
+
+Body:
+```
+# pvbt-strategy-design
+
+This skill supplements `superpowers:brainstorming` with pvbt-specific knowledge.
+It does NOT run its own flow; brainstorming still owns the conversation.
+This skill changes brainstorming's behavior from "ask about every slot" to
+"fill what you can from the description, ask only about gaps and risks".
+
+## When this skill fires
+
+Fires alongside brainstorming when the user describes a pvbt strategy.
+A typical cue is the user saying "I want to build a strategy that ...".
+
+## Strategy schema
+
+Every pvbt strategy fills these slots:
+1. Universe: static / index-tracking / rated.
+2. Schedule: tradecron expression.
+3. Signal: data metric plus computation.
+4. Selection: which subset of the universe gets held.
+5. Weighting: how capital is distributed among selected assets.
+6. Warmup: historical data required before first Compute.
+7. Benchmark and risk-free asset.
+8. CLI parameters to expose.
+9. Presets for named configurations.
+10. Risk management rules.
+
+## Extraction rules
+
+Natural language -> slot value:
+- "daily" -> @daily
+- "weekly" / "every week" -> @weekbegin or @weekend (ask only if ambiguous)
+- "monthly" / "every month" -> @monthend
+- "quarterly" -> @quarterend
+- "annually" -> @quarterend repeated; confirm
+- "N-month lookback" -> warmup ~= N * 21 trading days
+- "N-day lookback" -> warmup ~= N trading days
+- "rotate into the best" -> MaxAboveZero selection + EqualWeight
+- "top K" -> TopN selection + EqualWeight
+- "bottom K" / "cheapest" -> BottomN selection + EqualWeight
+- "momentum" unqualified -> total return over the stated lookback
+- "risk-adjusted momentum" -> RiskAdjustedPct
+- "US stocks" / "liquid US stocks" -> USTradable()
+- "S&P 500" -> eng.IndexUniverse("SPX")
+- "Nasdaq 100" -> eng.IndexUniverse("NDX")
+
+## Default table
+
+Apply when the author did not specify. Mark each default in the design doc as `(default)` so the author can override.
+
+| Slot | Default |
+|------|---------|
+| Benchmark | First asset in the primary universe if short; SPY if broad US equity |
+| Risk-free asset | Auto-resolved DGS3MO |
+| Weighting | EqualWeight |
+| Warmup | Derived from the longest declared lookback |
+| Schedule | @monthend if "rebalance" is mentioned without a cadence |
+| Selection | MaxAboveZero if "rotate" is the verb; TopN(1) if "pick the best" |
+| Parameters | Lookback, risk-on universe, risk-off universe — the stated knobs of the idea |
+| Presets | None unless named variants are mentioned |
+
+## Ambiguity triggers
+
+Pause the brainstorm and ask exactly one question when:
+1. Signal math is vague — could be raw return, risk-adjusted, or price-vs-MA.
+2. Selection count is undeclared for a "top N" style strategy.
+3. Rebalance cadence is neither stated nor implied.
+4. Exit rules are mentioned but not detailed (stop-loss, trailing drawdown).
+5. The universe is described but could be static or index-tracking (ask which).
+
+Do not ask about slots where a default is safe. Note the default in the design doc instead.
+
+## Red flag triggers
+
+Warn the author proactively, without waiting to be asked, when:
+1. The description names specific historical tickers for a backtest (survivorship bias).
+2. The trigger fires at a time when the data it needs has not settled (lookahead bias).
+3. The parameter count exceeds three or four without clear justification (overfitting risk).
+4. The warmup implied by the lookback exceeds the backtest window.
+5. The universe is a static list that excludes common failure cases.
+
+For each red flag, cite the relevant reference file:
+`references/common-pitfalls.md#survivorship-bias`, etc.
+
+## Output contract
+
+When `superpowers:brainstorming` writes the design doc at
+`docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`, this skill ensures the doc
+contains a section titled `## pvbt strategy spec` with one line per schema slot:
+
+```
+## pvbt strategy spec
+
+- **Universe:** USTradable() (default)
+- **Schedule:** @quarterend
+- **Signal:** trailing 12-month P/E ratio (asked: lookback window was not specified)
+- **Selection:** BottomN(N), where N = 10% of the universe size
+- **Weighting:** EqualWeight (default)
+- **Warmup:** 252 trading days
+- **Benchmark:** SPY (default)
+- **Risk-free asset:** DGS3MO (default)
+- **Parameters:** PercentileCut (default 0.10), RebalanceSchedule
+- **Presets:** none
+- **Risk management:** none (note: consider a stop-loss for single-name concentration)
+
+### Flagged risks
+- Lookahead bias: trailing P/E uses reported earnings; verify data provider supplies only post-announcement values.
+```
+
+The main Claude context then uses this section plus `references/` to generate code.
+No separate code-generation agent exists.
+
+## See also
+
+- references/strategy-api.md
+- references/scheduling.md
+- references/universes.md
+- references/signals-and-weighting.md
+- references/common-pitfalls.md
+```
+
+- [ ] **Step 3: Verify the skill handles the three acceptance scenarios**
+
+Dry-run each scenario by reading the skill as Claude would. For each scenario, confirm:
+- All slots that the skill says it can extract are actually extractable from the text.
+- The ambiguity triggers fire exactly where expected.
+- The red flag triggers fire exactly where expected.
+- The output contract produces a well-formed `## pvbt strategy spec` block.
+
+If any scenario produces the wrong behavior, revise the extraction rules, defaults, or triggers until all three scenarios pass.
+
+- [ ] **Step 4: Commit Phase 3**
+
+```bash
+git add skills/
+git commit -m "feat: add pvbt-strategy-design skill"
+```
+
+---
+
+## Phase 4: Reviewer agent
+
+### Task 13: `pvbt-strategy-reviewer` agent
+
+**Files:**
+- Create: `agents/pvbt-strategy-reviewer.md`
+
+- [ ] **Step 1: Acceptance scenarios**
+
+Write three known-bad strategy snippets and the findings a correct reviewer must produce.
+
+Scenario A (correctness bug):
+```go
+func (s *Foo) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
+    df, err := s.Assets.Window(ctx, data.Months(6), data.MetricClose)
+    if err != nil {
+        log.Error().Err(err).Msg("data fetch failed")
+        return nil
+    }
+    // ...
+}
+```
+
+Expected finding: Correctness — error is logged and nil returned, silencing the failure. Fix: return the wrapped error.
+
+Scenario B (idiom issue):
+```go
+func (s *Foo) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
+    df, err := s.Assets.Window(ctx, data.Months(6), data.MetricClose)
+    if err != nil { return err }
+    last := df.Last()
+    first := df.At(df.Times()[0])
+    returns := make(map[asset.Asset]float64)
+    for _, a := range df.AssetList() {
+        returns[a] = (last.Value(a, data.MetricClose) / first.Value(a, data.MetricClose)) - 1.0
+    }
+    // ... hand-rolled selection and weighting
+}
+```
+
+Expected finding: Idiom — hand-rolled return calculation, selection, and weighting. Fix: `df.Pct(df.Len()-1).Last()`, then `MaxAboveZero` + `EqualWeight`.
+
+Scenario C (quant red flag):
+```go
+type Foo struct {
+    Assets universe.Universe `pvbt:"assets" default:"AAPL,MSFT,GOOG,AMZN,META"`
+}
+
+func (s *Foo) Describe() engine.StrategyDescription {
+    return engine.StrategyDescription{ Schedule: "@monthend", Warmup: 252 }
+}
+```
+
+Expected finding: Quant red flag — hand-picked mega-cap list used as a static universe implies survivorship bias in any historical backtest. Fix: use USTradable with a liquidity filter or eng.IndexUniverse("SPX").
+
+- [ ] **Step 2: Write `agents/pvbt-strategy-reviewer.md`**
+
+Structure:
+```yaml
+---
+name: pvbt-strategy-reviewer
+description: Use this agent when Go code implementing a pvbt strategy has been written or modified. It reviews recently changed strategy code for correctness, pvbt idioms, and quant red flags such as survivorship bias and lookahead bias. Invoke after strategy edits. Examples:\n\n- user: "Write a momentum rotation strategy across SPY, EFA, EEM."\n  assistant: [writes strategy]\n  Since pvbt strategy code was written, use the pvbt-strategy-reviewer agent to review it.\n  assistant: "Let me use the pvbt-strategy-reviewer agent to check this against pvbt best practices."\n\n- user: "I refactored the signal calculation in my pvbt strategy."\n  assistant: [reads the change]\n  Since pvbt strategy code was modified, use the pvbt-strategy-reviewer agent.\n  assistant: "I'll run the pvbt-strategy-reviewer agent on the refactored code."
+tools: Bash, Glob, Grep, Read, WebFetch
+model: opus
+---
+```
+
+Body:
+```
+You are an expert pvbt strategy reviewer. You know the pvbt author-facing API
+deeply: the Strategy interface, Universe, DataFrame, Portfolio, Batch, schedules,
+warmup, signals, weighting, parameters, presets, and the common pitfalls that
+trip up quantitative strategy authors. You never use emoji.
+
+Your purpose is to review recently written or modified pvbt strategy code. You
+focus on changed code, not the entire codebase.
+
+## Knowledge base
+
+Your authoritative pvbt knowledge lives in the plugin's `references/` directory.
+Read only the references that apply to what the strategy actually uses. Do not
+read the entire reference set on every review.
+
+- references/strategy-api.md
+- references/scheduling.md
+- references/universes.md
+- references/data-frames.md
+- references/portfolio-and-batch.md
+- references/signals-and-weighting.md
+- references/parameters-and-presets.md
+- references/testing-strategies.md
+- references/common-pitfalls.md
+
+## Identification
+
+A strategy file imports `github.com/penny-vault/pvbt/engine` and defines a type
+with methods `Name`, `Setup`, and `Compute`. It typically also defines
+`Describe` and a `main` that calls `cli.Run`. If no such file exists in the
+changed set, report "no pvbt strategy found in the changed code" and stop.
+
+## Review protocol
+
+Perform three distinct passes and report findings in three sections.
+
+### Pass 1: Correctness
+
+Check:
+- The Strategy interface is fully and correctly implemented (method names,
+  signatures, receiver types).
+- Errors from data fetches, rebalances, and order placement are wrapped and
+  returned. Errors are not silently swallowed or downgraded to nil.
+- The portfolio is treated as read-only. Orders go through batch.RebalanceTo
+  or batch.Order only.
+- Warmup is declared in Describe() when the strategy needs historical data.
+  The warmup value is at least as large as the longest lookback used in Compute.
+- Schedule is declared and syntactically valid.
+- Context is threaded through to data fetches and batch operations.
+- Logging uses zerolog pulled from the context, not fmt or the standard log.
+
+Cite each finding as `file:line`. Link to the exact section of the relevant
+reference file.
+
+### Pass 2: pvbt idiom
+
+Check:
+- Built-in signal and weighting functions are used where they apply:
+  EqualWeight, MaxAboveZero, TopN, BottomN, df.Pct, df.RiskAdjustedPct,
+  portfolio.Months. Hand-rolled equivalents are findings.
+- Configuration is declarative via Describe() rather than imperative in Setup,
+  unless there is a reason.
+- Universe operations use Window or At, not manual date arithmetic.
+- Named variants are expressed as presets via struct tags, not branches in Setup.
+- Signal lookbacks use portfolio.Months or data.Months helpers.
+
+Cite each finding as `file:line`.
+
+### Pass 3: Quant red flags
+
+Check:
+- Survivorship bias: a static universe containing named tickers used as if it
+  represented historical reality. Suggest USTradable or an index universe.
+- Lookahead bias: decisions at time t that use data only available after t.
+  Pay special attention to schedules near market close and to trailing
+  fundamental metrics.
+- Leaked state: mutable fields on the strategy struct that accumulate across
+  Compute calls without explicit intent.
+- Insufficient warmup: Describe().Warmup less than the longest lookback used.
+- Missing benchmark or risk-free asset when the strategy relies on metrics that
+  need them.
+- Over-parameterization: more than three or four exposed parameters without
+  justification suggests overfitting.
+
+Cite each finding as `file:line`.
+
+## Output format
+
+Open with a one-line summary.
+
+Then three sections: `## Correctness`, `## Idiom`, `## Quant red flags`.
+Under each section, list findings in severity order:
+```
+- **<short title>** [file:line]
+  <what is wrong, one sentence>
+  <concrete fix, with a code block if it helps>
+  Reference: [<ref-file>#<anchor>]
+```
+
+If a section has no findings, write `No findings.` under the heading.
+
+Close with a "Good practices observed" section listing any notably idiomatic
+code, no more than three bullets.
+
+## Memory
+
+Update your agent memory with patterns you see across reviews in this
+project: recurring anti-patterns, project-specific idioms, and strategy
+families you have reviewed before. Do not bloat memory with per-review detail.
+
+## What you do not do
+
+- Do not rewrite the strategy from scratch. Your job is to find and explain,
+  not to replace.
+- Do not suggest style changes that are personal preference. Stick to findings
+  grounded in a reference file.
+- Do not cross-examine unrelated code. Review changed code.
+```
+
+- [ ] **Step 3: Verify the agent handles the three acceptance scenarios**
+
+Dry-run each scenario by reading the agent prompt as Claude would against each
+snippet. Confirm the agent produces:
+- Scenario A: a Correctness finding about silent error swallowing.
+- Scenario B: Idiom findings about hand-rolled return calculation and missing
+  built-in selection/weighting.
+- Scenario C: a Quant red flag about survivorship bias in the static mega-cap
+  list.
+
+If any expected finding is missing, revise the relevant pass of the agent
+prompt until all three scenarios produce the expected findings.
+
+- [ ] **Step 4: Commit Phase 4**
+
+```bash
+git add agents/
+git commit -m "feat: add pvbt-strategy-reviewer agent"
+```
+
+---
+
+## Phase 5: README and polish
+
+### Task 14: Write the public README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Write the full README**
+
+Overwrite the stub `README.md` with a complete user-facing document:
+
+```markdown
+# pvbt-strategy-author
+
+A Claude Code plugin for authoring and reviewing [pvbt](https://github.com/penny-vault/pvbt) quantitative trading strategies.
+
+## What it does
+
+- **Design** a new strategy by describing it in natural language. The `pvbt-strategy-design` skill extracts intent, fills sensible defaults, and only asks about genuine gaps or risks.
+- **Review** an existing strategy with the `pvbt-strategy-reviewer` agent. It checks correctness, pvbt idiom, and quant red flags such as survivorship and lookahead bias.
+
+## Requirements
+
+- Claude Code.
+- pvbt 0.6.0 or newer.
+
+## Install
+
+Install from the Claude Code marketplace:
+
+    /plugin install pvbt-strategy-author
+
+Or install from source:
+
+    git clone https://github.com/penny-vault/pvbt-strategy-author
+    /plugin install ./pvbt-strategy-author
+
+## Usage
+
+### Designing a strategy
+
+Describe your strategy idea in natural language. The skill activates automatically:
+
+> "I want a monthly momentum rotation across SPY, EFA, EEM with a 6-month lookback, falling back to SHY when nothing is positive."
+
+The skill extracts your intent, fills defaults, and only asks clarifying questions for genuine ambiguity.
+
+### Reviewing a strategy
+
+After writing strategy code, the reviewer agent runs automatically on changed files. You can also invoke it explicitly:
+
+> "Review my strategy."
+
+The reviewer returns a structured report with three sections: Correctness, Idiom, and Quant red flags.
+
+## How it works
+
+- `agents/pvbt-strategy-reviewer.md` — the reviewer agent definition.
+- `skills/pvbt-strategy-design/SKILL.md` — the design skill definition.
+- `references/` — curated pvbt reference material consumed by the agent and skill on demand.
+
+The plugin carries its pvbt knowledge with it. It does not require the pvbt source tree to be available at runtime.
+
+## Versioning
+
+This plugin uses semantic versioning. Major releases track breaking pvbt API changes. Minor releases add capabilities. Each reference file declares the pvbt version it was last verified against.
+
+## License
+
+Apache 2.0. See [LICENSE](./LICENSE).
+```
+
+- [ ] **Step 2: Commit Phase 5**
+
+```bash
+git add README.md
+git commit -m "docs: write public README"
+```
+
+---
+
+## Phase 6: Dogfood validation
+
+### Task 15: Validate against a real strategy
+
+**Files:**
+- Create: `validation/momentum-rotation.go` (disposable)
+- Create: `validation/notes.md`
+
+- [ ] **Step 1: Write a minimal real strategy for validation**
+
+Create `validation/momentum-rotation.go` based on the canonical example from `pvbt:docs/strategy-guide.md`. It should be the ideal, idiomatic version.
+
+- [ ] **Step 2: Run the reviewer against the ideal strategy**
+
+Dispatch a fresh Claude Code session (or subagent) with the `pvbt-strategy-reviewer` agent on `validation/momentum-rotation.go`.
+
+Expected output: no findings in any of the three sections, or only a single informational "good practices observed" note.
+
+- [ ] **Step 3: Write a degraded version**
+
+Modify `validation/momentum-rotation.go` to introduce one issue from each pass:
+- Correctness: log-and-return-nil on the data fetch error.
+- Idiom: hand-roll the momentum calculation instead of using `df.Pct`.
+- Quant red flag: change the universe to a static mega-cap list.
+
+- [ ] **Step 4: Re-run the reviewer**
+
+Dispatch again. Expected output: three findings, one per pass, each citing the correct file:line and reference section.
+
+- [ ] **Step 5: Record results in `validation/notes.md`**
+
+Structure:
+```
+# Validation notes
+
+## Ideal strategy run
+<date>
+<findings summary>
+
+## Degraded strategy run
+<date>
+<findings summary>
+
+## Adjustments made to the plugin
+<list of any reference or prompt edits prompted by validation>
+```
+
+- [ ] **Step 6: Commit Phase 6**
+
+```bash
+git add validation/
+git commit -m "test: add dogfood validation against real strategy"
+```
+
+---
+
+## Phase 7: Marketplace submission
+
+### Task 16: Prepare for marketplace submission
+
+**Files:**
+- Modify: `README.md` (add marketplace badge after acceptance)
+- Modify: `.claude-plugin/plugin.json` (bump to 0.1.0 release tag)
+
+- [ ] **Step 1: Push the repository to GitHub**
+
+```bash
+gh repo create penny-vault/pvbt-strategy-author --public --source=. --remote=origin --push
+```
+
+- [ ] **Step 2: Tag the 0.1.0 release**
+
+```bash
+git tag -a v0.1.0 -m "initial release"
+git push origin v0.1.0
+```
+
+- [ ] **Step 3: Submit to the Claude Code marketplace**
+
+Follow the marketplace submission process (docs vary — check the current submission guide at the time of release). Include:
+- Plugin repository URL.
+- One-paragraph description.
+- Screenshot or sample output from the reviewer.
+- Minimum Claude Code version.
+
+- [ ] **Step 4: Record the submission outcome in CHANGELOG.md**
+
+Create a top-level `CHANGELOG.md`:
+```
+# Changelog
+
+## 0.1.0 — 2026-04-07
+
+Initial release.
+
+- The pvbt-strategy-design skill extracts strategy intent from natural-language descriptions, fills sensible defaults, and pauses the brainstorm only for genuine ambiguity or flagged risk.
+- The pvbt-strategy-reviewer agent reviews strategy code for correctness, pvbt idiom, and quant red flags such as survivorship and lookahead bias.
+- Nine curated reference documents derived from pvbt 0.6.0 ship with the plugin and are loaded on demand by the agent and skill.
+```
+
+- [ ] **Step 5: Commit Phase 7**
+
+```bash
+git add CHANGELOG.md README.md .claude-plugin/plugin.json
+git commit -m "chore: prepare 0.1.0 release"
+git push
+```
+
+---
+
+## Self-review checklist
+
+Before declaring the plan done, verify:
+
+- [ ] Every slot in the spec's "Reviewer agent" section is covered by a specific check in Task 13.
+- [ ] Every slot in the spec's "Design skill" section is covered by a specific rule or default in Task 12.
+- [ ] Every reference file in the spec's "Plugin layout" appears as a task.
+- [ ] Every acceptance criterion question has a clear home in the corresponding reference file.
+- [ ] No step contains placeholder text like "TBD", "fill in later", or "similar to above".
+- [ ] Commit cadence is one per phase (Phases 1–7), not one per task.
+- [ ] Plugin version in `plugin.json` is `0.1.0` and every reference file header declares `pvbt 0.6.0`. The two values are different concepts — the plugin version is the plugin's own semver, and the reference version is the upstream pvbt release the docs were verified against.

--- a/docs/superpowers/specs/2026-04-07-pvbt-strategy-author-plugin-design.md
+++ b/docs/superpowers/specs/2026-04-07-pvbt-strategy-author-plugin-design.md
@@ -1,0 +1,169 @@
+# pvbt-strategy-author Claude Code Plugin
+
+## Goal
+
+Ship a Claude Code plugin to the marketplace that helps authors write and review pvbt quantitative trading strategies. The plugin targets strategy authors working in their own repositories (not pvbt contributors), so it must carry its pvbt-specific knowledge with it and not assume the pvbt source tree is available at runtime.
+
+The plugin delivers two pieces of value:
+
+1. **Design-phase help** during brainstorming: extract strategy intent from natural-language descriptions, fill in sensible defaults, and only pause on genuine ambiguity or risk.
+2. **Review-phase help** after code is written: catch correctness bugs, non-idiomatic pvbt usage, and quant red flags such as survivorship and lookahead bias.
+
+## Non-goals
+
+- Code generation is not a separate plugin component. After the design phase produces a filled-out spec, the main Claude context generates code using the plugin's shipped reference material.
+- No slash commands. Auto-activation via description fields is the only entry point in the first release. If discoverability proves weak, commands can be added later.
+- No CI integration or automated pull request review.
+- No multiple specialized reviewer agents. One reviewer with three distinct passes is simpler and matches the shape of `effective-go-reviewer`.
+- The plugin is not a replacement for pvbt documentation. Upstream `docs/*` remains authoritative; plugin references are derived.
+
+## Repository and distribution
+
+- Standalone repository, separate from `penny-vault/pvbt`.
+- Published to the Claude Code marketplace as `pvbt-strategy-author`.
+- Versioning independent of pvbt, but README declares minimum and recommended pvbt versions.
+- Semantic versioning:
+  - Major: pvbt has a breaking API change that forces plugin updates.
+  - Minor: pvbt adds a capability the plugin should surface, or plugin gains a meaningful new check.
+  - Patch: plugin-only fixes (prompt wording, reference doc corrections, bug fixes).
+
+## Plugin layout
+
+```
+pvbt-strategy-author/
+  .claude-plugin/
+    plugin.json
+  README.md
+  agents/
+    pvbt-strategy-reviewer.md
+  skills/
+    pvbt-strategy-design/
+      SKILL.md
+  references/
+    strategy-api.md
+    universes.md
+    data-frames.md
+    scheduling.md
+    portfolio-and-batch.md
+    signals-and-weighting.md
+    parameters-and-presets.md
+    testing-strategies.md
+    common-pitfalls.md
+```
+
+The agent and the skill are thin orchestrators. All pvbt-specific knowledge lives in `references/` and is loaded on demand. This keeps prompts short, lets reference content evolve without touching orchestration, and makes audit and review of the plugin tractable.
+
+## Reviewer agent
+
+### Activation
+
+The agent description must name pvbt explicitly so Claude invokes it only when Go code imports `github.com/penny-vault/pvbt/...` or implements the `engine.Strategy` interface. The description includes usage examples showing it being invoked after strategy code is written or modified.
+
+### Review protocol
+
+1. Identify strategy files in the working set. A strategy file imports pvbt and defines a type implementing `Name()`, `Setup()`, and `Compute()`.
+2. Read only the reference files relevant to what the strategy actually uses. A strategy with a static universe does not need `universes.md` loaded; a strategy using `IndexUniverse` does. This keeps each review bounded in context size.
+3. Perform three review passes, report three sections in the output:
+   - **Correctness**
+     - Interface fully implemented. No misspelled method names. Return type signatures match.
+     - Errors are wrapped with context and returned. Errors are not silently swallowed or downgraded to nil returns.
+     - The portfolio is treated as read-only. Orders go through `batch.RebalanceTo` or other batch methods.
+     - Warmup is declared in `Describe()` when the strategy needs historical data.
+     - Schedule is declared and valid.
+     - Resources such as contexts are threaded correctly.
+   - **Idiom**
+     - Built-in signal and weighting functions used where available: `EqualWeight`, `MaxAboveZero`, `df.Pct`, `df.RiskAdjustedPct`, `portfolio.Months`, and similar.
+     - Declarative `Describe()` preferred over imperative configuration in `Setup`.
+     - Universe `Window` and `At` used instead of manual date arithmetic.
+     - Presets declared via struct tags for named variants rather than hand-maintained configuration branches.
+     - Logging uses zerolog pulled from the context.
+   - **Quant red flags**
+     - Survivorship bias: a static universe used as if it represented historical reality.
+     - Lookahead bias: decisions at time `t` that use data only available after `t`.
+     - Leaked state between `Compute` calls: mutable fields on the strategy struct that accumulate across invocations without intent.
+     - Insufficient warmup relative to the declared lookback.
+     - Missing benchmark or risk-free asset when the strategy relies on metrics that need them.
+     - Parameter counts and preset counts indicative of overfitting.
+4. Each finding cites `file:line` and links to the specific reference document that explains the principle. Findings are ordered by severity within each section.
+
+### Agent memory
+
+The reviewer uses agent memory to record recurring patterns and anti-patterns it sees across reviews in a given project. This builds institutional knowledge that makes subsequent reviews more targeted without bloating the base prompt.
+
+## Design skill
+
+### Role
+
+The skill is a mental model plus a default table plus a gap detector. It does not run its own brainstorming flow. The `superpowers:brainstorming` skill continues to own the design conversation. The pvbt design skill changes brainstorming's behavior from "ask about every slot" to "fill what you can from the description, ask only about gaps and risks."
+
+### Activation
+
+The skill's frontmatter description matches when the user is designing, describing, or drafting a pvbt quantitative trading strategy. It fires alongside brainstorming.
+
+### Contents
+
+1. **Strategy schema.** The slots that make up any pvbt strategy:
+   - Universe (static, index-tracking, or rated)
+   - Schedule (tradecron expression)
+   - Signal (data metric plus computation)
+   - Selection (which subset of the universe gets held)
+   - Weighting (how capital is distributed among selected assets)
+   - Warmup (historical data required before first compute)
+   - Benchmark and risk-free asset
+   - Parameters to expose to the CLI
+   - Presets for named configurations
+   - Risk management rules
+2. **Extraction rules.** How to map natural-language phrasing to slot values. Examples:
+   - "monthly" maps to `@monthend`
+   - "quarterly" maps to `@quarterend`
+   - "N-month lookback" implies warmup of approximately `N * 21` trading days
+   - "rotate into the best" implies `MaxAboveZero` selection plus `EqualWeight`
+   - "equal weight across top K" implies `TopK` selection plus `EqualWeight`
+   - "momentum" without further qualification means total return over the lookback
+   - "risk-adjusted" or "Sharpe-like" means `RiskAdjustedPct`
+3. **Default table.** What each slot falls back to when the author does not specify it. Defaults appear in the design doc with a "(default)" marker so the author can override. Example defaults:
+   - Benchmark: first asset in the primary universe
+   - Risk-free asset: auto-resolved DGS3MO
+   - Weighting: `EqualWeight`
+   - Warmup: derived from the longest lookback mentioned
+4. **Ambiguity triggers.** The short list of situations worth pausing the brainstorm to ask about:
+   - Signal computation is vague (could be raw return, risk-adjusted, or something else)
+   - Selection rule is under-specified (how many assets get held)
+   - Rebalance cadence is not stated or implied
+   - Exit rules are mentioned but not detailed
+5. **Red-flag triggers.** Situations worth warning about even if the author did not ask:
+   - A historical backtest described with a hand-picked ticker list (survivorship risk)
+   - A decision point at market close using data that settles post-close (lookahead risk)
+   - A strategy that needs many parameters to function (overfitting risk)
+   - A universe-selection scheme incompatible with the declared warmup
+
+### Output contract
+
+When brainstorming writes its design document, the pvbt design skill ensures a "pvbt strategy spec" section is present and filled in. The section contains one line per schema slot with either the author's stated value or the default, plus any flagged ambiguities or red flags. The main Claude context then uses this section plus the `references/` files to generate code, without needing a separate code-generation agent.
+
+## Reference content strategy
+
+- **Curated, not verbatim.** Each file is scoped to a single task an agent or skill will perform. The audience is a capable Claude instance, not a human reader. Examples, constraints, and gotchas are prioritized over exposition.
+- **Source of truth remains upstream.** pvbt's `docs/*` tree is authoritative. Plugin references are derived and may lag. Each reference file has a header line naming the pvbt version it was last verified against.
+- **Cross-linked.** References use relative markdown links so Claude can navigate between them without re-reading the full set.
+- **Update workflow.** After each pvbt minor release, the plugin maintainer sweeps `references/`, diffs against upstream `docs/*`, updates wording and examples, bumps the header version line, and publishes a new plugin version.
+
+## plugin.json metadata
+
+- `name`: `pvbt-strategy-author`
+- `description`: one sentence that names pvbt, so Claude activates the plugin only in pvbt contexts.
+- `version`: semantic version.
+- `author`: penny-vault maintainer.
+- `homepage`: link to the plugin repository.
+- `keywords`: `pvbt`, `penny-vault`, `quantitative-trading`, `backtesting`.
+
+## Open questions
+
+None at this time. The design is ready for a plan.
+
+## Risks and mitigations
+
+- **Reference drift.** pvbt evolves faster than the plugin. Mitigation: version header on each reference file, scheduled sweep after every pvbt minor release, minimum-version declaration in the README.
+- **Over-activation.** The skill or agent fires outside pvbt contexts. Mitigation: description fields name pvbt explicitly and require pvbt imports or the `engine.Strategy` interface as a signal.
+- **Under-activation.** Authors do not realize the plugin applies. Mitigation: README includes explicit "how to invoke" examples; consider adding slash commands in a later version if telemetry suggests discovery is weak.
+- **Annoying brainstorm.** The skill asks too many questions, defeating its purpose. Mitigation: the extraction-first contract is load-bearing and tested by dogfooding before the first release.

--- a/docs/universes.md
+++ b/docs/universes.md
@@ -23,12 +23,6 @@ type Universe interface {
 
 `CurrentDate` returns the simulation date the universe is currently positioned at.
 
-## Choosing a universe
-
-Most strategies that trade a broad US equity opportunity set should start with `universe.USTradable(p)`. It is a daily-refreshed set of liquid US stocks that meet standard tradability criteria: market cap above the 25th percentile of US-listed common stocks, $2.5M median dollar volume over the trailing 200 days, prior close of at least $5, and 200 days of contiguous price history. Recent IPOs, ADRs, limited partnerships, ETFs, and OTC stocks are excluded, and for companies with multiple share classes only the most liquid common share is kept.
-
-Use `SP500` or `Nasdaq100` only when you specifically want to track those indexes. Use `NewStatic` for fixed asset lists like ETF rotations.
-
 ## Creating universes
 
 There are three ways to create a universe, depending on where the assets come from.
@@ -64,22 +58,41 @@ s.rates = universe.NewStatic("FRED:DGS3MO", "FRED:DGS10")
 
 ### From a predefined index
 
-For broad equity strategies, the recommended starting point:
+For broad equity strategies, the recommended starting point is `us-tradable`:
 
 ```go
-s.stocks = universe.USTradable(indexProvider)
+func (s *MomentumStrategy) Setup(eng *engine.Engine) error {
+    s.stocks = eng.IndexUniverse("us-tradable")
+    return nil
+}
 ```
 
-For well-known indexes whose membership changes over time:
+For well-known market indexes whose membership changes over time:
 
 ```go
-s.stocks = universe.SP500(indexProvider)
-s.tech = universe.Nasdaq100(indexProvider)
+func (s *MyStrategy) Setup(eng *engine.Engine) error {
+    s.sp500 = eng.IndexUniverse("SPX")
+    s.ndx   = eng.IndexUniverse("NDX")
+    return nil
+}
 ```
 
-These constructors take a `data.IndexProvider` -- a provider that knows how to supply historical index membership. The database provider implements this interface alongside `BatchProvider`. The returned universe's membership varies by date. If you backtest a strategy that uses `universe.SP500(p)` starting in 2010, the universe in January 2010 will contain whatever companies were in the S&P 500 at that time -- not today's list.
+`eng.IndexUniverse` finds the registered `IndexProvider` and wires the resulting universe to the engine's data source. The returned universe's membership varies by date: if you backtest a strategy that uses `eng.IndexUniverse("SPX")` starting in 2010, the universe in January 2010 will contain whatever companies were in the S&P 500 at that time -- not today's list.
 
-Index universes delegate to the data provider, which loads all snapshot and changelog data on the first call and advances as time progresses. The returned membership slice is borrowed and only valid for the current engine step.
+The provider loads all snapshot and changelog data on the first call and advances as time progresses. The returned membership slice is borrowed and only valid for the current engine step.
+
+#### What `us-tradable` filters
+
+The `us-tradable` universe is recomputed daily by pv-data and includes only US common stocks meeting all of the following:
+
+- Market cap above the 25th percentile of US-listed common stocks
+- Median daily dollar volume of at least $2.5M over the trailing 200 days
+- Prior close of at least $5
+- 200 trading days of contiguous price and volume history
+
+ADRs, limited partnerships, ETFs, closed-end funds, OTC stocks, and recent IPOs are excluded. For companies with multiple share classes, only the most liquid common share is kept. Membership typically lands in the 1,500-2,500 range. This is the same set of constraints Quantopian's QTradableStocksUS used to define its tradable universe, with a percentile-based market cap floor that adapts across time rather than a fixed dollar threshold.
+
+Use `us-tradable` as the default for any broad US equity strategy. Use `SPX` or `NDX` only when you specifically want to track those indexes. Use `NewStatic` for fixed asset lists like ETF rotations.
 
 ## Getting data for a universe
 

--- a/docs/universes.md
+++ b/docs/universes.md
@@ -23,6 +23,12 @@ type Universe interface {
 
 `CurrentDate` returns the simulation date the universe is currently positioned at.
 
+## Choosing a universe
+
+Most strategies that trade a broad US equity opportunity set should start with `universe.USTradable(p)`. It is a daily-refreshed set of liquid US stocks that meet standard tradability criteria: market cap above the 25th percentile of US-listed common stocks, $2.5M median dollar volume over the trailing 200 days, prior close of at least $5, and 200 days of contiguous price history. Recent IPOs, ADRs, limited partnerships, ETFs, and OTC stocks are excluded, and for companies with multiple share classes only the most liquid common share is kept.
+
+Use `SP500` or `Nasdaq100` only when you specifically want to track those indexes. Use `NewStatic` for fixed asset lists like ETF rotations.
+
 ## Creating universes
 
 There are three ways to create a universe, depending on where the assets come from.
@@ -57,6 +63,12 @@ s.rates = universe.NewStatic("FRED:DGS3MO", "FRED:DGS10")
 ```
 
 ### From a predefined index
+
+For broad equity strategies, the recommended starting point:
+
+```go
+s.stocks = universe.USTradable(indexProvider)
+```
 
 For well-known indexes whose membership changes over time:
 

--- a/engine/parameter.go
+++ b/engine/parameter.go
@@ -30,6 +30,38 @@ type Parameter struct {
 	Suggestions map[string]string `json:"suggestions,omitempty"` // preset name -> value
 }
 
+// ParameterName returns the parameter name used for a strategy struct field.
+// It prefers an explicit `pvbt` struct tag and otherwise derives a slug from
+// the Go field name by converting PascalCase or camelCase to kebab-case (for
+// example `RiskOn` becomes `risk-on`). This function is the single source of
+// truth for field-to-parameter-name derivation; both the engine and the CLI
+// call it so the names used in `describe`, cobra flags, and `--preset`
+// lookups always agree.
+func ParameterName(field reflect.StructField) string {
+	if tag := field.Tag.Get("pvbt"); tag != "" {
+		return tag
+	}
+
+	return toKebabCase(field.Name)
+}
+
+// toKebabCase converts a PascalCase or camelCase identifier to kebab-case.
+// It inserts a hyphen before every upper-case rune that is not the first
+// rune, then lower-cases the whole string.
+func toKebabCase(s string) string {
+	var result strings.Builder
+
+	for idx, runeValue := range s {
+		if idx > 0 && runeValue >= 'A' && runeValue <= 'Z' {
+			result.WriteByte('-')
+		}
+
+		result.WriteRune(runeValue)
+	}
+
+	return strings.ToLower(result.String())
+}
+
 // StrategyParameters reflects over the strategy struct and returns metadata
 // for each exported field. Used by the CLI to generate flags and by UIs to
 // build configuration forms.
@@ -58,10 +90,7 @@ func StrategyParameters(s Strategy) []Parameter {
 			continue
 		}
 
-		name := field.Tag.Get("pvbt")
-		if name == "" {
-			name = strings.ToLower(field.Name)
-		}
+		name := ParameterName(field)
 
 		var suggestions map[string]string
 		if suggestTag := field.Tag.Get("suggest"); suggestTag != "" {

--- a/engine/parameter_test.go
+++ b/engine/parameter_test.go
@@ -30,15 +30,16 @@ import (
 )
 
 type paramTestStrategy struct {
-	Lookback float64           `pvbt:"lookback" desc:"Lookback in months" default:"6.0"`
-	Ticker   asset.Asset       `pvbt:"ticker" desc:"Primary ticker" default:"SPY"`
-	RiskOn   universe.Universe `pvbt:"riskOn" desc:"Risk-on universe" default:"VFINX,PRIDX" suggest:"Classic=VFINX,PRIDX|Modern=SPY,QQQ"`
-	Name_    string            // exported, no pvbt tag -- name derived from field name
-	hidden   int               // unexported, should be skipped
-	Duration time.Duration     `pvbt:"dur" desc:"Interval" default:"5m"`
-	Enabled  bool              `pvbt:"enabled" desc:"Enable feature" default:"true"`
-	Count    int               `pvbt:"count" desc:"Number of items" default:"10"`
-	Label    string            `pvbt:"label" desc:"Display label" default:"hello"`
+	Lookback    float64           `pvbt:"lookback" desc:"Lookback in months" default:"6.0"`
+	Ticker      asset.Asset       `pvbt:"ticker" desc:"Primary ticker" default:"SPY"`
+	RiskOn      universe.Universe `pvbt:"riskOn" desc:"Risk-on universe" default:"VFINX,PRIDX" suggest:"Classic=VFINX,PRIDX|Modern=SPY,QQQ"`
+	Name_       string            // exported, no pvbt tag -- name derived from field name
+	RebalanceAt string            // exported, no pvbt tag, multi-word -- exercises kebab-case derivation
+	hidden      int               // unexported, should be skipped
+	Duration    time.Duration     `pvbt:"dur" desc:"Interval" default:"5m"`
+	Enabled     bool              `pvbt:"enabled" desc:"Enable feature" default:"true"`
+	Count       int               `pvbt:"count" desc:"Number of items" default:"10"`
+	Label       string            `pvbt:"label" desc:"Display label" default:"hello"`
 }
 
 func (s *paramTestStrategy) Name() string           { return "test" }
@@ -61,8 +62,8 @@ var _ = Describe("StrategyParameters", func() {
 		strategy := &paramTestStrategy{}
 		params := engine.StrategyParameters(strategy)
 
-		// Should include exported fields only: Lookback, Ticker, RiskOn, Name_, Duration, Enabled, Count, Label = 8
-		Expect(params).To(HaveLen(8))
+		// Should include exported fields only: Lookback, Ticker, RiskOn, Name_, RebalanceAt, Duration, Enabled, Count, Label = 9
+		Expect(params).To(HaveLen(9))
 
 		lookback := findParam(params, "lookback")
 		Expect(lookback).NotTo(BeNil())
@@ -71,13 +72,44 @@ var _ = Describe("StrategyParameters", func() {
 		Expect(lookback.GoType).To(Equal(reflect.TypeOf(float64(0))))
 	})
 
-	It("derives name from field name when pvbt tag is missing", func() {
+	It("derives a single-word name from the field name when the pvbt tag is missing", func() {
 		strategy := &paramTestStrategy{}
 		params := engine.StrategyParameters(strategy)
 
 		nameParam := findParam(params, "name_")
 		Expect(nameParam).NotTo(BeNil())
 		Expect(nameParam.FieldName).To(Equal("Name_"))
+	})
+
+	It("derives a kebab-case name for multi-word fields when the pvbt tag is missing", func() {
+		strategy := &paramTestStrategy{}
+		params := engine.StrategyParameters(strategy)
+
+		rebalanceAt := findParam(params, "rebalance-at")
+		Expect(rebalanceAt).NotTo(BeNil())
+		Expect(rebalanceAt.FieldName).To(Equal("RebalanceAt"))
+	})
+})
+
+var _ = Describe("ParameterName", func() {
+	fieldByName := func(name string) reflect.StructField {
+		t := reflect.TypeOf(paramTestStrategy{})
+		field, ok := t.FieldByName(name)
+		Expect(ok).To(BeTrue())
+		return field
+	}
+
+	It("returns the pvbt tag verbatim when present", func() {
+		Expect(engine.ParameterName(fieldByName("Lookback"))).To(Equal("lookback"))
+		Expect(engine.ParameterName(fieldByName("RiskOn"))).To(Equal("riskOn"))
+	})
+
+	It("derives kebab-case from a PascalCase field name when the tag is missing", func() {
+		Expect(engine.ParameterName(fieldByName("RebalanceAt"))).To(Equal("rebalance-at"))
+	})
+
+	It("leaves a single-word exported field lowercased", func() {
+		Expect(engine.ParameterName(fieldByName("Name_"))).To(Equal("name_"))
 	})
 
 	It("parses suggest tags into a suggestions map", func() {

--- a/universe/doc.go
+++ b/universe/doc.go
@@ -53,13 +53,21 @@
 //
 //	u := universe.NewStatic("GLD", "TLT", "FRED:DGS3MO")
 //
-// From predefined indexes: use SP500 or Nasdaq100 with an IndexProvider.
-// The provider loads all snapshot and changelog data on first access and
-// advances as time progresses. The returned membership slice is borrowed
-// and only valid for the current engine step.
+// From predefined indexes: use USTradable, SP500, or Nasdaq100 with an
+// IndexProvider, or call eng.IndexUniverse(name) from within Setup. The
+// provider loads all snapshot and changelog data on first access and advances
+// as time progresses. The returned membership slice is borrowed and only
+// valid for the current engine step.
 //
+//	u := universe.USTradable(indexProvider)
 //	u := universe.SP500(indexProvider)
 //	u := universe.Nasdaq100(indexProvider)
+//
+// USTradable is the recommended default for broad US equity strategies. It
+// is a daily-refreshed set of liquid US common stocks meeting standard
+// tradability criteria (market cap, dollar volume, price floor, and data
+// completeness). Use SP500 or Nasdaq100 only when you specifically want to
+// track those indexes.
 //
 // # Getting Data
 //

--- a/universe/index.go
+++ b/universe/index.go
@@ -123,3 +123,18 @@ func SP500(p data.IndexProvider) *indexUniverse {
 func Nasdaq100(p data.IndexProvider) *indexUniverse {
 	return NewIndex(p, "NDX")
 }
+
+// USTradable creates a universe of US stocks meeting standard tradability
+// criteria: market cap above the 25th percentile of US-listed common stocks,
+// median daily dollar volume of at least $2.5M over the trailing 200 days,
+// prior close of at least $5, and 200 days of contiguous price history.
+// Recent IPOs, ADRs, limited partnerships, ETFs, and OTC stocks are excluded.
+// For companies with multiple share classes, the most liquid common share is
+// kept. Membership is recomputed daily.
+//
+// This is the recommended default universe for strategies that trade a broad
+// US equity opportunity set. Use SP500 or Nasdaq100 only when you specifically
+// want to track those indexes.
+func USTradable(p data.IndexProvider) *indexUniverse {
+	return NewIndex(p, "us-tradable")
+}

--- a/universe/index_test.go
+++ b/universe/index_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Index Universe", func() {
 		})
 	})
 
-	Describe("SP500 and Nasdaq100 convenience constructors", func() {
+	Describe("SP500, Nasdaq100, and USTradable convenience constructors", func() {
 		It("SP500 returns a universe that queries 'SPX'", func() {
 			provider := &mockIndexProvider{
 				assetResults: map[int64][]asset.Asset{
@@ -256,6 +256,24 @@ var _ = Describe("Index Universe", func() {
 			u := universe.Nasdaq100(provider)
 			assets := u.Assets(now)
 			Expect(assets).To(ConsistOf(goog))
+		})
+
+		It("USTradable returns a universe that queries 'us-tradable'", func() {
+			provider := &mockIndexProvider{
+				assetResults: map[int64][]asset.Asset{
+					now.Unix(): {aapl, goog, msft},
+				},
+				constituentResults: map[int64][]data.IndexConstituent{
+					now.Unix(): {
+						{Asset: aapl, Weight: 0.4},
+						{Asset: goog, Weight: 0.35},
+						{Asset: msft, Weight: 0.25},
+					},
+				},
+			}
+			u := universe.USTradable(provider)
+			assets := u.Assets(now)
+			Expect(assets).To(ConsistOf(aapl, goog, msft))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Four related changes:

1. `fix: align parameter naming between engine and CLI, refresh docs` — the engine derived parameter names via `strings.ToLower`, the CLI via `toKebabCase`. For multi-word fields like `RiskOn` without an explicit `pvbt` tag, the two derivations disagreed (`riskon` vs. `risk-on`), and `--preset` silently dropped those fields. Pulls a shared `engine.ParameterName` helper into place and has both layers use it. Also refreshes the strategy guide, overview, and scheduling examples: current `Universe.At(ctx, metrics...)` signature, wrapped errors, and corrected DataFrame aggregation section (`Mean`, `Sum`, `Variance`, `Std` reduce across time, not across assets).

2. `feat: add USTradable convenience universe constructor` — the feature commit already on this branch (was local, unpushed).

3. `docs: document USTradable in universes guide and package doc` — follow-up doc updates for #2.

4. `docs: add pvbt-strategy-author plugin spec and plan` — brainstorming spec and implementation plan for the external [`pvbt-strategy-author`](https://github.com/penny-vault/pvbt-strategy-author) Claude Code plugin shipped separately.

## Context

The parameter-naming bug was surfaced while writing the `pvbt-strategy-author` plugin references — the reference author noticed that `docs/strategy-guide.md` claimed `RiskOn` becomes `--risk-on` but the engine code produced `riskon`, which broke preset lookups silently. Fixes #30 as a side effect.

Closes related doc bugs discovered in the same pass (stale `Universe.At` signature and wrong aggregation semantics in `docs/strategy-guide.md`).