### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-15
+
+### Fixed
+
+- Long backtests no longer crash near the end with an index-out-of-range panic when risk-free rate data is unavailable for recent dates.
+
 ## [0.7.0] - 2026-04-14
 
 ### Changed
@@ -198,7 +204,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotate portfolio decisions with justifications for audit trails.
 - Save and reload complete backtest results between sessions.
 
-[unreleased]: https://github.com/penny-vault/pvbt/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/penny-vault/pvbt/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/penny-vault/pvbt/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/penny-vault/pvbt/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/penny-vault/pvbt/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/penny-vault/pvbt/compare/v0.4.0...v0.5.0

--- a/data/data_frame.go
+++ b/data/data_frame.go
@@ -349,6 +349,9 @@ func (df *DataFrame) Value(a asset.Asset, metric Metric) float64 {
 	}
 
 	col := df.colSlice(aIdx, mIdx)
+	if len(col) == 0 {
+		return math.NaN()
+	}
 
 	return col[len(col)-1]
 }

--- a/data/data_frame_test.go
+++ b/data/data_frame_test.go
@@ -128,6 +128,12 @@ var _ = Describe("DataFrame", func() {
 			Expect(math.IsNaN(df.Value(aapl, data.Metric("Nonexistent")))).To(BeTrue())
 		})
 
+		It("Value returns NaN when asset/metric are registered but no timestamps exist", func() {
+			empty, err := data.NewDataFrame(nil, []asset.Asset{aapl}, []data.Metric{data.Price}, data.Daily, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(math.IsNaN(empty.Value(aapl, data.Price))).To(BeTrue())
+		})
+
 		It("ValueAt returns value at specific timestamp", func() {
 			Expect(df.ValueAt(aapl, data.Price, times[2])).To(Equal(102.0))
 			Expect(df.ValueAt(goog, data.Volume, times[0])).To(Equal(2000.0))


### PR DESCRIPTION
## Summary

- Fix an index-out-of-range panic in `DataFrame.Value` when the frame has an asset and metric registered but zero timestamps, which crashed long backtests near the end of the simulation when risk-free rate data was unavailable for recent dates.
- Bump the changelog to v0.7.1.