### PR TITLE
fix: point-in-time fundamental data access with forward-fill and dimension control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Strategies can use `universe.USTradable` as a daily-refreshed investable universe of liquid US stocks. Membership is sourced from pv-data and filters by market cap, dollar volume, price floor, and data completeness, mirroring the criteria of Quantopian's QTradableStocksUS. This is the recommended default universe for broad US equity strategies.
+- Strategies can configure the fundamental data dimension (ARQ, MRQ, ARY, MRY, ART, MRT) via `SetFundamentalDimension` in `Setup`. AR dimensions use SEC filing dates for point-in-time correctness; MR dimensions include restatements and are indexed to the fiscal period. Defaults to ARQ.
 
 ### Fixed
 
 - `--preset` silently skipped strategy fields like `RiskOn` when they had no `pvbt` tag. It now applies them.
 - The strategy guide and overview examples did not compile — they called `Universe.At(ctx, date, metrics...)`, which was removed in 0.6.0.
 - The strategy guide wrongly documented `Mean`, `Sum`, `Variance`, and `Std` as reducing across assets. They reduce across time and preserve the asset axis.
+- Fundamental metrics (revenue, working capital, etc.) are now forward-filled onto the daily time grid. Previously, `FetchAt` returned NaN when the simulation date did not exactly match a filing date, and `Fetch` returned sparse data with NaN gaps between quarterly filings.
 
 ## [0.6.0] - 2026-04-06
 

