### PR TITLE
fix: serialize split, interest, and journal transaction types in SQLite

### DIFF
--- a/portfolio/sqlite.go
+++ b/portfolio/sqlite.go
@@ -109,6 +109,12 @@ func transactionTypeToString(txnType asset.TransactionType) string {
 		return "deposit"
 	case asset.WithdrawalTransaction:
 		return "withdrawal"
+	case asset.SplitTransaction:
+		return "split"
+	case asset.InterestTransaction:
+		return "interest"
+	case asset.JournalTransaction:
+		return "journal"
 	default:
 		return fmt.Sprintf("unknown(%d)", int(txnType))
 	}
@@ -129,6 +135,12 @@ func stringToTransactionType(str string) (asset.TransactionType, error) {
 		return asset.DepositTransaction, nil
 	case "withdrawal":
 		return asset.WithdrawalTransaction, nil
+	case "split":
+		return asset.SplitTransaction, nil
+	case "interest":
+		return asset.InterestTransaction, nil
+	case "journal":
+		return asset.JournalTransaction, nil
 	default:
 		return 0, fmt.Errorf("unknown transaction type: %q", str)
 	}

--- a/portfolio/sqlite_test.go
+++ b/portfolio/sqlite_test.go
@@ -314,6 +314,48 @@ var _ = Describe("SQLite", func() {
 		})
 	})
 
+	Describe("transaction type round-trip", func() {
+		It("persists split, interest, and journal transaction types", func() {
+			spy := asset.Asset{Ticker: "SPY", CompositeFigi: "BBG000BHTMY2"}
+			acct := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+
+			txnDate := time.Date(2024, 3, 22, 0, 0, 0, 0, time.UTC)
+
+			acct.Record(portfolio.Transaction{
+				Date:  txnDate,
+				Asset: spy,
+				Type:  asset.SplitTransaction,
+				Qty:   20,
+				Price: 250,
+			})
+			acct.Record(portfolio.Transaction{
+				Date:   txnDate,
+				Asset:  spy,
+				Type:   asset.InterestTransaction,
+				Amount: 12.50,
+			})
+			acct.Record(portfolio.Transaction{
+				Date:   txnDate,
+				Asset:  spy,
+				Type:   asset.JournalTransaction,
+				Amount: 500,
+			})
+
+			path := filepath.Join(tmpDir, "txntypes.db")
+			Expect(acct.ToSQLite(path)).To(Succeed())
+
+			restored, err := portfolio.FromSQLite(path)
+			Expect(err).NotTo(HaveOccurred())
+
+			txns := restored.Transactions()
+			// First txn is the deposit from WithCash, then our three.
+			Expect(txns).To(HaveLen(4))
+			Expect(txns[1].Type).To(Equal(asset.SplitTransaction))
+			Expect(txns[2].Type).To(Equal(asset.InterestTransaction))
+			Expect(txns[3].Type).To(Equal(asset.JournalTransaction))
+		})
+	})
+
 	Describe("error cases", func() {
 		It("returns an error for nonexistent file", func() {
 			_, err := portfolio.FromSQLite(filepath.Join(tmpDir, "noexist.db"))


### PR DESCRIPTION
## Summary

- `transactionTypeToString` and `stringToTransactionType` in `portfolio/sqlite.go` only handled transaction types 0-5 (Buy through Withdrawal). Types 6 (Split), 7 (Interest), and 8 (Journal) fell through to the default case, producing `unknown(N)` strings in the output database and failing to deserialize on read.
- Added the three missing cases to both functions and a round-trip test that verifies all three types survive SQLite persistence.