### PR TITLE
feat(engine): add testonly struct tag for strategy parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strategies can use `universe.USTradable` as a daily-refreshed investable universe of liquid US stocks. Membership is sourced from pv-data and filters by market cap, dollar volume, price floor, and data completeness, mirroring the criteria of Quantopian's QTradableStocksUS. This is the recommended default universe for broad US equity strategies.
 - The `asset.Asset` type carries metadata from the data provider: name, asset type, exchange, sector, industry, SIC code, CIK, and listing dates. Strategies can filter by these fields directly (e.g. exclude financial-sector stocks or limit to common stock).
 - Strategies can configure the fundamental data dimension (ARQ, MRQ, ARY, MRY, ART, MRT) via `SetFundamentalDimension` in `Setup`. AR dimensions use SEC filing dates for point-in-time correctness; MR dimensions include restatements and are indexed to the fiscal period. Defaults to ARQ.
+- Strategy authors can mark a parameter field as test-only with `testonly:"true"`. Test-only parameters are hidden from `pvbt describe`, the TUI, CLI flags, presets, and study sweeps, and `engine.ApplyParams` rejects any attempt to set them. Tests assign test-only fields directly on the strategy struct.
 
 ### Fixed
 

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -242,6 +242,10 @@ func strategyParams(strategy engine.Strategy) map[string]any {
 			continue
 		}
 
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
 		name := field.Tag.Get("pvbt")
 		if name == "" {
 			name = strings.ToLower(field.Name)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -386,3 +386,15 @@ var _ = Describe("collectParamSweeps with testonly fields", func() {
 		}
 	})
 })
+
+var _ = Describe("strategyParams with testonly fields", func() {
+	It("does not include a test-only field in the backtest metadata map", func() {
+		strategy := &testOnlyFlagStrategy{}
+
+		params := strategyParams(strategy)
+
+		Expect(params).NotTo(HaveKey("seed"))
+		Expect(params).To(HaveKey("lookback"))
+		Expect(params).To(HaveKey("window"))
+	})
+})

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -326,3 +326,63 @@ var _ = Describe("applyPreset", func() {
 		Expect(err.Error()).To(ContainSubstring("unknown preset"))
 	})
 })
+
+type testOnlyFlagStrategy struct {
+	Lookback int `pvbt:"lookback" desc:"lookback" default:"30"`
+	Seed     int `pvbt:"seed" testonly:"true"`
+	Window   int `pvbt:"window" desc:"window" default:"5"`
+}
+
+func (s *testOnlyFlagStrategy) Name() string           { return "testOnlyFlag" }
+func (s *testOnlyFlagStrategy) Setup(e *engine.Engine) {}
+func (s *testOnlyFlagStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	return nil
+}
+
+var _ = Describe("registerStrategyFlags with testonly fields", func() {
+	It("does not register a cobra flag for a test-only field", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testOnlyFlagStrategy{}
+
+		registerStrategyFlags(cmd, strategy)
+
+		Expect(cmd.Flags().Lookup("lookback")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup("window")).NotTo(BeNil())
+		Expect(cmd.Flags().Lookup("seed")).To(BeNil())
+	})
+})
+
+var _ = Describe("applyStrategyFlags with testonly fields", func() {
+	It("leaves a test-only field untouched even if a flag is registered out of band", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testOnlyFlagStrategy{}
+
+		// Manually register a flag for "seed" to simulate a flag being
+		// registered out of band (e.g., by another command). The
+		// test-only check inside applyStrategyFlags must still skip the
+		// field, leaving it at its zero value.
+		cmd.Flags().Int("seed", 999, "")
+
+		applyStrategyFlags(cmd, strategy)
+		Expect(strategy.Seed).To(Equal(0))
+	})
+})
+
+var _ = Describe("collectParamSweeps with testonly fields", func() {
+	It("does not collect a sweep for a test-only field even if a flag is registered out of band", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testOnlyFlagStrategy{}
+
+		registerStrategyFlags(cmd, strategy)
+
+		// Manually register a "seed" flag with range syntax. Without the
+		// explicit IsTestOnlyField check inside collectParamSweeps, this
+		// would be picked up as a parameter sweep.
+		cmd.Flags().String("seed", "1:5:1", "")
+
+		sweeps := collectParamSweeps(cmd, strategy)
+		for _, sweep := range sweeps {
+			Expect(sweep.Field()).NotTo(Equal("seed"))
+		}
+	})
+})

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -40,6 +40,12 @@ func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			continue
 		}
 
+		// Skip fields marked test-only -- they must not be exposed as
+		// CLI flags.
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
 		name := engine.ParameterName(field)
 
 		desc := field.Tag.Get("desc")