--- a/data/metric_view_test.go
+++ b/data/metric_view_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/data"
+)
+
+var _ = Describe("IsFundamental", func() {
+	It("returns true for fundamental metrics", func() {
+		Expect(data.IsFundamental(data.Revenue)).To(BeTrue())
+		Expect(data.IsFundamental(data.WorkingCapital)).To(BeTrue())
+		Expect(data.IsFundamental(data.NetIncome)).To(BeTrue())
+	})
+
+	It("returns false for eod metrics", func() {
+		Expect(data.IsFundamental(data.MetricClose)).To(BeFalse())
+		Expect(data.IsFundamental(data.Volume)).To(BeFalse())
+	})
+
+	It("returns false for derived metrics", func() {
+		Expect(data.IsFundamental(data.MarketCap)).To(BeFalse())
+		Expect(data.IsFundamental(data.PE)).To(BeFalse())
+	})
+
+	It("returns false for unknown metrics", func() {
+		Expect(data.IsFundamental(data.Metric("nonexistent"))).To(BeFalse())
+	})
+})

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -601,7 +601,7 @@ func (p *PVDataProvider) fetchFundamentals(
 	}
 
 	query := fmt.Sprintf(
-		`SELECT composite_figi, event_date, %s
+		`SELECT composite_figi, event_date, date_key, %s
 		 FROM fundamentals
 		 WHERE composite_figi = ANY($1) AND event_date BETWEEN $2::date AND $3::date AND dimension = $4
 		 ORDER BY event_date`,
@@ -618,15 +618,17 @@ func (p *PVDataProvider) fetchFundamentals(
 		var (
 			figi      string
 			eventDate time.Time
+			dateKey   time.Time
 		)
 
-		vals := make([]any, len(sqlCols)+2)
+		vals := make([]any, len(sqlCols)+3)
 		vals[0] = &figi
 		vals[1] = &eventDate
+		vals[2] = &dateKey
 
 		floatVals := make([]*float64, len(sqlCols))
 		for idx := range sqlCols {
-			vals[idx+2] = &floatVals[idx]
+			vals[idx+3] = &floatVals[idx]
 		}
 
 		if err := rows.Scan(vals...); err != nil {

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -73,6 +73,12 @@ func WithConfigFile(path string) PVDataOption {
 	return func(o *pvdataOptions) { o.configFile = path }
 }
 
+// SetDimension updates the fundamental dimension filter at runtime.
+// Valid values: "ARQ", "ARY", "ART", "MRQ", "MRY", "MRT".
+func (p *PVDataProvider) SetDimension(dim string) {
+	p.dimension = dim
+}
+
 // NewPVDataProvider creates a provider that reads from a pv-data database.
 // If pool is nil the provider reads ~/.pvdata.toml (or the path set via
 // WithConfigFile) for the connection URL and creates its own pool.

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -932,6 +932,13 @@ var metricView = map[Metric]string{
 	MarketCapFundamental:                "fundamentals",
 }
 
+// IsFundamental reports whether the given metric is sourced from the
+// fundamentals table. Fundamental metrics are sparse (quarterly) and
+// require forward-fill when merged with daily price data.
+func IsFundamental(metric Metric) bool {
+	return metricView[metric] == "fundamentals"
+}
+
 // metricColumn maps fundamental Metrics to their SQL column names.
 var metricColumn = map[Metric]string{
 	Revenue:                             "revenues",

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -460,9 +460,9 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 			args := make([]any, 5+len(colMetrics))
 			args[0] = a.CompositeFigi
 			args[1] = dateStr
-			args[2] = nil  // date_key: populated when DataFrame metadata is available
-			args[3] = nil  // report_period: populated when DataFrame metadata is available
-			args[4] = "ARQ" // default dimension
+			args[2] = nil // date_key: populated when DataFrame metadata is available
+			args[3] = nil // report_period: populated when DataFrame metadata is available
+			args[4] = "ARQ"
 
 			for idx, metric := range colMetrics {
 				mi, ok := mIdx[metric]

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -429,13 +429,15 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 		return nil
 	}
 
-	placeholders := make([]string, 3+len(colNames))
-	placeholders[0] = "?"
-	placeholders[1] = "?"
+	placeholders := make([]string, 5+len(colNames))
+	placeholders[0] = "?" // composite_figi
+	placeholders[1] = "?" // event_date
+	placeholders[2] = "?" // date_key
+	placeholders[3] = "?" // report_period
+	placeholders[4] = "?" // dimension
 
-	placeholders[2] = "?"
 	for idx := range colNames {
-		placeholders[3+idx] = "?"
+		placeholders[5+idx] = "?"
 	}
 
 	// Build ON CONFLICT clause for upsert.
@@ -445,7 +447,7 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 	}
 
 	query := fmt.Sprintf(
-		"INSERT INTO fundamentals (composite_figi, event_date, dimension, %s) VALUES (%s) ON CONFLICT(composite_figi, event_date, dimension) DO UPDATE SET %s",
+		"INSERT INTO fundamentals (composite_figi, event_date, date_key, report_period, dimension, %s) VALUES (%s) ON CONFLICT(composite_figi, event_date, dimension) DO UPDATE SET %s",
 		strings.Join(colNames, ", "),
 		strings.Join(placeholders, ", "),
 		strings.Join(upsertCols, ", "),
@@ -455,23 +457,25 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 		for timeIdx, timestamp := range df.times {
 			dateStr := timestamp.Format("2006-01-02")
 
-			args := make([]any, 3+len(colMetrics))
+			args := make([]any, 5+len(colMetrics))
 			args[0] = a.CompositeFigi
 			args[1] = dateStr
-			args[2] = "ARQ" // default dimension
+			args[2] = nil  // date_key: populated when DataFrame metadata is available
+			args[3] = nil  // report_period: populated when DataFrame metadata is available
+			args[4] = "ARQ" // default dimension
 
 			for idx, metric := range colMetrics {
 				mi, ok := mIdx[metric]
 				if !ok {
-					args[3+idx] = nil
+					args[5+idx] = nil
 					continue
 				}
 
 				val := df.columns[assetIdx*numDFMetrics+mi][timeIdx]
 				if math.IsNaN(val) {
-					args[3+idx] = nil
+					args[5+idx] = nil
 				} else {
-					args[3+idx] = val
+					args[5+idx] = val
 				}
 			}
 

--- a/data/snapshot_schema.go
+++ b/data/snapshot_schema.go
@@ -51,6 +51,8 @@ func CreateSnapshotSchema(db *sql.DB) error {
 		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS fundamentals (
 			composite_figi TEXT NOT NULL REFERENCES assets(composite_figi),
 			event_date TEXT NOT NULL,
+			date_key TEXT,
+			report_period TEXT,
 			dimension TEXT NOT NULL,
 			%s,
 			PRIMARY KEY (composite_figi, event_date, dimension)

--- a/data/snapshot_schema_test.go
+++ b/data/snapshot_schema_test.go
@@ -2,6 +2,7 @@ package data_test
 
 import (
 	"database/sql"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,5 +44,37 @@ var _ = Describe("SnapshotSchema", func() {
 		// Insert a row with just the required columns to verify the table accepts them.
 		_, err = db.Exec("INSERT INTO fundamentals (composite_figi, event_date, dimension) VALUES ('TEST', '2024-01-02', 'ARQ')")
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("creates fundamentals table with date_key and report_period columns", func() {
+		dbPath := filepath.Join(GinkgoT().TempDir(), "schema_check.db")
+		fileDB, err := sql.Open("sqlite", dbPath)
+		Expect(err).NotTo(HaveOccurred())
+		defer fileDB.Close()
+
+		err = data.CreateSnapshotSchema(fileDB)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify columns exist by inserting a row with date_key and report_period.
+		_, err = fileDB.Exec(
+			"INSERT INTO assets (composite_figi, ticker) VALUES (?, ?)",
+			"TEST-FIGI", "TEST",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = fileDB.Exec(
+			"INSERT INTO fundamentals (composite_figi, event_date, date_key, report_period, dimension) VALUES (?, ?, ?, ?, ?)",
+			"TEST-FIGI", "2024-06-30", "2024-03-31", "2024-03-29", "ARQ",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var dateKey, reportPeriod string
+		err = fileDB.QueryRow(
+			"SELECT date_key, report_period FROM fundamentals WHERE composite_figi = ?",
+			"TEST-FIGI",
+		).Scan(&dateKey, &reportPeriod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dateKey).To(Equal("2024-03-31"))
+		Expect(reportPeriod).To(Equal("2024-03-29"))
 	})
 })

--- a/docs/data.md
+++ b/docs/data.md
@@ -52,6 +52,26 @@ const CPI data.Metric = "CPI"
 const FedFundsRate data.Metric = "FedFundsRate"
 ```
 
+### Fundamental data semantics
+
+Fundamental metrics (revenue, earnings, balance sheet items, etc.) are sourced
+from SEC filings and stored with three date fields:
+
+| Field | Meaning |
+|-------|---------|
+| `event_date` | Filing date -- when the data became publicly available (AR dimensions) or fiscal period end (MR dimensions). This is the temporal index used for queries. |
+| `date_key` | Normalized calendar quarter/year boundary. Used for cross-company comparison (e.g., aligning all companies' Q2 data). |
+| `report_period` | The actual end date of the company's fiscal period as stated in filings. |
+
+The engine automatically forward-fills fundamental values onto the daily time
+grid. Once a filing becomes public, its values are treated as current until the
+next filing supersedes them. This means `Fetch` and `FetchAt` return dense data
+for fundamental metrics -- no NaN gaps between quarterly filings.
+
+Fundamental queries filter by dimension (default `"ARQ"` -- As Reported
+Quarterly). See `SetFundamentalDimension` in the strategy guide for how to
+change this.
+
 ### Economic indicators
 
 Economic indicators like unemployment and CPI are not tied to a specific asset. They use the sentinel `asset.EconomicIndicator` in requests and DataFrames. From the DataFrame's perspective they look like any other asset -- the data layout stays uniform.

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -267,6 +267,33 @@ The benchmark is used for Beta, Alpha, Tracking Error, and Information Ratio.
 
 The risk-free rate is DGS3MO (3-month treasury yield), resolved automatically by the engine during initialization when available. When resolved, the engine pre-computes a cumulative risk-free series and attaches it to all DataFrames returned by `Fetch` and `FetchAt`, enabling `df.RiskAdjustedPct(n)` to subtract the risk-free return automatically. The risk-free rate feeds Sharpe, Sortino, Treynor, and related metrics.
 
+### Fundamental dimension
+
+Strategies that use fundamental data can configure which reporting dimension
+to query. Call `SetFundamentalDimension` during `Setup`:
+
+```go
+func (s *MyStrategy) Setup(eng *engine.Engine) {
+    eng.SetFundamentalDimension("ARQ")
+}
+```
+
+If not called, defaults to `"ARQ"`.
+
+| Dimension | Description |
+|-----------|-------------|
+| `ARQ` | As Reported, Quarterly. Point-in-time (indexed to SEC filing date). Excludes restatements. Recommended for backtesting. |
+| `ARY` | As Reported, Annual. Same as ARQ but annual observations. |
+| `ART` | As Reported, Trailing Twelve Months. Quarterly observations of one-year duration. |
+| `MRQ` | Most Recent Reported, Quarterly. Indexed to fiscal period end. Includes restatements. Suitable for business performance analysis. |
+| `MRY` | Most Recent Reported, Annual. |
+| `MRT` | Most Recent Reported, Trailing Twelve Months. |
+
+AR dimensions are suitable for backtesting because they are indexed to the SEC
+filing date, preventing look-ahead bias. MR dimensions include restatements
+and are indexed to the fiscal period end, so they may introduce look-ahead bias
+in backtests.
+
 ### Asset lookup
 
 `eng.Asset(ticker)` resolves a ticker to an `asset.Asset` using the registered `AssetProvider`. It panics if the ticker is not found, which is appropriate in `Setup` since a missing benchmark or risk-free asset is a fatal configuration error.

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -267,32 +267,19 @@ The benchmark is used for Beta, Alpha, Tracking Error, and Information Ratio.
 
 The risk-free rate is DGS3MO (3-month treasury yield), resolved automatically by the engine during initialization when available. When resolved, the engine pre-computes a cumulative risk-free series and attaches it to all DataFrames returned by `Fetch` and `FetchAt`, enabling `df.RiskAdjustedPct(n)` to subtract the risk-free return automatically. The risk-free rate feeds Sharpe, Sortino, Treynor, and related metrics.
 
-### Fundamental dimension
+### Fundamental data
 
-Strategies that use fundamental data can configure which reporting dimension
-to query. Call `SetFundamentalDimension` during `Setup`:
+Fundamental metrics (revenue, earnings, balance sheet items) come from SEC filings and behave differently from price data. Prices update every trading day; fundamentals update quarterly when companies file. The engine handles this automatically -- once a filing becomes public, its values are forward-filled across trading days until the next filing supersedes them. Your strategy sees dense data from both `Fetch` and `FetchAt` without NaN gaps.
+
+Fundamental data comes in two families. "As Reported" (AR) dimensions are indexed to the SEC filing date -- the date the data became publicly available. These are safe for backtesting because your strategy only sees data that existed at the time. "Most Recent Reported" (MR) dimensions include restatements and are indexed to the fiscal period end, which can introduce look-ahead bias since the restated numbers weren't available at that date.
+
+Within each family there are three time spans: Quarterly (Q), Annual (Y), and Trailing Twelve Months (T). The default is ARQ -- quarterly data indexed to filing dates, excluding restatements. To change it, call `SetFundamentalDimension` in `Setup`:
 
 ```go
-func (s *MyStrategy) Setup(eng *engine.Engine) {
-    eng.SetFundamentalDimension("ARQ")
-}
+eng.SetFundamentalDimension("MRQ") // most-recent reported, quarterly
 ```
 
-If not called, defaults to `"ARQ"`.
-
-| Dimension | Description |
-|-----------|-------------|
-| `ARQ` | As Reported, Quarterly. Point-in-time (indexed to SEC filing date). Excludes restatements. Recommended for backtesting. |
-| `ARY` | As Reported, Annual. Same as ARQ but annual observations. |
-| `ART` | As Reported, Trailing Twelve Months. Quarterly observations of one-year duration. |
-| `MRQ` | Most Recent Reported, Quarterly. Indexed to fiscal period end. Includes restatements. Suitable for business performance analysis. |
-| `MRY` | Most Recent Reported, Annual. |
-| `MRT` | Most Recent Reported, Trailing Twelve Months. |
-
-AR dimensions are suitable for backtesting because they are indexed to the SEC
-filing date, preventing look-ahead bias. MR dimensions include restatements
-and are indexed to the fiscal period end, so they may introduce look-ahead bias
-in backtests.
+The six dimensions are ARQ, ARY, ART (as reported) and MRQ, MRY, MRT (most recent reported). Use AR dimensions for backtesting and MR dimensions when you need restated numbers for business performance analysis.
 
 ### Asset lookup
 

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -279,7 +279,14 @@ Within each family there are three time spans: Quarterly (Q), Annual (Y), and Tr
 eng.SetFundamentalDimension("MRQ") // most-recent reported, quarterly
 ```
 
-The six dimensions are ARQ, ARY, ART (as reported) and MRQ, MRY, MRT (most recent reported). Use AR dimensions for backtesting and MR dimensions when you need restated numbers for business performance analysis.
+| Dimension | Description |
+|-----------|-------------|
+| `ARQ` | As Reported, Quarterly. Point-in-time (indexed to SEC filing date). Excludes restatements. Recommended for backtesting. |
+| `ARY` | As Reported, Annual. Same as ARQ but annual observations. |
+| `ART` | As Reported, Trailing Twelve Months. Quarterly observations of one-year duration. |
+| `MRQ` | Most Recent Reported, Quarterly. Indexed to fiscal period end. Includes restatements. Suitable for business performance analysis. |
+| `MRY` | Most Recent Reported, Annual. |
+| `MRT` | Most Recent Reported, Trailing Twelve Months. |
 
 ### Asset lookup
 

--- a/docs/superpowers/plans/2026-04-10-fundamental-point-in-time.md
+++ b/docs/superpowers/plans/2026-04-10-fundamental-point-in-time.md
@@ -1,0 +1,837 @@
+# Point-in-Time Fundamental Data Access Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix look-ahead bias and sparse-data failures in fundamental data queries by using filing-date semantics, forward-filling fundamental columns onto the daily grid, and letting strategies configure the fundamental dimension.
+
+**Architecture:** The provider query adds `date_key` to SELECT. The engine forward-fills fundamental metric columns in the slab before trimming with `Between`. A new `SetFundamentalDimension` method on Engine flows through to the provider. The snapshot schema gains `date_key` and `report_period` columns.
+
+**Tech Stack:** Go, PostgreSQL (pgx), SQLite (modernc.org/sqlite), Ginkgo/Gomega
+
+**Spec:** `docs/superpowers/specs/2026-04-10-fundamental-point-in-time-design.md`
+
+---
+
+### Task 1: Add `IsFundamental` classification function
+
+**Files:**
+- Modify: `data/pvdata_provider.go:816-845` (metricView map area)
+- Create: `data/metric_view_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `data/metric_view_test.go`:
+
+```go
+package data_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/data"
+)
+
+var _ = Describe("IsFundamental", func() {
+	It("returns true for fundamental metrics", func() {
+		Expect(data.IsFundamental(data.Revenue)).To(BeTrue())
+		Expect(data.IsFundamental(data.WorkingCapital)).To(BeTrue())
+		Expect(data.IsFundamental(data.NetIncome)).To(BeTrue())
+	})
+
+	It("returns false for eod metrics", func() {
+		Expect(data.IsFundamental(data.MetricClose)).To(BeFalse())
+		Expect(data.IsFundamental(data.Volume)).To(BeFalse())
+	})
+
+	It("returns false for derived metrics", func() {
+		Expect(data.IsFundamental(data.MarketCap)).To(BeFalse())
+		Expect(data.IsFundamental(data.PE)).To(BeFalse())
+	})
+
+	It("returns false for unknown metrics", func() {
+		Expect(data.IsFundamental(data.Metric("nonexistent"))).To(BeFalse())
+	})
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "IsFundamental" ./data/`
+Expected: FAIL -- `IsFundamental` not defined
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `data/pvdata_provider.go` after the `metricView` map (around line 933):
+
+```go
+// IsFundamental reports whether the given metric is sourced from the
+// fundamentals table. Fundamental metrics are sparse (quarterly) and
+// require forward-fill when merged with daily price data.
+func IsFundamental(metric Metric) bool {
+	return metricView[metric] == "fundamentals"
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "IsFundamental" ./data/`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add data/pvdata_provider.go data/metric_view_test.go
+git commit -m "feat: add IsFundamental classifier for metric view routing"
+```
+
+---
+
+### Task 2: Add `date_key` to `fetchFundamentals` SELECT
+
+**Files:**
+- Modify: `data/pvdata_provider.go:574-648` (fetchFundamentals)
+
+This task changes the SQL query to also read `date_key`. The column is scanned but not yet used for anything beyond being available in future work. The time axis and WHERE clause stay on `event_date`.
+
+- [ ] **Step 1: Write the failing test**
+
+This is an internal query change that doesn't affect the provider's public API yet. Add an integration-style test that verifies `date_key` is readable. However, since the existing tests use `TestProvider` (no database), and the real database query is an internal detail, we verify this indirectly in Task 5. For now, no new test -- move to the implementation.
+
+- [ ] **Step 2: Update the SQL query and scan**
+
+In `data/pvdata_provider.go`, change `fetchFundamentals` (starting at line 603):
+
+Replace the query and scan block:
+
+```go
+	query := fmt.Sprintf(
+		`SELECT composite_figi, event_date, date_key, %s
+		 FROM fundamentals
+		 WHERE composite_figi = ANY($1) AND event_date BETWEEN $2::date AND $3::date AND dimension = $4
+		 ORDER BY event_date`,
+		strings.Join(sqlCols, ", "),
+	)
+
+	rows, err := conn.Query(ctx, query, figis, start, end, p.dimension)
+	if err != nil {
+		return fmt.Errorf("pvdata: query fundamentals: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			figi      string
+			eventDate time.Time
+			dateKey   time.Time
+		)
+
+		vals := make([]any, len(sqlCols)+3)
+		vals[0] = &figi
+		vals[1] = &eventDate
+		vals[2] = &dateKey
+
+		floatVals := make([]*float64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[idx+3] = &floatVals[idx]
+		}
+
+		if err := rows.Scan(vals...); err != nil {
+			return fmt.Errorf("pvdata: scan fundamentals row: %w", err)
+		}
+
+		eventDate = eodTimestamp(eventDate)
+		sec := eventDate.Unix()
+		timeSet[sec] = eventDate
+
+		for idx, m := range metricOrder {
+			if floatVals[idx] != nil {
+				ensureCol(figi, m)[sec] = *floatVals[idx]
+			}
+		}
+	}
+```
+
+Note: `dateKey` is scanned but not yet used. It will be exposed as DataFrame metadata in a future change.
+
+- [ ] **Step 3: Run existing tests to verify nothing broke**
+
+Run: `ginkgo run -race ./data/`
+Expected: PASS (existing tests use TestProvider, not the real database)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/pvdata_provider.go
+git commit -m "feat: read date_key column in fetchFundamentals query"
+```
+
+---
+
+### Task 3: Forward-fill fundamental columns in `fetchRange`
+
+**Files:**
+- Modify: `engine/engine.go:558-598` (slab assembly in fetchRange)
+- Modify: `engine/fetch_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `engine/fetch_test.go`. This test creates a provider with both daily price data and sparse fundamental data (only a few dates have values), runs a `FetchAt` on a date with no fundamental row, and verifies the fundamental value is forward-filled from the most recent prior entry.
+
+```go
+Context("with sparse fundamental data", func() {
+	It("forward-fills fundamental metrics to the simulation date", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		fundamentalAssets := []asset.Asset{spy}
+		assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+		// Daily close prices: Jan 1 - Mar 31 2024
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 90, fundamentalAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		// Sparse fundamental data: only two filing dates
+		filingDate1 := time.Date(2024, 1, 15, 16, 0, 0, 0, time.UTC) // Q3 filing
+		filingDate2 := time.Date(2024, 2, 20, 16, 0, 0, 0, time.UTC) // Q4 filing
+
+		fundTimes := []time.Time{filingDate1, filingDate2}
+		fundVals := [][]float64{{100_000_000}, {120_000_000}} // WorkingCapital
+		fundDF, err := data.NewDataFrame(fundTimes, fundamentalAssets,
+			[]data.Metric{data.WorkingCapital}, data.Daily, fundVals)
+		Expect(err).NotTo(HaveOccurred())
+		fundProvider := data.NewTestProvider([]data.Metric{data.WorkingCapital}, fundDF)
+
+		// Strategy fetches both Close and WorkingCapital via FetchAt
+		strategy := &fetchAtStrategy{
+			metrics: []data.Metric{data.MetricClose, data.WorkingCapital},
+			assets:  fundamentalAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProvider),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		// Run on Feb 28 -- no fundamental filing on this date.
+		// Should forward-fill from the Feb 20 filing (120M).
+		simDate := time.Date(2024, 2, 28, 0, 0, 0, 0, time.UTC)
+		_, btErr := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(btErr).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+		Expect(strategy.fetched).NotTo(BeNil())
+
+		wc := strategy.fetched.Column(spy, data.WorkingCapital)
+		Expect(wc).To(HaveLen(1))
+		Expect(wc[0]).To(BeNumerically("==", 120_000_000))
+	})
+
+	It("forward-fills fundamentals in Fetch with a lookback range", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		fundamentalAssets := []asset.Asset{spy}
+		assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+		// Daily close prices: Jan 1 - Mar 31 2024
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 90, fundamentalAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		// Single fundamental filing on Feb 1
+		filingDate := time.Date(2024, 2, 1, 16, 0, 0, 0, time.UTC)
+		fundDF, err := data.NewDataFrame(
+			[]time.Time{filingDate},
+			fundamentalAssets,
+			[]data.Metric{data.Revenue},
+			data.Daily,
+			[][]float64{{500_000_000}},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		fundProvider := data.NewTestProvider([]data.Metric{data.Revenue}, fundDF)
+
+		strategy := &fetchStrategy{
+			lookback: portfolio.Days(30),
+			metrics:  []data.Metric{data.MetricClose, data.Revenue},
+			assets:   fundamentalAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProvider),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		// Run on Mar 1. Lookback 30 days covers Feb 1 - Mar 1.
+		// Revenue should be filled forward from Feb 1 across all days.
+		simDate := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+		_, btErr := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(btErr).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+		revCol := strategy.fetched.Column(spy, data.Revenue)
+		Expect(len(revCol)).To(BeNumerically(">", 1))
+
+		// Every value from the filing date onward should be 500M.
+		for _, val := range revCol {
+			Expect(val).To(BeNumerically("==", 500_000_000))
+		}
+	})
+
+	It("does not forward-fill price metrics", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		fundamentalAssets := []asset.Asset{spy}
+		assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+		// Sparse close prices: only 2 days, with a gap
+		day1 := time.Date(2024, 2, 1, 16, 0, 0, 0, time.UTC)
+		day2 := time.Date(2024, 2, 5, 16, 0, 0, 0, time.UTC)
+		priceDF, err := data.NewDataFrame(
+			[]time.Time{day1, day2},
+			fundamentalAssets,
+			[]data.Metric{data.MetricClose},
+			data.Daily,
+			[][]float64{{100.0}, {105.0}},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		priceProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, priceDF)
+
+		strategy := &fetchStrategy{
+			lookback: portfolio.Days(5),
+			metrics:  []data.Metric{data.MetricClose},
+			assets:   fundamentalAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(priceProvider),
+			engine.WithAssetProvider(assetProvider),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simDate := time.Date(2024, 2, 5, 0, 0, 0, 0, time.UTC)
+		_, btErr := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(btErr).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+		closeCol := strategy.fetched.Column(spy, data.MetricClose)
+		// Should have exactly 2 values (the 2 actual price days), not forward-filled
+		Expect(closeCol).To(HaveLen(2))
+	})
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `ginkgo run -race --focus "sparse fundamental" ./engine/`
+Expected: FAIL -- the `FetchAt` test gets NaN for WorkingCapital; the `Fetch` test gets NaN for Revenue on non-filing days.
+
+- [ ] **Step 3: Implement forward-fill in fetchRange**
+
+In `engine/engine.go`, add the forward-fill logic after the slab scatter loop (after line 590) and before the `NewDataFrame` call (line 592). Import `data.IsFundamental`.
+
+Insert between the scatter loop closing brace (line 590) and the `assembled, err :=` line (line 592):
+
+```go
+	// Forward-fill fundamental metric columns. Fundamentals are sparse
+	// (quarterly filing dates) but represent step-function data: the
+	// value holds until the next filing supersedes it.
+	for mIdx, metric := range metrics {
+		if !data.IsFundamental(metric) {
+			continue
+		}
+
+		for aIdx := range assets {
+			colStart := (aIdx*numMetrics + mIdx) * numTimes
+
+			for ti := 1; ti < numTimes; ti++ {
+				if math.IsNaN(slab[colStart+ti]) && !math.IsNaN(slab[colStart+ti-1]) {
+					slab[colStart+ti] = slab[colStart+ti-1]
+				}
+			}
+		}
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "sparse fundamental" ./engine/`
+Expected: PASS
+
+- [ ] **Step 5: Run full engine test suite**
+
+Run: `ginkgo run -race ./engine/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/engine.go engine/fetch_test.go
+git commit -m "feat: forward-fill fundamental metrics onto the daily grid in fetchRange"
+```
+
+---
+
+### Task 4: Add `SetFundamentalDimension` on Engine and `SetDimension` on PVDataProvider
+
+**Files:**
+- Modify: `data/pvdata_provider.go:49-56` (PVDataProvider struct area)
+- Modify: `engine/engine.go:50-77` (Engine struct area)
+- Create: `engine/dimension_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `engine/dimension_test.go`:
+
+```go
+package engine_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+type dimensionStrategy struct {
+	dimensionToSet string
+	metrics        []data.Metric
+	assets         []asset.Asset
+	fetched        *data.DataFrame
+	fetchErr       error
+}
+
+func (s *dimensionStrategy) Name() string { return "dimensionStrategy" }
+
+func (s *dimensionStrategy) Setup(eng *engine.Engine) {
+	if s.dimensionToSet != "" {
+		eng.SetFundamentalDimension(s.dimensionToSet)
+	}
+}
+
+func (s *dimensionStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5"}
+}
+
+func (s *dimensionStrategy) Compute(ctx context.Context, eng *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	s.fetched, s.fetchErr = eng.FetchAt(ctx, s.assets, eng.CurrentDate(), s.metrics)
+	return nil
+}
+
+var _ = Describe("SetFundamentalDimension", func() {
+	It("accepts valid dimensions", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+
+		closeDF := makeDailyDF(
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			90, testAssets, []data.Metric{data.MetricClose},
+		)
+		provider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+		assetProv := &mockAssetProvider{assets: testAssets}
+
+		strategy := &dimensionStrategy{
+			dimensionToSet: "MRQ",
+			metrics:        []data.Metric{data.MetricClose},
+			assets:         testAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(provider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		start := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 2, 5, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects invalid dimensions", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+
+		closeDF := makeDailyDF(
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			90, testAssets, []data.Metric{data.MetricClose},
+		)
+		provider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+		assetProv := &mockAssetProvider{assets: testAssets}
+
+		strategy := &dimensionStrategy{
+			dimensionToSet: "INVALID",
+			metrics:        []data.Metric{data.MetricClose},
+			assets:         testAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(provider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		start := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 2, 5, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid fundamental dimension"))
+	})
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "SetFundamentalDimension" ./engine/`
+Expected: FAIL -- `SetFundamentalDimension` not defined
+
+- [ ] **Step 3: Add `SetDimension` on PVDataProvider**
+
+In `data/pvdata_provider.go`, add after the `WithConfigFile` function (after line 74):
+
+```go
+// SetDimension updates the fundamental dimension filter at runtime.
+// Valid values: "ARQ", "ARY", "ART", "MRQ", "MRY", "MRT".
+func (p *PVDataProvider) SetDimension(dim string) {
+	p.dimension = dim
+}
+```
+
+- [ ] **Step 4: Add `SetFundamentalDimension` on Engine**
+
+In `engine/engine.go`, add a field to the Engine struct (around line 73, after `predicting`):
+
+```go
+	fundamentalDimension string
+```
+
+Add validation set:
+
+```go
+// validDimensions lists the accepted fundamental dimension codes.
+var validDimensions = map[string]bool{
+	"ARQ": true, "ARY": true, "ART": true,
+	"MRQ": true, "MRY": true, "MRT": true,
+}
+```
+
+Add the public method:
+
+```go
+// SetFundamentalDimension configures the fundamental data dimension used
+// by this engine. Valid values: "ARQ", "ARY", "ART", "MRQ", "MRY", "MRT".
+// Call this from Strategy.Setup. If not called, defaults to "ARQ".
+func (e *Engine) SetFundamentalDimension(dim string) {
+	e.fundamentalDimension = dim
+}
+```
+
+- [ ] **Step 5: Wire dimension into engine initialization**
+
+Find the engine initialization code that calls `buildProviderRouting` (or the backtest/live run setup). After `Setup` is called on the strategy and before the first data fetch, validate and apply the dimension.
+
+In the engine's initialization sequence, after the strategy `Setup` call, add:
+
+```go
+	if e.fundamentalDimension != "" {
+		if !validDimensions[e.fundamentalDimension] {
+			return nil, fmt.Errorf("invalid fundamental dimension %q; valid values: ARQ, ARY, ART, MRQ, MRY, MRT", e.fundamentalDimension)
+		}
+
+		for _, provider := range e.providers {
+			if pvProvider, ok := provider.(interface{ SetDimension(string) }); ok {
+				pvProvider.SetDimension(e.fundamentalDimension)
+			}
+		}
+	}
+```
+
+Use the `interface{ SetDimension(string) }` type assertion so this works without coupling the engine to `PVDataProvider` directly.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `ginkgo run -race --focus "SetFundamentalDimension" ./engine/`
+Expected: PASS
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `ginkgo run -race ./engine/`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add data/pvdata_provider.go engine/engine.go engine/dimension_test.go
+git commit -m "feat: add SetFundamentalDimension for strategy-level dimension control"
+```
+
+---
+
+### Task 5: Update snapshot schema with `date_key` and `report_period`
+
+**Files:**
+- Modify: `data/snapshot_schema.go:51-57`
+- Modify: `data/snapshot_recorder.go:404-483`
+- Modify: `data/snapshot_provider.go:529-540`
+- Modify: `data/snapshot_recorder_test.go` (or `data/snapshot_provider_test.go`)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test in the existing snapshot test file that verifies `date_key` and `report_period` survive a round-trip through snapshot write/read. Since the snapshot recorder writes fundamental data and the snapshot provider reads it, check that the new columns are present in the schema.
+
+In `data/snapshot_recorder_test.go`, add a test that creates a snapshot database, verifies the fundamentals table has the `date_key` and `report_period` columns:
+
+```go
+It("creates fundamentals table with date_key and report_period columns", func() {
+	dbPath := filepath.Join(tmpDir, "schema_check.db")
+	db, err := sql.Open("sqlite", dbPath)
+	Expect(err).NotTo(HaveOccurred())
+	defer db.Close()
+
+	err = data.CreateSnapshotSchema(db)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Verify columns exist by inserting a row with date_key and report_period.
+	_, err = db.Exec(
+		"INSERT INTO assets (composite_figi, ticker) VALUES (?, ?)",
+		"TEST-FIGI", "TEST",
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = db.Exec(
+		"INSERT INTO fundamentals (composite_figi, event_date, date_key, report_period, dimension) VALUES (?, ?, ?, ?, ?)",
+		"TEST-FIGI", "2024-06-30", "2024-03-31", "2024-03-29", "ARQ",
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	var dateKey, reportPeriod string
+	err = db.QueryRow(
+		"SELECT date_key, report_period FROM fundamentals WHERE composite_figi = ?",
+		"TEST-FIGI",
+	).Scan(&dateKey, &reportPeriod)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(dateKey).To(Equal("2024-03-31"))
+	Expect(reportPeriod).To(Equal("2024-03-29"))
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `ginkgo run -race --focus "date_key and report_period" ./data/`
+Expected: FAIL -- columns don't exist in schema
+
+- [ ] **Step 3: Update `CreateSnapshotSchema`**
+
+In `data/snapshot_schema.go`, change the fundamentals CREATE TABLE (lines 51-57) to include the new columns:
+
+```go
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS fundamentals (
+			composite_figi TEXT NOT NULL REFERENCES assets(composite_figi),
+			event_date TEXT NOT NULL,
+			date_key TEXT,
+			report_period TEXT,
+			dimension TEXT NOT NULL,
+			%s,
+			PRIMARY KEY (composite_figi, event_date, dimension)
+		)`, fundamentalCols),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `ginkgo run -race --focus "date_key and report_period" ./data/`
+Expected: PASS
+
+- [ ] **Step 5: Update snapshot recorder**
+
+In `data/snapshot_recorder.go`, update `recordFundamentals` to write `date_key` and `report_period`. These columns are not yet populated from the DataFrame (that depends on the deferred metadata work), so write them as NULL for now. Change the INSERT statement (around line 447-448):
+
+Update the placeholders and query to include the two new columns:
+
+```go
+	placeholders := make([]string, 5+len(colNames))
+	placeholders[0] = "?" // composite_figi
+	placeholders[1] = "?" // event_date
+	placeholders[2] = "?" // date_key (NULL for now)
+	placeholders[3] = "?" // report_period (NULL for now)
+	placeholders[4] = "?" // dimension
+
+	for idx := range colNames {
+		placeholders[5+idx] = "?"
+	}
+```
+
+```go
+	query := fmt.Sprintf(
+		"INSERT INTO fundamentals (composite_figi, event_date, date_key, report_period, dimension, %s) VALUES (%s) ON CONFLICT(composite_figi, event_date, dimension) DO UPDATE SET %s",
+		strings.Join(colNames, ", "),
+		strings.Join(placeholders, ", "),
+		strings.Join(upsertCols, ", "),
+	)
+```
+
+Update the args construction in the row loop:
+
+```go
+			args := make([]any, 5+len(colMetrics))
+			args[0] = a.CompositeFigi
+			args[1] = dateStr
+			args[2] = nil // date_key: populated when DataFrame metadata is available
+			args[3] = nil // report_period: populated when DataFrame metadata is available
+			args[4] = "ARQ" // default dimension
+```
+
+And update the metric indexing to offset by 5 instead of 3:
+
+```go
+			for idx, metric := range colMetrics {
+				mi, ok := mIdx[metric]
+				if !ok {
+					args[5+idx] = nil
+					continue
+				}
+
+				val := df.columns[assetIdx*numDFMetrics+mi][timeIdx]
+				if math.IsNaN(val) {
+					args[5+idx] = nil
+				} else {
+					args[5+idx] = val
+				}
+			}
+```
+
+- [ ] **Step 6: Update snapshot provider**
+
+In `data/snapshot_provider.go`, the `fetchFundamentals` query (around line 532-539) should also read `date_key` if present but the snapshot provider doesn't need to use it yet. For forward compatibility, just leave the query as-is -- it selects specific metric columns by name and won't break with new columns in the table. No change needed here.
+
+- [ ] **Step 7: Run full data test suite**
+
+Run: `ginkgo run -race ./data/`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add data/snapshot_schema.go data/snapshot_recorder.go data/snapshot_recorder_test.go
+git commit -m "feat: add date_key and report_period columns to snapshot fundamentals table"
+```
+
+---
+
+### Task 6: Update documentation
+
+**Files:**
+- Modify: `docs/data.md`
+- Modify: `docs/strategy-guide.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update `docs/data.md`**
+
+Add a new section after the fundamentals metrics listing (or wherever fundamental data is described). Add a section titled "Fundamental data semantics":
+
+```markdown
+### Fundamental data semantics
+
+Fundamental metrics (revenue, earnings, balance sheet items, etc.) are sourced
+from SEC filings and stored with three date fields:
+
+| Field | Meaning |
+|-------|---------|
+| `event_date` | Filing date -- when the data became publicly available (AR dimensions) or fiscal period end (MR dimensions). This is the temporal index used for queries. |
+| `date_key` | Normalized calendar quarter/year boundary. Used for cross-company comparison (e.g., aligning all companies' Q2 data). |
+| `report_period` | The actual end date of the company's fiscal period as stated in filings. |
+
+The engine automatically forward-fills fundamental values onto the daily time
+grid. Once a filing becomes public, its values are treated as current until the
+next filing supersedes them. This means `Fetch` and `FetchAt` return dense data
+for fundamental metrics -- no NaN gaps between quarterly filings.
+
+Fundamental queries filter by dimension (default `"ARQ"` -- As Reported
+Quarterly). See `SetFundamentalDimension` in the strategy guide for how to
+change this.
+```
+
+- [ ] **Step 2: Update `docs/strategy-guide.md`**
+
+Add documentation for `SetFundamentalDimension` near the `Setup` method documentation:
+
+```markdown
+### Fundamental dimension
+
+Strategies that use fundamental data can configure which reporting dimension
+to query. Call `SetFundamentalDimension` during `Setup`:
+
+```go
+func (s *MyStrategy) Setup(eng *engine.Engine) {
+    eng.SetFundamentalDimension("ARQ")
+}
+```
+
+If not called, defaults to `"ARQ"`.
+
+| Dimension | Description |
+|-----------|-------------|
+| `ARQ` | As Reported, Quarterly. Point-in-time (indexed to SEC filing date). Excludes restatements. Recommended for backtesting. |
+| `ARY` | As Reported, Annual. Same as ARQ but annual observations. |
+| `ART` | As Reported, Trailing Twelve Months. Quarterly observations of one-year duration. |
+| `MRQ` | Most Recent Reported, Quarterly. Indexed to fiscal period end. Includes restatements. Suitable for business performance analysis. |
+| `MRY` | Most Recent Reported, Annual. |
+| `MRT` | Most Recent Reported, Trailing Twelve Months. |
+
+AR dimensions are suitable for backtesting because they are indexed to the SEC
+filing date, preventing look-ahead bias. MR dimensions include restatements
+and are indexed to the fiscal period end, so they may introduce look-ahead bias
+in backtests.
+```
+
+- [ ] **Step 3: Update `CHANGELOG.md`**
+
+Add entries under `[Unreleased]`:
+
+Under `### Added`:
+```markdown
+- Strategies can configure the fundamental data dimension (ARQ, MRQ, ARY, MRY, ART, MRT) via `SetFundamentalDimension` in `Setup`. AR dimensions use SEC filing dates for point-in-time correctness; MR dimensions include restatements and are indexed to the fiscal period. Defaults to ARQ.
+```
+
+Under `### Fixed`:
+```markdown
+- Fundamental metrics (revenue, working capital, etc.) are now forward-filled onto the daily time grid. Previously, `FetchAt` returned NaN when the simulation date did not exactly match a filing date, and `Fetch` returned sparse data with NaN gaps between quarterly filings.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/data.md docs/strategy-guide.md CHANGELOG.md
+git commit -m "docs: document point-in-time fundamental semantics and SetFundamentalDimension"
+```
+
+---
+
+### Task 7: Run full test suite and lint
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `ginkgo run -race ./...`
+Expected: PASS
+
+- [ ] **Step 2: Run linter**
+
+Run: `golangci-lint run ./...`
+Expected: 0 issues
+
+- [ ] **Step 3: Fix any issues found**
+
+If any tests fail or lint issues appear, fix them before proceeding.
+
+- [ ] **Step 4: Final commit if any fixes were needed**
+
+Only if step 3 produced changes:
+
+```bash
+git add -A
+git commit -m "fix: address lint and test issues from fundamental point-in-time changes"
+```

--- a/docs/superpowers/specs/2026-04-10-fundamental-point-in-time-design.md
+++ b/docs/superpowers/specs/2026-04-10-fundamental-point-in-time-design.md
@@ -1,0 +1,106 @@
+# Point-in-Time Fundamental Data Access
+
+## Problem
+
+The engine's fundamental data queries use `event_date BETWEEN $start AND $end` where `event_date` is about to become the SEC filing date (AR dimensions) or the fiscal period end (MR dimensions). Two bugs exist:
+
+1. **Look-ahead bias.** Before the column swap, `event_date` was the normalized calendar quarter boundary, not the filing date. The query returned data on the quarter boundary date even though the filing hadn't happened yet. For example, AAPL Q2 2024 data appeared at June 30 but wasn't filed until August 2.
+
+2. **Weekend alignment failure.** `FetchAt` passes `(timestamp, timestamp)` to `fetchRange`, which trims with `Between(timestamp, timestamp)`. Fundamental filing dates are sparse -- they rarely land on the simulation date. For daily price data this works because there's a row on every trading day. For quarterly fundamentals, exact-match almost never succeeds.
+
+After the ongoing column swap (`event_date` becomes the filing date, `date_key` becomes the normalized quarter boundary), problem 1 is resolved at the data level. Problem 2 remains: `FetchAt` on a simulation date won't match a filing date, and `Fetch` over a date range returns fundamentals only on their filing dates with NaN gaps everywhere else.
+
+Additionally, strategies cannot configure which fundamental dimension (ARQ, MRQ, etc.) to use. The dimension is hardcoded to `"ARQ"` in the provider.
+
+## Design
+
+### 1. Provider: add date_key to SELECT
+
+In `PVDataProvider.fetchFundamentals` (`data/pvdata_provider.go`), add `date_key` to the SELECT clause:
+
+```sql
+SELECT composite_figi, event_date, date_key, {metric columns}
+FROM fundamentals
+WHERE composite_figi = ANY($1)
+  AND event_date BETWEEN $2::date AND $3::date
+  AND dimension = $4
+ORDER BY event_date
+```
+
+The WHERE clause stays on `event_date` (filing date post-swap). The `date_key` (normalized quarter boundary post-swap) is read but not used for filtering. It is stored alongside the metric values in the cache so downstream consumers can access it in the future.
+
+The `date_key` value is stored as a new `DateKey` field on a per-row basis in the cache entry. The exact representation is an implementation detail, but one approach is a parallel `[]time.Time` in `colCacheEntry` or a separate metadata structure keyed by `(figi, event_date_unix)`.
+
+### 2. Engine: forward-fill fundamentals in fetchRange
+
+In `Engine.fetchRange` (`engine/engine.go`), after scattering cached values into the NaN-filled slab (around line 590) and before the `Between` trim (line 598):
+
+1. Identify which metrics are fundamentals. Use the existing `metricView` map: any metric where `metricView[metric] == "fundamentals"` is a fundamental metric. This classification needs to be accessible from the engine layer. Add a `data.IsFundamental(metric)` function that checks `metricView`.
+
+2. For each fundamental metric column in the slab, forward-fill NaN gaps. Walk the column chronologically; when a NaN is encountered, replace it with the most recent non-NaN value. This implements step-function semantics: once a filing is public, its values are current until the next filing.
+
+3. The `Between(rangeStart, rangeEnd)` trim then works correctly for both `Fetch` (range) and `FetchAt` (single date). Fundamental values are dense on the daily grid, so `Between(timestamp, timestamp)` finds a value.
+
+Forward-fill only runs on fundamental columns. Price and derived metric columns are left unchanged.
+
+### 3. Engine: SetFundamentalDimension
+
+Add a method on `*Engine`:
+
+```go
+func (e *Engine) SetFundamentalDimension(dim string)
+```
+
+Valid values: `"ARQ"`, `"ARY"`, `"ART"`, `"MRQ"`, `"MRY"`, `"MRT"`. The engine validates the value during initialization (in `buildProviderRouting` or the run loop setup). Invalid values produce an error before the backtest starts.
+
+The engine passes the dimension to the provider. Since the provider is created before the engine in the CLI commands, the engine calls a method on the provider to update the dimension, or the engine re-creates the provider with the new dimension. The simplest path: add a `SetDimension(dim string)` method on `PVDataProvider` that updates `p.dimension`.
+
+Strategy authors call this in `Setup`:
+
+```go
+func (s *MyStrategy) Setup(eng *engine.Engine) {
+    eng.SetFundamentalDimension("ARQ") // default; explicit for clarity
+}
+```
+
+If not called, defaults to `"ARQ"`.
+
+This is a public API addition (strategy author surface).
+
+### 4. Snapshot schema
+
+Update `CreateSnapshotSchema` in `data/snapshot_schema.go` to add `date_key` and `report_period` columns to the fundamentals table:
+
+```sql
+CREATE TABLE IF NOT EXISTS fundamentals (
+    composite_figi TEXT NOT NULL REFERENCES assets(composite_figi),
+    event_date TEXT NOT NULL,
+    date_key TEXT,
+    report_period TEXT,
+    dimension TEXT NOT NULL,
+    {metric columns},
+    PRIMARY KEY (composite_figi, event_date, dimension)
+)
+```
+
+Update `recordFundamentals` in `data/snapshot_recorder.go` to write these columns. Update the snapshot reader to read them back.
+
+### 5. Documentation
+
+- `docs/data.md`: Document the fundamental date field semantics. After the column swap: `event_date` is the filing date (when data became publicly available for AR dimensions), `date_key` is the normalized calendar quarter boundary (for cross-company comparison), `report_period` is the actual fiscal period end. Explain that the engine automatically applies point-in-time filtering and forward-fill for fundamental metrics.
+
+- `docs/strategy-guide.md`: Document `SetFundamentalDimension`. Explain the dimension choices (AR vs MR, Q vs Y vs T) and their implications. AR dimensions are suitable for backtesting (point-in-time indexed to SEC filing). MR dimensions include restatements and are indexed to the fiscal period end.
+
+- `CHANGELOG.md`: Entries under appropriate headings for the point-in-time fix, dimension API, and snapshot schema change.
+
+### 6. Deferred: DataFrame metadata for date_key
+
+A future change will expose `date_key` (normalized quarter boundary) as DataFrame metadata so strategies can group fundamentals by reporting period for cross-company alignment. This is not needed for the initial fix -- the NCAVE strategy and similar "most recent available" patterns work without it.
+
+## What does not change
+
+- The `DataSource` interface (`Fetch`, `FetchAt`, `CurrentDate`) -- signatures are unchanged.
+- The `DataRequest` struct -- no new fields needed.
+- The `BatchProvider` interface.
+- `fetchEod` and `fetchMetrics` queries -- daily data, `event_date` is already correct for those tables.
+- The cache key structure (`colCacheKey`) -- fundamental columns are cached the same way, just with forward-fill applied during assembly.

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -108,7 +108,20 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 		}
 	}
 
-	// 4d. Initialize child strategies.
+	// 4d. Validate and wire fundamental dimension if set by Setup.
+	if e.fundamentalDimension != "" {
+		if !validDimensions[e.fundamentalDimension] {
+			return nil, fmt.Errorf("engine: invalid fundamental dimension %q; valid values: ARQ, ARY, ART, MRQ, MRY, MRT", e.fundamentalDimension)
+		}
+
+		for _, provider := range e.providers {
+			if pvProvider, ok := provider.(interface{ SetDimension(string) }); ok {
+				pvProvider.SetDimension(e.fundamentalDimension)
+			}
+		}
+	}
+
+	// 4e. Initialize child strategies.
 	for _, child := range e.children {
 		if err := hydrateFields(e, child.strategy); err != nil {
 			return nil, fmt.Errorf("engine: hydrating child %q: %w", child.name, err)

--- a/engine/dimension_test.go
+++ b/engine/dimension_test.go
@@ -1,0 +1,115 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+type dimensionStrategy struct {
+	dimensionToSet string
+	metrics        []data.Metric
+	assets         []asset.Asset
+	fetched        *data.DataFrame
+	fetchErr       error
+}
+
+func (s *dimensionStrategy) Name() string { return "dimensionStrategy" }
+
+func (s *dimensionStrategy) Setup(eng *engine.Engine) {
+	if s.dimensionToSet != "" {
+		eng.SetFundamentalDimension(s.dimensionToSet)
+	}
+}
+
+func (s *dimensionStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5"}
+}
+
+func (s *dimensionStrategy) Compute(ctx context.Context, eng *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	s.fetched, s.fetchErr = eng.FetchAt(ctx, s.assets, eng.CurrentDate(), s.metrics)
+	return nil
+}
+
+var _ = Describe("SetFundamentalDimension", func() {
+	It("accepts valid dimensions", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+
+		closeDF := makeDailyDF(
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			90, testAssets, []data.Metric{data.MetricClose},
+		)
+		provider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+		assetProv := &mockAssetProvider{assets: testAssets}
+
+		strategy := &dimensionStrategy{
+			dimensionToSet: "MRQ",
+			metrics:        []data.Metric{data.MetricClose},
+			assets:         testAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(provider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		start := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 2, 5, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("rejects invalid dimensions", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+
+		closeDF := makeDailyDF(
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			90, testAssets, []data.Metric{data.MetricClose},
+		)
+		provider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+		assetProv := &mockAssetProvider{assets: testAssets}
+
+		strategy := &dimensionStrategy{
+			dimensionToSet: "INVALID",
+			metrics:        []data.Metric{data.MetricClose},
+			assets:         testAssets,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(provider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		start := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 2, 5, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid fundamental dimension"))
+	})
+})

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -239,55 +239,6 @@ func (e *Engine) buildProviderRouting() error {
 	return nil
 }
 
-// fetchFromProviders groups metrics by their provider, issues one Fetch call
-// per provider, and merges the results with MergeColumns.
-func (e *Engine) fetchFromProviders(ctx context.Context, assets []asset.Asset, metrics []data.Metric, start, end time.Time) (*data.DataFrame, error) {
-	if e.metricProvider == nil {
-		return nil, fmt.Errorf("engine: provider routing not initialized; call buildProviderRouting first")
-	}
-
-	// Group metrics by provider.
-	providerMetrics := make(map[data.BatchProvider][]data.Metric)
-
-	for _, metric := range metrics {
-		batchProvider, ok := e.metricProvider[metric]
-		if !ok {
-			return nil, fmt.Errorf("engine: no provider registered for metric %q", metric)
-		}
-
-		providerMetrics[batchProvider] = append(providerMetrics[batchProvider], metric)
-	}
-
-	var frames []*data.DataFrame
-
-	for batchProvider, provMetrics := range providerMetrics {
-		req := data.DataRequest{
-			Assets:    assets,
-			Metrics:   provMetrics,
-			Start:     start,
-			End:       end,
-			Frequency: data.Daily,
-		}
-
-		df, err := batchProvider.Fetch(ctx, req)
-		if err != nil {
-			return nil, fmt.Errorf("engine: provider fetch: %w", err)
-		}
-
-		frames = append(frames, df)
-	}
-
-	if len(frames) == 0 {
-		return data.NewDataFrame(nil, nil, nil, data.Daily, nil)
-	}
-
-	if len(frames) == 1 {
-		return frames[0], nil
-	}
-
-	return data.MergeColumns(frames...)
-}
-
 // Fetch implements data.DataSource.
 func (e *Engine) Fetch(ctx context.Context, assets []asset.Asset, lookback portfolio.Period, metrics []data.Metric) (*data.DataFrame, error) {
 	log := zerolog.Ctx(ctx)
@@ -454,7 +405,11 @@ func (e *Engine) fetchRange(ctx context.Context, assets []asset.Asset, metrics [
 		}
 	}
 
-	// Fetch misses: one bulk call per chunk year.
+	// Fetch misses: one bulk call per provider per chunk year. Each provider
+	// is fetched independently so that providers with different time axes
+	// (e.g. sparse fundamental filing dates vs. dense daily close prices)
+	// do not need to share a common timestamp grid at fetch time. The slab
+	// assembly below builds the union time axis from cached column entries.
 	for year, cacheMiss := range misses {
 		missAssets := make([]asset.Asset, 0, len(cacheMiss.assets))
 		for _, assetItem := range cacheMiss.assets {
@@ -476,39 +431,96 @@ func (e *Engine) fetchRange(ctx context.Context, assets []asset.Asset, metrics [
 			Time("chunkEnd", chunkEnd).
 			Msg("engine.fetchRange cache miss")
 
-		df, err := e.fetchFromProviders(ctx, missAssets, missMetrics, chunkStart, chunkEnd)
-		if err != nil {
-			return nil, err
+		// Group miss metrics by provider so each provider is fetched once.
+		type providerFetch struct {
+			provider data.BatchProvider
+			metrics  []data.Metric
 		}
 
-		// Decompose the DataFrame into individual columns and cache them.
-		// For empty results, cache empty entries so we don't re-fetch.
-		dfTimes := df.Times()
-		if len(dfTimes) == 0 {
-			empty := &colCacheEntry{}
+		providerMap := make(map[data.BatchProvider]*providerFetch)
 
-			for _, assetItem := range missAssets {
-				for _, metric := range missMetrics {
-					key := colCacheKey{figi: assetItem.CompositeFigi, metric: metric, chunkStart: year}
-					e.cache.put(key, empty)
+		for _, metric := range missMetrics {
+			bp, ok := e.metricProvider[metric]
+			if !ok {
+				return nil, fmt.Errorf("engine: no provider registered for metric %q", metric)
+			}
+
+			pf, exists := providerMap[bp]
+			if !exists {
+				pf = &providerFetch{provider: bp}
+				providerMap[bp] = pf
+			}
+
+			pf.metrics = append(pf.metrics, metric)
+		}
+
+		// Cache metrics that could not be fetched (not in any miss) as empty
+		// so we record them as checked and don't re-fetch on subsequent calls.
+		cachedMetrics := make(map[data.Metric]bool, len(missMetrics))
+
+		for _, pf := range providerMap {
+			req := data.DataRequest{
+				Assets:    missAssets,
+				Metrics:   pf.metrics,
+				Start:     chunkStart,
+				End:       chunkEnd,
+				Frequency: data.Daily,
+			}
+
+			df, fetchErr := pf.provider.Fetch(ctx, req)
+			if fetchErr != nil {
+				return nil, fmt.Errorf("engine: provider fetch: %w", fetchErr)
+			}
+
+			// Decompose the DataFrame into individual columns and cache them.
+			// Each provider may have its own time axis (e.g. sparse fundamentals).
+			dfTimes := df.Times()
+			if len(dfTimes) == 0 {
+				empty := &colCacheEntry{}
+
+				for _, assetItem := range missAssets {
+					for _, metric := range pf.metrics {
+						key := colCacheKey{figi: assetItem.CompositeFigi, metric: metric, chunkStart: year}
+						e.cache.put(key, empty)
+
+						cachedMetrics[metric] = true
+					}
+				}
+			} else {
+				timesCopy := make([]time.Time, len(dfTimes))
+				copy(timesCopy, dfTimes)
+
+				for _, assetItem := range df.AssetList() {
+					for _, metric := range df.MetricList() {
+						col := df.Column(assetItem, metric)
+						if col == nil {
+							continue
+						}
+
+						colCopy := make([]float64, len(col))
+						copy(colCopy, col)
+
+						key := colCacheKey{figi: assetItem.CompositeFigi, metric: metric, chunkStart: year}
+						e.cache.put(key, &colCacheEntry{times: timesCopy, values: colCopy})
+
+						cachedMetrics[metric] = true
+					}
 				}
 			}
-		} else {
-			for _, assetItem := range df.AssetList() {
-				for _, metric := range df.MetricList() {
-					col := df.Column(assetItem, metric)
-					if col == nil {
-						continue
-					}
+		}
 
-					colCopy := make([]float64, len(col))
-					copy(colCopy, col)
+		// Any miss metric not placed into the cache (because its provider
+		// returned an empty result without listing it in MetricList) needs an
+		// empty sentinel so we don't re-fetch it on the next call.
+		for _, assetItem := range missAssets {
+			for _, metric := range missMetrics {
+				if cachedMetrics[metric] {
+					continue
+				}
 
-					timesCopy := make([]time.Time, len(dfTimes))
-					copy(timesCopy, dfTimes)
-
-					key := colCacheKey{figi: assetItem.CompositeFigi, metric: metric, chunkStart: year}
-					e.cache.put(key, &colCacheEntry{times: timesCopy, values: colCopy})
+				key := colCacheKey{figi: assetItem.CompositeFigi, metric: metric, chunkStart: year}
+				if _, already := e.cache.get(key); !already {
+					e.cache.put(key, &colCacheEntry{})
 				}
 			}
 		}
@@ -584,6 +596,25 @@ func (e *Engine) fetchRange(ctx context.Context, assets []asset.Asset, metrics [
 					}
 
 					slab[colStart+ti] = entry.values[ii]
+				}
+			}
+		}
+	}
+
+	// Forward-fill fundamental metric columns. Fundamentals are sparse
+	// (quarterly filing dates) but represent step-function data: the
+	// value holds until the next filing supersedes it.
+	for mIdx, metric := range metrics {
+		if !data.IsFundamental(metric) {
+			continue
+		}
+
+		for aIdx := range assets {
+			colStart := (aIdx*numMetrics + mIdx) * numTimes
+
+			for ti := 1; ti < numTimes; ti++ {
+				if math.IsNaN(slab[colStart+ti]) && !math.IsNaN(slab[colStart+ti-1]) {
+					slab[colStart+ti] = slab[colStart+ti-1]
 				}
 			}
 		}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -50,16 +50,17 @@ type Engine struct {
 	riskFreeIndex      map[time.Time]int // date -> index into riskFreeValues, built once during init
 
 	// configuration (set via options, used during init)
-	cacheMaxBytes    int64
-	initialDeposit   float64
-	broker           broker.Broker
-	snapshot         portfolio.PortfolioSnapshot
-	dateRangeMode    DateRangeMode
-	warmup           int
-	benchmarkTicker  string
-	fillBaseModel    broker.BaseModel
-	fillAdjusters    []broker.Adjuster
-	middlewareConfig *MiddlewareConfig
+	cacheMaxBytes        int64
+	initialDeposit       float64
+	broker               broker.Broker
+	snapshot             portfolio.PortfolioSnapshot
+	dateRangeMode        DateRangeMode
+	warmup               int
+	benchmarkTicker      string
+	fillBaseModel        broker.BaseModel
+	fillAdjusters        []broker.Adjuster
+	middlewareConfig     *MiddlewareConfig
+	fundamentalDimension string
 
 	account portfolio.PortfolioManager
 
@@ -129,6 +130,19 @@ func (e *Engine) createAccount(start time.Time) portfolio.PortfolioManager {
 	opts = append(opts, portfolio.WithBroker(e.broker))
 
 	return portfolio.New(opts...)
+}
+
+// validDimensions lists the accepted fundamental dimension codes.
+var validDimensions = map[string]bool{
+	"ARQ": true, "ARY": true, "ART": true,
+	"MRQ": true, "MRY": true, "MRT": true,
+}
+
+// SetFundamentalDimension configures the fundamental data dimension used
+// by this engine. Valid values: "ARQ", "ARY", "ART", "MRQ", "MRY", "MRT".
+// Call this from Strategy.Setup. If not called, defaults to "ARQ".
+func (e *Engine) SetFundamentalDimension(dim string) {
+	e.fundamentalDimension = dim
 }
 
 // SetBenchmark sets the benchmark asset for performance comparison.

--- a/engine/fetch_test.go
+++ b/engine/fetch_test.go
@@ -423,4 +423,138 @@ var _ = Describe("Fetch", func() {
 			Expect(strategy.fetched.Len()).To(BeNumerically(">", 10))
 		})
 	})
+
+	Context("with sparse fundamental data", func() {
+		It("forward-fills fundamental metrics to the simulation date", func() {
+			spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+			fundamentalAssets := []asset.Asset{spy}
+			assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+			// Daily close prices: Jan 1 - Mar 31 2024
+			closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			closeDF := makeDailyDF(closeStart, 90, fundamentalAssets, []data.Metric{data.MetricClose})
+			closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+			// Sparse fundamental data: only two filing dates
+			filingDate1 := time.Date(2024, 1, 15, 16, 0, 0, 0, time.UTC)
+			filingDate2 := time.Date(2024, 2, 20, 16, 0, 0, 0, time.UTC)
+
+			fundTimes := []time.Time{filingDate1, filingDate2}
+			fundVals := [][]float64{{100_000_000, 120_000_000}}
+			fundDF, err := data.NewDataFrame(fundTimes, fundamentalAssets,
+				[]data.Metric{data.WorkingCapital}, data.Daily, fundVals)
+			Expect(err).NotTo(HaveOccurred())
+			fundProvider := data.NewTestProvider([]data.Metric{data.WorkingCapital}, fundDF)
+
+			strategy := &fetchAtStrategy{
+				metrics: []data.Metric{data.MetricClose, data.WorkingCapital},
+				assets:  fundamentalAssets,
+			}
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(closeProvider, fundProvider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			)
+
+			simStart := time.Date(2024, 2, 28, 0, 0, 0, 0, time.UTC)
+			simEnd := time.Date(2024, 2, 28, 23, 0, 0, 0, time.UTC)
+			_, btErr := eng.Backtest(context.Background(), simStart, simEnd)
+			Expect(btErr).NotTo(HaveOccurred())
+			Expect(strategy.fetchErr).NotTo(HaveOccurred())
+			Expect(strategy.fetched).NotTo(BeNil())
+
+			wc := strategy.fetched.Column(spy, data.WorkingCapital)
+			Expect(wc).To(HaveLen(1))
+			Expect(wc[0]).To(BeNumerically("==", 120_000_000))
+		})
+
+		It("forward-fills fundamentals in Fetch with a lookback range", func() {
+			spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+			fundamentalAssets := []asset.Asset{spy}
+			assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+			closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			closeDF := makeDailyDF(closeStart, 90, fundamentalAssets, []data.Metric{data.MetricClose})
+			closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+			// Filing date is before the lookback window so all 30 days in range
+			// have the forward-filled value.
+			filingDate := time.Date(2024, 1, 15, 16, 0, 0, 0, time.UTC)
+			fundDF, err := data.NewDataFrame(
+				[]time.Time{filingDate},
+				fundamentalAssets,
+				[]data.Metric{data.Revenue},
+				data.Daily,
+				[][]float64{{500_000_000}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			fundProvider := data.NewTestProvider([]data.Metric{data.Revenue}, fundDF)
+
+			strategy := &fetchStrategy{
+				lookback: portfolio.Days(30),
+				metrics:  []data.Metric{data.MetricClose, data.Revenue},
+				assets:   fundamentalAssets,
+			}
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(closeProvider, fundProvider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			)
+
+			// Sim date Mar 1; lookback starts Jan 31 -- well after the Jan 15 filing.
+			simStart := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+			simEnd := time.Date(2024, 3, 1, 23, 0, 0, 0, time.UTC)
+			_, btErr := eng.Backtest(context.Background(), simStart, simEnd)
+			Expect(btErr).NotTo(HaveOccurred())
+			Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+			revCol := strategy.fetched.Column(spy, data.Revenue)
+			Expect(len(revCol)).To(BeNumerically(">", 1))
+
+			for _, val := range revCol {
+				Expect(val).To(BeNumerically("==", 500_000_000))
+			}
+		})
+
+		It("does not forward-fill price metrics", func() {
+			spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+			fundamentalAssets := []asset.Asset{spy}
+			assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+			day1 := time.Date(2024, 2, 1, 16, 0, 0, 0, time.UTC)
+			day2 := time.Date(2024, 2, 5, 16, 0, 0, 0, time.UTC)
+			priceDF, err := data.NewDataFrame(
+				[]time.Time{day1, day2},
+				fundamentalAssets,
+				[]data.Metric{data.MetricClose},
+				data.Daily,
+				[][]float64{{100.0, 105.0}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			priceProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, priceDF)
+
+			strategy := &fetchStrategy{
+				lookback: portfolio.Days(5),
+				metrics:  []data.Metric{data.MetricClose},
+				assets:   fundamentalAssets,
+			}
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(priceProvider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			)
+
+			simStart := time.Date(2024, 2, 5, 0, 0, 0, 0, time.UTC)
+			simEnd := time.Date(2024, 2, 5, 23, 0, 0, 0, time.UTC)
+			_, btErr := eng.Backtest(context.Background(), simStart, simEnd)
+			Expect(btErr).NotTo(HaveOccurred())
+			Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+			closeCol := strategy.fetched.Column(spy, data.MetricClose)
+			Expect(closeCol).To(HaveLen(2))
+		})
+	})
 })

--- a/engine/live.go
+++ b/engine/live.go
@@ -93,6 +93,19 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 		}
 	}
 
+	// 4d. Validate and wire fundamental dimension if set by Setup.
+	if e.fundamentalDimension != "" {
+		if !validDimensions[e.fundamentalDimension] {
+			return nil, fmt.Errorf("engine: invalid fundamental dimension %q; valid values: ARQ, ARY, ART, MRQ, MRY, MRT", e.fundamentalDimension)
+		}
+
+		for _, provider := range e.providers {
+			if pvProvider, ok := provider.(interface{ SetDimension(string) }); ok {
+				pvProvider.SetDimension(e.fundamentalDimension)
+			}
+		}
+	}
+
 	// 5. Validate.
 	if e.schedule == nil {
 		return nil, fmt.Errorf("engine: strategy %q did not set a schedule during Setup", e.strategy.Name())


### PR DESCRIPTION
## Summary

- Fundamental metrics are now forward-filled onto the daily time grid. Once a filing is public, its values are treated as current until the next filing supersedes them. `FetchAt` and `Fetch` return dense data for fundamental metrics instead of NaN on non-filing dates.
- Strategies can configure the fundamental data dimension (ARQ, MRQ, ARY, MRY, ART, MRT) via `SetFundamentalDimension` in `Setup`. Defaults to ARQ.
- The fundamentals SQL query now reads the `date_key` column (normalized quarter boundary) alongside `event_date` (filing date) for future cross-company alignment metadata.
- Snapshot schema gains `date_key` and `report_period` columns for forward compatibility.