@@ -127,6 +133,10 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 	for ii := 0; ii < strategyType.NumField(); ii++ {
 		field := strategyType.Field(ii)
 		if !field.IsExported() {
+			continue
+		}
+
+		if engine.IsTestOnlyField(field) {
 			continue
 		}
 
@@ -228,6 +238,10 @@ func collectParamSweeps(cmd *cobra.Command, strategy engine.Strategy) []study.Pa
 	for ii := 0; ii < strategyType.NumField(); ii++ {
 		field := strategyType.Field(ii)
 		if !field.IsExported() {
+			continue
+		}
+
+		if engine.IsTestOnlyField(field) {
 			continue
 		}
 

--- a/docs/superpowers/plans/2026-04-10-test-only-parameters.md
+++ b/docs/superpowers/plans/2026-04-10-test-only-parameters.md
@@ -1,0 +1,760 @@
+# Test-Only Strategy Parameters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `testonly` struct tag that lets a strategy author hide a parameter from every user-facing surface (CLI flags, `describe`, TUI, presets, study sweeps) and reject any external attempt to set it, while still letting tests assign the field directly.
+
+**Architecture:** A single boolean tag detected by one helper, `engine.IsTestOnlyField`, that returns true when the `testonly` tag is present and parses as `true`. Filtering happens at every place that walks a strategy struct's fields: `engine.StrategyParameters` (which feeds `DescribeStrategy` and preset lookup), the three field-walking functions in `cli/flags.go`, and `engine.ApplyParams`. The field stays exported so test code constructs strategies with literal field assignment.
+
+**Tech Stack:** Go 1.22+, Ginkgo/Gomega for tests, cobra for CLI flags, reflection-based struct tag parsing.
+
+**Spec:** [`docs/superpowers/specs/2026-04-10-test-only-parameters-design.md`](../specs/2026-04-10-test-only-parameters-design.md)
+
+---
+
+## File Overview
+
+- **Modified `engine/parameter.go`** -- adds `IsTestOnlyField` helper; `StrategyParameters` skips test-only fields.
+- **Modified `engine/parameter_test.go`** -- tests for `IsTestOnlyField` and the `StrategyParameters` filter.
+- **Modified `engine/apply_params.go`** -- `ApplyParams` rejects merged param names that correspond to test-only fields.
+- **Modified `engine/apply_params_test.go`** -- tests for the new error.
+- **Modified `engine/descriptor_test.go`** -- defense-in-depth test that `DescribeStrategy` omits test-only fields.
+- **Modified `cli/flags.go`** -- `registerStrategyFlags`, `applyStrategyFlags`, and `collectParamSweeps` skip test-only fields.
+- **Modified `cli/cli_test.go`** -- tests for the three flag-walker functions.
+- **Modified `CHANGELOG.md`** -- single bullet under `## [Unreleased]` `### Added`.
+
+---
+
+## Task 1: Add `IsTestOnlyField` helper
+
+**Files:**
+- Modify: `engine/parameter.go`
+- Modify: `engine/parameter_test.go`
+
+- [ ] **Step 1: Write failing tests for the helper**
+
+Append to `engine/parameter_test.go` (add `"strconv"` to the import block if missing):
+
+```go
+type testOnlyTagStrategy struct {
+    Visible    int  `pvbt:"visible" desc:"v" default:"1"`
+    HiddenTrue int  `pvbt:"hidden-true" testonly:"true"`
+    HiddenFalse int `pvbt:"hidden-false" testonly:"false"`
+}
+
+func (s *testOnlyTagStrategy) Name() string                                                                                                            { return "testOnlyTag" }
+func (s *testOnlyTagStrategy) Setup(_ *engine.Engine)                                                                                                  {}
+func (s *testOnlyTagStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+    return nil
+}
+
+var _ = Describe("IsTestOnlyField", func() {
+    fieldByName := func(name string) reflect.StructField {
+        t := reflect.TypeOf(testOnlyTagStrategy{})
+        field, ok := t.FieldByName(name)
+        Expect(ok).To(BeTrue())
+        return field
+    }
+
+    It("returns false when the testonly tag is absent", func() {
+        Expect(engine.IsTestOnlyField(fieldByName("Visible"))).To(BeFalse())
+    })
+
+    It("returns true when the testonly tag is \"true\"", func() {
+        Expect(engine.IsTestOnlyField(fieldByName("HiddenTrue"))).To(BeTrue())
+    })
+
+    It("returns false when the testonly tag is \"false\"", func() {
+        Expect(engine.IsTestOnlyField(fieldByName("HiddenFalse"))).To(BeFalse())
+    })
+
+    It("panics when the testonly tag has an unparseable value", func() {
+        type bad struct {
+            Field int `pvbt:"x" testonly:"banana"`
+        }
+        field, ok := reflect.TypeOf(bad{}).FieldByName("Field")
+        Expect(ok).To(BeTrue())
+        Expect(func() { engine.IsTestOnlyField(field) }).To(PanicWith(ContainSubstring("invalid testonly tag")))
+    })
+})
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run: `ginkgo run --focus "IsTestOnlyField" ./engine/...`
+Expected: compilation error -- `engine.IsTestOnlyField undefined`.
+
+- [ ] **Step 3: Implement `IsTestOnlyField`**
+
+Open `engine/parameter.go`. Add `"fmt"` and `"strconv"` to the import block (currently `"reflect"` and `"strings"`), then append this function below `ParameterName`:
+
+```go
+// IsTestOnlyField reports whether the given strategy struct field is marked as
+// test-only via a `testonly:"true"` struct tag. Test-only fields are hidden
+// from every user-facing surface (CLI flags, describe output, TUI, presets,
+// study sweeps) and cannot be set through ApplyParams. They remain exported
+// so that test code can assign them directly.
+//
+// The tag value must parse as a Go boolean. An unparseable value is a
+// programming error in the strategy source code, so this function panics
+// rather than silently treating it as false.
+func IsTestOnlyField(field reflect.StructField) bool {
+    raw, ok := field.Tag.Lookup("testonly")
+    if !ok {
+        return false
+    }
+
+    val, err := strconv.ParseBool(raw)
+    if err != nil {
+        panic(fmt.Sprintf("strategy field %s: invalid testonly tag %q: %v", field.Name, raw, err))
+    }
+
+    return val
+}
+```
+
+- [ ] **Step 4: Run the tests and verify they pass**
+
+Run: `ginkgo run --focus "IsTestOnlyField" ./engine/...`
+Expected: PASS for all four `It` blocks.
+
+- [ ] **Step 5: Run the linter**
+
+Run: `make lint`
+Expected: no new findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/parameter.go engine/parameter_test.go
+git commit -m "feat(engine): add IsTestOnlyField helper for testonly tag
+
+Detects the new testonly:\"true\" struct tag on strategy parameter
+fields. Panics on unparseable values since they are programming errors
+in strategy source, not user input."
+```
+
+---
+
+## Task 2: Skip test-only fields in `StrategyParameters`
+
+**Files:**
+- Modify: `engine/parameter.go:81-108`
+- Modify: `engine/parameter_test.go`
+
+- [ ] **Step 1: Write a failing test**
+
+Append to `engine/parameter_test.go`:
+
+```go
+var _ = Describe("StrategyParameters with testonly fields", func() {
+    It("omits fields tagged testonly:\"true\"", func() {
+        strategy := &testOnlyTagStrategy{}
+        params := engine.StrategyParameters(strategy)
+
+        // Visible and HiddenFalse remain; HiddenTrue is filtered.
+        Expect(params).To(HaveLen(2))
+        Expect(findParam(params, "visible")).NotTo(BeNil())
+        Expect(findParam(params, "hidden-false")).NotTo(BeNil())
+        Expect(findParam(params, "hidden-true")).To(BeNil())
+    })
+})
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `ginkgo run --focus "StrategyParameters with testonly" ./engine/...`
+Expected: FAIL -- `params` has length 3, includes `hidden-true`.
+
+- [ ] **Step 3: Implement the filter**
+
+Edit `engine/parameter.go` inside the `StrategyParameters` field loop. The current loop body starts at line 81 with `field := paramType.Field(ii)`. After the existing `if !field.IsExported() { continue }` check and the existing Strategy-typed-field skip, add a new skip for test-only fields. Replace:
+
+```go
+		// Skip Strategy-typed fields -- these are children, not parameters.
+		if field.Type.Implements(strategyType) ||
+			(field.Type.Kind() == reflect.Pointer && field.Type.Elem().Implements(strategyType)) {
+			continue
+		}
+
+		name := ParameterName(field)
+```
+
+with:
+
+```go
+		// Skip Strategy-typed fields -- these are children, not parameters.
+		if field.Type.Implements(strategyType) ||
+			(field.Type.Kind() == reflect.Pointer && field.Type.Elem().Implements(strategyType)) {
+			continue
+		}
+
+		// Skip fields marked test-only -- they must not appear on any
+		// user-facing surface.
+		if IsTestOnlyField(field) {
+			continue
+		}
+
+		name := ParameterName(field)
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `ginkgo run --focus "StrategyParameters with testonly" ./engine/...`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full engine suite to catch regressions**
+
+Run: `ginkgo run -race ./engine/...`
+Expected: PASS. The pre-existing `extracts exported fields with correct metadata` test in `parameter_test.go` still expects `HaveLen(9)` because `paramTestStrategy` has no `testonly` fields -- this should remain green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/parameter.go engine/parameter_test.go
+git commit -m "feat(engine): filter test-only fields from StrategyParameters
+
+Test-only fields are now omitted from parameter discovery, which
+cascades through DescribeStrategy and preset lookups so the describe
+command, TUI, and study reports never see them."
+```
+
+---
+
+## Task 3: Add a defense-in-depth test that `DescribeStrategy` omits test-only fields
+
+**Files:**
+- Modify: `engine/descriptor_test.go`
+
+This task adds no production code; the cascade through `StrategyParameters` already covers `DescribeStrategy`. The test exists so a future refactor that bypasses `StrategyParameters` would be caught.
+
+- [ ] **Step 1: Add a strategy type and a test**
+
+Append to `engine/descriptor_test.go`:
+
+```go
+// testOnlyDescriptorStrategy has a mix of regular and test-only fields and
+// implements Descriptor so it can be passed to DescribeStrategy.
+type testOnlyDescriptorStrategy struct {
+    Lookback int       `pvbt:"lookback" desc:"Lookback" default:"6"`
+    Now      time.Time `pvbt:"now" testonly:"true"`
+}
+
+func (s *testOnlyDescriptorStrategy) Name() string                                                                                                            { return "TestOnlyDescriptor" }
+func (s *testOnlyDescriptorStrategy) Setup(_ *engine.Engine)                                                                                                  {}
+func (s *testOnlyDescriptorStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+    return nil
+}
+func (s *testOnlyDescriptorStrategy) Describe() engine.StrategyDescription {
+    return engine.StrategyDescription{ShortCode: "tod"}
+}
+
+var _ = Describe("DescribeStrategy with testonly fields", func() {
+    It("omits test-only fields from StrategyInfo.Parameters", func() {
+        info := engine.DescribeStrategy(&testOnlyDescriptorStrategy{})
+
+        Expect(info.Parameters).To(HaveLen(1))
+        Expect(info.Parameters[0].Name).To(Equal("lookback"))
+    })
+})
+```
+
+Add `"time"` to the import block at the top of `engine/descriptor_test.go` if not already present.
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `ginkgo run --focus "DescribeStrategy with testonly" ./engine/...`
+Expected: PASS (no production change needed -- the filter from Task 2 already covers this path).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add engine/descriptor_test.go
+git commit -m "test(engine): verify DescribeStrategy hides test-only fields
+
+Defense-in-depth test so a future refactor that bypasses
+StrategyParameters would be caught."
+```
+
+---
+
+## Task 4: Skip test-only fields in `cli/flags.go` field walkers
+
+`cli/flags.go` iterates strategy struct fields directly in three functions: `registerStrategyFlags`, `applyStrategyFlags`, and `collectParamSweeps`. None of them go through `StrategyParameters`, so each needs its own `IsTestOnlyField` check. (`collectParamSweeps` is defended in practice by the missing-flag check, but the explicit skip keeps the three walkers symmetrical.)
+
+**Files:**
+- Modify: `cli/flags.go:37-41`, `cli/flags.go:127-131`, `cli/flags.go:228-232`
+- Modify: `cli/cli_test.go`
+
+- [ ] **Step 1: Write failing tests for the three walkers**
+
+Append to `cli/cli_test.go`:
+
+```go
+type testOnlyFlagStrategy struct {
+    Lookback int `pvbt:"lookback" desc:"lookback" default:"30"`
+    Seed     int `pvbt:"seed" testonly:"true"`
+    Window   int `pvbt:"window" desc:"window" default:"5"`
+}
+
+func (s *testOnlyFlagStrategy) Name() string           { return "testOnlyFlag" }
+func (s *testOnlyFlagStrategy) Setup(e *engine.Engine) {}
+func (s *testOnlyFlagStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+    return nil
+}
+
+var _ = Describe("registerStrategyFlags with testonly fields", func() {
+    It("does not register a cobra flag for a test-only field", func() {
+        cmd := &cobra.Command{Use: "test"}
+        strategy := &testOnlyFlagStrategy{}
+
+        registerStrategyFlags(cmd, strategy)
+
+        Expect(cmd.Flags().Lookup("lookback")).NotTo(BeNil())
+        Expect(cmd.Flags().Lookup("window")).NotTo(BeNil())
+        Expect(cmd.Flags().Lookup("seed")).To(BeNil())
+    })
+})
+
+var _ = Describe("applyStrategyFlags with testonly fields", func() {
+    It("leaves a test-only field untouched even if a flag is registered out of band", func() {
+        cmd := &cobra.Command{Use: "test"}
+        strategy := &testOnlyFlagStrategy{}
+
+        // Manually register a flag for "seed" to simulate a flag being
+        // registered out of band (e.g., by another command). The
+        // test-only check inside applyStrategyFlags must still skip the
+        // field, leaving it at its zero value.
+        cmd.Flags().Int("seed", 999, "")
+
+        applyStrategyFlags(cmd, strategy)
+        Expect(strategy.Seed).To(Equal(0))
+    })
+})
+
+var _ = Describe("collectParamSweeps with testonly fields", func() {
+    It("does not collect a sweep for a test-only field even if a flag is registered out of band", func() {
+        cmd := &cobra.Command{Use: "test"}
+        strategy := &testOnlyFlagStrategy{}
+
+        registerStrategyFlags(cmd, strategy)
+
+        // Manually register a "seed" flag with range syntax. Without the
+        // explicit IsTestOnlyField check inside collectParamSweeps, this
+        // would be picked up as a parameter sweep.
+        cmd.Flags().String("seed", "1:5:1", "")
+
+        sweeps := collectParamSweeps(cmd, strategy)
+        for _, sweep := range sweeps {
+            Expect(sweep.Field).NotTo(Equal("seed"))
+        }
+    })
+})
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run: `ginkgo run --focus "with testonly fields" ./cli/...`
+Expected:
+- `registerStrategyFlags with testonly fields` FAILS -- a cobra `Int` flag named `seed` is registered because nothing currently filters on `testonly`.
+- `applyStrategyFlags with testonly fields` FAILS -- the manually registered `seed` flag is found, parsed, and `strategy.Seed` becomes 999 instead of 0.
+- `collectParamSweeps with testonly fields` FAILS -- a `ParamSweep` with `Field == "seed"` is returned because the loop reaches the manually registered flag and parses `"1:5:1"` as a range.
+
+- [ ] **Step 3: Implement the skip in `registerStrategyFlags`**
+
+Edit `cli/flags.go`. Inside the `registerStrategyFlags` loop body, after the existing `if !field.IsExported() { continue }` check at line 39-41, add a new skip:
+
+Replace:
+
+```go
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+```
+
+(at the top of the `registerStrategyFlags` loop) with:
+
+```go
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		// Skip fields marked test-only -- they must not be exposed as
+		// CLI flags.
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+```
+
+- [ ] **Step 4: Implement the skip in `applyStrategyFlags`**
+
+Inside the `applyStrategyFlags` loop body (around line 127-131), make the same change. Replace:
+
+```go
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+```
+
+with:
+
+```go
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+```
+
+- [ ] **Step 5: Implement the skip in `collectParamSweeps`**
+
+Inside the `collectParamSweeps` loop body (around line 228-232), make the same change. Replace:
+
+```go
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+```
+
+with:
+
+```go
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+```
+
+- [ ] **Step 6: Run the focused tests and verify they pass**
+
+Run: `ginkgo run --focus "with testonly fields" ./cli/...`
+Expected: PASS for all three new `It` blocks.
+
+- [ ] **Step 7: Run the full cli suite**
+
+Run: `ginkgo run -race ./cli/...`
+Expected: PASS. Existing `registerStrategyFlags` tests over `testStrategy` and `universeStrategy` should be unaffected (neither uses `testonly`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cli/flags.go cli/cli_test.go
+git commit -m "feat(cli): skip test-only fields in flag registration
+
+registerStrategyFlags, applyStrategyFlags, and collectParamSweeps now
+skip any field marked testonly:\"true\". The three field walkers stay
+symmetrical even though collectParamSweeps was already defended by the
+missing-flag check."
+```
+
+---
+
+## Task 5: Reject test-only param names in `ApplyParams`
+
+`ApplyParams` builds a merged map of preset values plus explicit params, then calls `applyParamValue` for each. Test-only fields are filtered from `StrategyParameters`, so the preset path can never produce a test-only name -- but the explicit `params` argument is supplied verbatim by the caller and could still contain one. This task adds an explicit reject.
+
+**Files:**
+- Modify: `engine/apply_params.go`
+- Modify: `engine/apply_params_test.go`
+
+- [ ] **Step 1: Write a failing test**
+
+Append to `engine/apply_params_test.go`:
+
+```go
+// applyParamsTestOnlyStrategy has one regular field and one test-only field.
+// It implements Descriptor so the preset path is also exercisable.
+type applyParamsTestOnlyStrategy struct {
+    Window int `pvbt:"window" desc:"Rolling window" default:"12"`
+    Seed   int `pvbt:"seed" testonly:"true"`
+}
+
+func (ap *applyParamsTestOnlyStrategy) Name() string           { return "ApplyParamsTestOnly" }
+func (ap *applyParamsTestOnlyStrategy) Setup(_ *engine.Engine) {}
+func (ap *applyParamsTestOnlyStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+    return nil
+}
+func (ap *applyParamsTestOnlyStrategy) Describe() engine.StrategyDescription {
+    return engine.StrategyDescription{ShortCode: "apto"}
+}
+
+var _ = Describe("ApplyParams with testonly fields", func() {
+    It("returns an error when explicit params target a test-only field", func() {
+        strategy := &applyParamsTestOnlyStrategy{}
+        eng := engine.New(strategy)
+
+        err := engine.ApplyParams(eng, "", map[string]string{"seed": "42"})
+        Expect(err).To(HaveOccurred())
+        Expect(err.Error()).To(ContainSubstring("seed"))
+        Expect(err.Error()).To(ContainSubstring("test-only"))
+        Expect(strategy.Seed).To(Equal(0))
+    })
+
+    It("still applies non-test-only params alongside the rejected one", func() {
+        strategy := &applyParamsTestOnlyStrategy{}
+        eng := engine.New(strategy)
+
+        err := engine.ApplyParams(eng, "", map[string]string{
+            "window": "24",
+            "seed":   "42",
+        })
+        Expect(err).To(HaveOccurred())
+        // The whole call fails -- no params should be partially applied.
+        Expect(strategy.Window).To(Equal(0))
+        Expect(strategy.Seed).To(Equal(0))
+    })
+
+    It("allows direct struct assignment of a test-only field", func() {
+        strategy := &applyParamsTestOnlyStrategy{Seed: 99}
+        eng := engine.New(strategy)
+
+        err := engine.ApplyParams(eng, "", map[string]string{"window": "24"})
+        Expect(err).NotTo(HaveOccurred())
+        Expect(strategy.Window).To(Equal(24))
+        Expect(strategy.Seed).To(Equal(99))
+    })
+})
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run: `ginkgo run --focus "ApplyParams with testonly" ./engine/...`
+Expected: FAIL -- the first two tests pass without error and `Seed` becomes 42.
+
+- [ ] **Step 3: Add the test-only set helper**
+
+Edit `engine/apply_params.go`. Add `"reflect"` to the imports if it is not already present, then add this unexported helper at the bottom of the file:
+
+```go
+// testOnlyParamNames returns the set of parameter names (as kebab-case)
+// belonging to fields marked testonly:"true" on the given strategy.
+func testOnlyParamNames(strategy Strategy) map[string]struct{} {
+    names := make(map[string]struct{})
+
+    val := reflect.ValueOf(strategy)
+    if val.Kind() == reflect.Ptr {
+        val = val.Elem()
+    }
+
+    if val.Kind() != reflect.Struct {
+        return names
+    }
+
+    targetType := val.Type()
+    for ii := 0; ii < targetType.NumField(); ii++ {
+        field := targetType.Field(ii)
+        if !field.IsExported() {
+            continue
+        }
+
+        if !IsTestOnlyField(field) {
+            continue
+        }
+
+        names[ParameterName(field)] = struct{}{}
+    }
+
+    return names
+}
+```
+
+- [ ] **Step 4: Reject test-only names in `ApplyParams`**
+
+Edit `engine/apply_params.go` inside `ApplyParams`. After the merged map has been built and before the `for paramName, paramValue := range merged { ... applyParamValue(...) }` loop, add the reject. Replace:
+
+```go
+	// Explicit params override preset values.
+	for paramName, paramValue := range params {
+		merged[paramName] = paramValue
+	}
+
+	// Apply all merged parameters via applyParamValue.
+	for paramName, paramValue := range merged {
+		if err := applyParamValue(eng.strategy, paramName, paramValue); err != nil {
+			return fmt.Errorf("ApplyParams: applying param %q=%q: %w", paramName, paramValue, err)
+		}
+	}
+```
+
+with:
+
+```go
+	// Explicit params override preset values.
+	for paramName, paramValue := range params {
+		merged[paramName] = paramValue
+	}
+
+	// Reject any merged param that targets a test-only field. Test-only
+	// parameters are deliberately invisible to user surfaces and must not
+	// be settable via ApplyParams; tests should construct strategies with
+	// direct field assignment instead.
+	testOnly := testOnlyParamNames(eng.strategy)
+	for paramName := range merged {
+		if _, isTestOnly := testOnly[paramName]; isTestOnly {
+			return fmt.Errorf("ApplyParams: parameter %q is test-only and cannot be set via ApplyParams; assign the field directly on the strategy struct", paramName)
+		}
+	}
+
+	// Apply all merged parameters via applyParamValue.
+	for paramName, paramValue := range merged {
+		if err := applyParamValue(eng.strategy, paramName, paramValue); err != nil {
+			return fmt.Errorf("ApplyParams: applying param %q=%q: %w", paramName, paramValue, err)
+		}
+	}
+```
+
+The reject loop runs *before* the apply loop so that a single test-only name aborts the call without partially applying the other params -- this is what the second test in Step 1 verifies.
+
+- [ ] **Step 5: Run the focused tests and verify they pass**
+
+Run: `ginkgo run --focus "ApplyParams with testonly" ./engine/...`
+Expected: PASS for all three `It` blocks.
+
+- [ ] **Step 6: Run the full engine suite**
+
+Run: `ginkgo run -race ./engine/...`
+Expected: PASS. Existing `ApplyParams` tests in the file should be unaffected since they use strategies without `testonly` fields.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add engine/apply_params.go engine/apply_params_test.go
+git commit -m "feat(engine): reject test-only parameter names in ApplyParams
+
+ApplyParams now returns an error if the merged params map (preset
+values plus explicit overrides) targets a field marked testonly:\"true\".
+The reject runs before any field is set, so a single test-only name
+aborts the whole call without partially applying other params. Tests
+must assign test-only fields directly on the strategy struct."
+```
+
+---
+
+## Task 6: Sanity check -- test-only field readable inside `Compute`
+
+This task verifies that a test-only field set via direct struct assignment remains a normal Go field that `Compute` can read. The point is to prove the marker only changes user-surface visibility and does not interfere with normal field reads. Calling `Compute` directly is sufficient -- a full backtest setup adds nothing.
+
+**Files:**
+- Modify: `engine/parameter_test.go`
+
+- [ ] **Step 1: Add a sanity test that observes the test-only field inside Compute**
+
+Append to `engine/parameter_test.go`:
+
+```go
+// sanityTestOnlyStrategy records the value of a test-only field the first
+// time Compute is called. This proves direct struct assignment of a
+// testonly field is visible to Compute even though the field is hidden
+// from every user surface.
+type sanityTestOnlyStrategy struct {
+    Window   int `pvbt:"window" desc:"window" default:"5"`
+    Injected int `pvbt:"injected" testonly:"true"`
+
+    observed int
+    seen     bool
+}
+
+func (s *sanityTestOnlyStrategy) Name() string           { return "sanityTestOnly" }
+func (s *sanityTestOnlyStrategy) Setup(_ *engine.Engine) {}
+func (s *sanityTestOnlyStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+    if !s.seen {
+        s.observed = s.Injected
+        s.seen = true
+    }
+    return nil
+}
+
+var _ = Describe("test-only field accessibility", func() {
+    It("is observable inside Compute when set via direct struct assignment", func() {
+        strategy := &sanityTestOnlyStrategy{Injected: 42}
+        Expect(strategy.Injected).To(Equal(42))
+
+        // Calling Compute directly is sufficient to prove the field is
+        // readable. The point of this test is the marker does not block
+        // normal Go field reads -- it only filters discovery surfaces.
+        err := strategy.Compute(context.Background(), nil, nil, nil)
+        Expect(err).NotTo(HaveOccurred())
+        Expect(strategy.seen).To(BeTrue())
+        Expect(strategy.observed).To(Equal(42))
+
+        // And the parameter is correctly hidden from discovery.
+        params := engine.StrategyParameters(strategy)
+        Expect(findParam(params, "injected")).To(BeNil())
+        Expect(findParam(params, "window")).NotTo(BeNil())
+    })
+})
+```
+
+- [ ] **Step 2: Run the test and verify it passes**
+
+Run: `ginkgo run --focus "test-only field accessibility" ./engine/...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add engine/parameter_test.go
+git commit -m "test(engine): sanity-check direct assignment of testonly fields
+
+Confirms a testonly field set via direct struct literal assignment is
+observable inside Compute, proving the marker only filters discovery
+surfaces and does not block normal Go field reads."
+```
+
+---
+
+## Task 7: Update the changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add a single bullet under `## [Unreleased]` `### Added`**
+
+Edit `CHANGELOG.md`. The current `### Added` block under `## [Unreleased]` already has several bullets. Append one more bullet at the end of that list:
+
+```markdown
+- Strategy authors can mark a parameter field as test-only with `testonly:"true"`. Test-only parameters are hidden from `pvbt describe`, the TUI, CLI flags, presets, and study sweeps, and `engine.ApplyParams` rejects any attempt to set them. Tests assign test-only fields directly on the strategy struct.
+```
+
+- [ ] **Step 2: Run the linter and the full test suite once more**
+
+Run: `make lint && make test`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for test-only strategy parameters"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `make lint` -- expect no findings.
+- [ ] Run `make test` -- expect all packages green.
+- [ ] Run `git log --oneline main..HEAD` -- expect 7 commits (one per task).

--- a/docs/superpowers/specs/2026-04-10-test-only-parameters-design.md
+++ b/docs/superpowers/specs/2026-04-10-test-only-parameters-design.md
@@ -1,0 +1,93 @@
+# Test-Only Strategy Parameters
+
+## Goal
+
+Allow a strategy author to mark a parameter as test-only so that it is invisible to every user-facing surface (CLI flags, `describe` output, TUI, presets, study sweeps) and cannot be set from any external input. The field remains an exported Go field so test code can set it by direct struct assignment.
+
+## Motivation
+
+Strategies sometimes need parameters that exist purely to make the strategy testable (for example: a fixed clock, an injection point that forces a specific code path, a stub data hook). Today every exported field on a strategy struct automatically becomes a user parameter -- it appears in `describe` output, gets a cobra flag, and shows up in the TUI parameter list. Strategy authors who want testability either pollute their public surface or resort to package-private state with bespoke test hooks. A `testonly` tag fixes this by letting a single declaration mark a field as hidden from users while still letting tests set it.
+
+## Tag
+
+A new struct tag, `testonly`, is added to the recognized strategy tag set. The value must parse as a Go boolean. Presence with `"true"` marks the field as test-only; presence with `"false"` is equivalent to omitting the tag. Any other value is a programming error and panics the first time the strategy is reflected over.
+
+```go
+type MyStrategy struct {
+    Lookback float64   `pvbt:"lookback" desc:"Lookback in months" default:"6.0"`
+    Now      time.Time `pvbt:"now" testonly:"true"`
+}
+```
+
+The `testonly:"true"` form matches the existing pvbt tag style (`pvbt:"name"`, `desc:"text"`, `default:"value"`, `suggest:"..."`), and leaves the `"false"` form available so a derived strategy could in principle un-mark an inherited field.
+
+## Detection helper
+
+A single helper in `engine/parameter.go` is the source of truth:
+
+```go
+func IsTestOnlyField(field reflect.StructField) bool {
+    raw, ok := field.Tag.Lookup("testonly")
+    if !ok {
+        return false
+    }
+    val, err := strconv.ParseBool(raw)
+    if err != nil {
+        panic(fmt.Sprintf("strategy field %s: invalid testonly tag %q: %v",
+            field.Name, raw, err))
+    }
+    return val
+}
+```
+
+A panic is appropriate because an invalid `testonly` value is a bug in strategy source code, caught the first time the strategy struct is reflected over (during `Setup` or describe). It is not user input, so there is no benign "soft" recovery path.
+
+## Filter points
+
+A test-only parameter must be filtered everywhere that walks strategy fields. There are four such places:
+
+1. **`engine/parameter.go` `StrategyParameters()`** -- skip fields where `IsTestOnlyField` is true. This single change cascades to:
+   - `engine/descriptor.go` `DescribeStrategy()`, which feeds the `describe` command, study reports, and the TUI parameter list (all consume `StrategyInfo`).
+   - `cli/preset.go` preset lookup, so no `suggest` value can target a test-only field.
+2. **`cli/flags.go` `registerStrategyFlags()`** -- skip test-only fields, so no cobra flag is created for them. (`flags.go` iterates struct fields directly rather than going through `StrategyParameters`, so it needs its own check via `IsTestOnlyField`.)
+3. **`cli/flags.go` `applyStrategyFlags()`** -- skip test-only fields. Defensive: no flag should exist, but the field iteration here mirrors `registerStrategyFlags` and must stay consistent.
+4. **`engine/apply_params.go` `ApplyParams()`** -- if the merged params map (preset values plus explicit params) contains the name of any test-only parameter, return an explicit error rather than silently setting it. This blocks `--params foo=bar` from the CLI and `Params:` entries in study sweep configs.
+
+`applyParamValue` itself is unchanged. It is a low-level field setter; gating happens at the boundaries that decide whether a value should reach it.
+
+## Tests use direct assignment
+
+Test-only parameters remain exported Go fields. Tests construct the strategy and set them directly:
+
+```go
+strategy := &MyStrategy{Now: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)}
+```
+
+No new test API is introduced. The `testonly` tag exists to hide the field from users, not to add a new way of setting it.
+
+## Tests for the feature
+
+The following tests must be added in their respective packages:
+
+- `engine/parameter_test.go`: a strategy with a `testonly:"true"` field is omitted from `StrategyParameters` output.
+- `engine/parameter_test.go`: `IsTestOnlyField` returns true for `"true"`, false for `"false"`, false when the tag is absent, and panics for an unparseable value.
+- `engine/descriptor_test.go`: `DescribeStrategy` omits test-only fields from `StrategyInfo.Parameters`.
+- `engine/apply_params_test.go`: `ApplyParams` returns an error whose message names the offending parameter when the explicit `params` argument contains a test-only parameter name. (The preset path is structurally safe -- presets are built from `suggest:` tags on fields that have themselves been filtered out of `StrategyParameters` -- so no preset test is needed.)
+- `cli/cli_test.go`: `registerStrategyFlags` does not register a cobra flag for a test-only field, and `applyStrategyFlags` is a no-op for it.
+- `engine/parameter_test.go` (or a new integration-style test in the engine suite): a strategy with a test-only field set via direct struct assignment runs through a full backtest and the assigned value is observed by `Compute`.
+
+## Out of scope
+
+- A runtime "unhide test params" mode that exposes them as flags under a debug build. If such a thing is ever wanted, it can be added later as a separate feature.
+- Loading test-only params from `pvbt.toml`, environment variables, or any other external source.
+- Refactoring `cli/flags.go` to consume `StrategyParameters()` instead of duplicating struct field iteration. That cleanup is worthwhile but unrelated to this feature.
+- Validation that test-only params have safe defaults; the existing `default` tag handling applies unchanged.
+
+## Public-API impact
+
+Per `CLAUDE.md`, the following changes are user-visible and must appear in the changelog:
+
+- The `testonly` struct tag is added to the recognized strategy tag set.
+- `engine.IsTestOnlyField` is added as a public helper.
+- `engine.ApplyParams` returns a new error class when asked to set a parameter that has been declared test-only.
+- The `describe` command, the TUI parameter list, and study sweep configurations no longer list or accept test-only parameters.

--- a/engine/apply_params.go
+++ b/engine/apply_params.go
@@ -17,6 +17,7 @@ package engine
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 )
@@ -62,6 +63,17 @@ func ApplyParams(eng *Engine, preset string, params map[string]string) error {
 		merged[paramName] = paramValue
 	}
 
+	// Reject any merged param that targets a test-only field. Test-only
+	// parameters are deliberately invisible to user surfaces and must not
+	// be settable via ApplyParams; tests should construct strategies with
+	// direct field assignment instead.
+	testOnly := testOnlyParamNames(eng.strategy)
+	for paramName := range merged {
+		if _, isTestOnly := testOnly[paramName]; isTestOnly {
+			return fmt.Errorf("ApplyParams: parameter %q is test-only and cannot be set via ApplyParams; assign the field directly on the strategy struct", paramName)
+		}
+	}
+
 	// Apply all merged parameters via applyParamValue.
 	for paramName, paramValue := range merged {
 		if err := applyParamValue(eng.strategy, paramName, paramValue); err != nil {
@@ -75,4 +87,35 @@ func ApplyParams(eng *Engine, preset string, params map[string]string) error {
 	}
 
 	return nil
+}
+
+// testOnlyParamNames returns the set of parameter names (as kebab-case)
+// belonging to fields marked testonly:"true" on the given strategy.
+func testOnlyParamNames(strategy Strategy) map[string]struct{} {
+	names := make(map[string]struct{})
+
+	val := reflect.ValueOf(strategy)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+
+	if val.Kind() != reflect.Struct {
+		return names
+	}
+
+	targetType := val.Type()
+	for ii := 0; ii < targetType.NumField(); ii++ {
+		field := targetType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		if !IsTestOnlyField(field) {
+			continue
+		}
+
+		names[ParameterName(field)] = struct{}{}
+	}
+
+	return names
 }

--- a/engine/apply_params_test.go
+++ b/engine/apply_params_test.go
@@ -148,3 +148,56 @@ var _ = Describe("ApplyParams", func() {
 		})
 	})
 })
+
+// applyParamsTestOnlyStrategy has one regular field and one test-only field.
+// It implements Descriptor so the preset path is also exercisable.
+type applyParamsTestOnlyStrategy struct {
+	Window int `pvbt:"window" desc:"Rolling window" default:"12"`
+	Seed   int `pvbt:"seed" testonly:"true"`
+}
+
+func (ap *applyParamsTestOnlyStrategy) Name() string           { return "ApplyParamsTestOnly" }
+func (ap *applyParamsTestOnlyStrategy) Setup(_ *engine.Engine) {}
+func (ap *applyParamsTestOnlyStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	return nil
+}
+func (ap *applyParamsTestOnlyStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "apto"}
+}
+
+var _ = Describe("ApplyParams with testonly fields", func() {
+	It("returns an error when explicit params target a test-only field", func() {
+		strategy := &applyParamsTestOnlyStrategy{}
+		eng := engine.New(strategy)
+
+		err := engine.ApplyParams(eng, "", map[string]string{"seed": "42"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("seed"))
+		Expect(err.Error()).To(ContainSubstring("test-only"))
+		Expect(strategy.Seed).To(Equal(0))
+	})
+
+	It("still applies non-test-only params alongside the rejected one", func() {
+		strategy := &applyParamsTestOnlyStrategy{}
+		eng := engine.New(strategy)
+
+		err := engine.ApplyParams(eng, "", map[string]string{
+			"window": "24",
+			"seed":   "42",
+		})
+		Expect(err).To(HaveOccurred())
+		// The whole call fails -- no params should be partially applied.
+		Expect(strategy.Window).To(Equal(0))
+		Expect(strategy.Seed).To(Equal(0))
+	})
+
+	It("allows direct struct assignment of a test-only field", func() {
+		strategy := &applyParamsTestOnlyStrategy{Seed: 99}
+		eng := engine.New(strategy)
+
+		err := engine.ApplyParams(eng, "", map[string]string{"window": "24"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.Window).To(Equal(24))
+		Expect(strategy.Seed).To(Equal(99))
+	})
+})

--- a/engine/descriptor_test.go
+++ b/engine/descriptor_test.go
@@ -17,6 +17,8 @@ package engine_test
 
 import (
 	"context"
+	"time"
+
 	"github.com/bytedance/sonic"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -188,5 +190,30 @@ var _ = Describe("DescribeStrategy", func() {
 			Expect(jsonStr).NotTo(ContainSubstring(`"source"`))
 			Expect(jsonStr).NotTo(ContainSubstring(`"version"`))
 		})
+	})
+})
+
+// testOnlyDescriptorStrategy has a mix of regular and test-only fields and
+// implements Descriptor so it can be passed to DescribeStrategy.
+type testOnlyDescriptorStrategy struct {
+	Lookback int       `pvbt:"lookback" desc:"Lookback" default:"6"`
+	Now      time.Time `pvbt:"now" testonly:"true"`
+}
+
+func (s *testOnlyDescriptorStrategy) Name() string           { return "TestOnlyDescriptor" }
+func (s *testOnlyDescriptorStrategy) Setup(_ *engine.Engine) {}
+func (s *testOnlyDescriptorStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	return nil
+}
+func (s *testOnlyDescriptorStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "tod"}
+}
+
+var _ = Describe("DescribeStrategy with testonly fields", func() {
+	It("omits test-only fields from StrategyInfo.Parameters", func() {
+		info := engine.DescribeStrategy(&testOnlyDescriptorStrategy{})
+
+		Expect(info.Parameters).To(HaveLen(1))
+		Expect(info.Parameters[0].Name).To(Equal("lookback"))
 	})
 })

--- a/engine/parameter.go
+++ b/engine/parameter.go
@@ -16,7 +16,9 @@
 package engine
 
 import (
+	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -43,6 +45,29 @@ func ParameterName(field reflect.StructField) string {
 	}
 
 	return toKebabCase(field.Name)
+}
+
+// IsTestOnlyField reports whether the given strategy struct field is marked as
+// test-only via a `testonly:"true"` struct tag. Test-only fields are hidden
+// from every user-facing surface (CLI flags, describe output, TUI, presets,
+// study sweeps) and cannot be set through ApplyParams. They remain exported
+// so that test code can assign them directly.
+//
+// The tag value must parse as a Go boolean. An unparseable value is a
+// programming error in the strategy source code, so this function panics
+// rather than silently treating it as false.
+func IsTestOnlyField(field reflect.StructField) bool {
+	raw, ok := field.Tag.Lookup("testonly")
+	if !ok {
+		return false
+	}
+
+	val, err := strconv.ParseBool(raw)
+	if err != nil {
+		panic(fmt.Sprintf("strategy field %s: invalid testonly tag %q: %v", field.Name, raw, err))
+	}
+
+	return val
 }
 
 // toKebabCase converts a PascalCase or camelCase identifier to kebab-case.

--- a/engine/parameter.go
+++ b/engine/parameter.go
@@ -115,6 +115,12 @@ func StrategyParameters(s Strategy) []Parameter {
 			continue
 		}
 
+		// Skip fields marked test-only -- they must not appear on any
+		// user-facing surface.
+		if IsTestOnlyField(field) {
+			continue
+		}
+
 		name := ParameterName(field)
 
 		var suggestions map[string]string

--- a/engine/parameter_test.go
+++ b/engine/parameter_test.go
@@ -187,3 +187,45 @@ var _ = Describe("StrategyParameters with testonly fields", func() {
 		Expect(findParam(params, "hidden-true")).To(BeNil())
 	})
 })
+
+// sanityTestOnlyStrategy records the value of a test-only field the first
+// time Compute is called. This proves direct struct assignment of a
+// testonly field is visible to Compute even though the field is hidden
+// from every user surface.
+type sanityTestOnlyStrategy struct {
+	Window   int `pvbt:"window" desc:"window" default:"5"`
+	Injected int `pvbt:"injected" testonly:"true"`
+
+	observed int
+	seen     bool
+}
+
+func (s *sanityTestOnlyStrategy) Name() string           { return "sanityTestOnly" }
+func (s *sanityTestOnlyStrategy) Setup(_ *engine.Engine) {}
+func (s *sanityTestOnlyStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	if !s.seen {
+		s.observed = s.Injected
+		s.seen = true
+	}
+	return nil
+}
+
+var _ = Describe("test-only field accessibility", func() {
+	It("is observable inside Compute when set via direct struct assignment", func() {
+		strategy := &sanityTestOnlyStrategy{Injected: 42}
+		Expect(strategy.Injected).To(Equal(42))
+
+		// Calling Compute directly is sufficient to prove the field is
+		// readable. The point of this test is the marker does not block
+		// normal Go field reads -- it only filters discovery surfaces.
+		err := strategy.Compute(context.Background(), nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.seen).To(BeTrue())
+		Expect(strategy.observed).To(Equal(42))
+
+		// And the parameter is correctly hidden from discovery.
+		params := engine.StrategyParameters(strategy)
+		Expect(findParam(params, "injected")).To(BeNil())
+		Expect(findParam(params, "window")).NotTo(BeNil())
+	})
+})

--- a/engine/parameter_test.go
+++ b/engine/parameter_test.go
@@ -174,3 +174,16 @@ var _ = Describe("IsTestOnlyField", func() {
 		Expect(func() { engine.IsTestOnlyField(field) }).To(PanicWith(ContainSubstring("invalid testonly tag")))
 	})
 })
+
+var _ = Describe("StrategyParameters with testonly fields", func() {
+	It("omits fields tagged testonly:\"true\"", func() {
+		strategy := &testOnlyTagStrategy{}
+		params := engine.StrategyParameters(strategy)
+
+		// Visible and HiddenFalse remain; HiddenTrue is filtered.
+		Expect(params).To(HaveLen(2))
+		Expect(findParam(params, "visible")).NotTo(BeNil())
+		Expect(findParam(params, "hidden-false")).NotTo(BeNil())
+		Expect(findParam(params, "hidden-true")).To(BeNil())
+	})
+})

--- a/engine/parameter_test.go
+++ b/engine/parameter_test.go
@@ -132,3 +132,45 @@ var _ = Describe("ParameterName", func() {
 		Expect(lookback.Suggestions).To(BeNil())
 	})
 })
+
+type testOnlyTagStrategy struct {
+	Visible     int `pvbt:"visible" desc:"v" default:"1"`
+	HiddenTrue  int `pvbt:"hidden-true" testonly:"true"`
+	HiddenFalse int `pvbt:"hidden-false" testonly:"false"`
+}
+
+func (s *testOnlyTagStrategy) Name() string           { return "testOnlyTag" }
+func (s *testOnlyTagStrategy) Setup(_ *engine.Engine) {}
+func (s *testOnlyTagStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	return nil
+}
+
+var _ = Describe("IsTestOnlyField", func() {
+	fieldByName := func(name string) reflect.StructField {
+		t := reflect.TypeOf(testOnlyTagStrategy{})
+		field, ok := t.FieldByName(name)
+		Expect(ok).To(BeTrue())
+		return field
+	}
+
+	It("returns false when the testonly tag is absent", func() {
+		Expect(engine.IsTestOnlyField(fieldByName("Visible"))).To(BeFalse())
+	})
+
+	It("returns true when the testonly tag is \"true\"", func() {
+		Expect(engine.IsTestOnlyField(fieldByName("HiddenTrue"))).To(BeTrue())
+	})
+
+	It("returns false when the testonly tag is \"false\"", func() {
+		Expect(engine.IsTestOnlyField(fieldByName("HiddenFalse"))).To(BeFalse())
+	})
+
+	It("panics when the testonly tag has an unparseable value", func() {
+		type bad struct {
+			Field int `pvbt:"x" testonly:"banana"`
+		}
+		field, ok := reflect.TypeOf(bad{}).FieldByName("Field")
+		Expect(ok).To(BeTrue())
+		Expect(func() { engine.IsTestOnlyField(field) }).To(PanicWith(ContainSubstring("invalid testonly tag")))
+	})
+})


### PR DESCRIPTION
## Summary

- Adds a `testonly:"true"` struct tag. Tagged strategy parameter fields stay as normal Go fields that tests can assign directly, but are hidden from `pvbt describe`, CLI flags, the TUI, presets, study sweeps, and persisted backtest metadata.
- `engine.ApplyParams` rejects any merged param name that targets a test-only field, so `--params foo=bar` and study sweep configs cannot set them from outside tests.
- Strategy authors use this for fields that exist purely to make a strategy testable (injected clocks, forced code paths) without polluting the public parameter surface.

Design and plan: `docs/superpowers/specs/2026-04-10-test-only-parameters-design.md`, `docs/superpowers/plans/2026-04-10-test-only-parameters.md`.