### PR TITLE
Release v0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-04-18
+
 ### Added
 
-- Strategies can request a specific fundamentals reporting period with `Engine.FetchFundamentalsByDateKey`. The call returns one row per asset for the given `date_key` (e.g. Q1 boundary), filtered to the engine's configured dimension and to filings public as of `CurrentDate()`.
-- Two new fundamental metrics expose per-row date metadata: `data.FundamentalsDateKey` (normalized quarter boundary) and `data.FundamentalsReportPeriod` (actual fiscal period end). Values are encoded as Unix seconds in `float64`; convert with `time.Unix(int64(v), 0)`.
-- Snapshots now persist `date_key`, `report_period`, and the configured dimension instead of writing NULL/`"ARQ"` placeholders.
+- Strategies can query a specific fundamentals reporting period with `Engine.FetchFundamentalsByDateKey`, and can read the period behind any fundamental value via the new `FundamentalsDateKey` and `FundamentalsReportPeriod` metrics. Values are encoded as Unix seconds; round-trip with `time.Unix(int64(v), 0)`.
+- Snapshots capture the reporting-period metadata and configured dimension instead of NULL/`"ARQ"` placeholders, so replays match live queries.
 
 ## [0.7.1] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Strategies can request a specific fundamentals reporting period with `Engine.FetchFundamentalsByDateKey`. The call returns one row per asset for the given `date_key` (e.g. Q1 boundary), filtered to the engine's configured dimension and to filings public as of `CurrentDate()`.
+- Two new fundamental metrics expose per-row date metadata: `data.FundamentalsDateKey` (normalized quarter boundary) and `data.FundamentalsReportPeriod` (actual fiscal period end). Values are encoded as Unix seconds in `float64`; convert with `time.Unix(int64(v), 0)`.
+- Snapshots now persist `date_key`, `report_period`, and the configured dimension instead of writing NULL/`"ARQ"` placeholders.
+
 ## [0.7.1] - 2026-04-15
 
 ### Fixed

--- a/data/data_provider.go
+++ b/data/data_provider.go
@@ -83,7 +83,7 @@ type HolidayProvider interface {
 
 // FundamentalsByDateKeyProvider is implemented by providers that can
 // return fundamentals filtered to a specific reporting period (date_key).
-// The engine type-asserts on this interface from FetchByDateKey.
+// The engine type-asserts on this interface from FetchFundamentalsByDateKey.
 type FundamentalsByDateKeyProvider interface {
 	// FetchFundamentalsByDateKey returns one row per asset for the given
 	// date_key + dimension. Only filings with event_date <= maxEventDate

--- a/data/data_provider.go
+++ b/data/data_provider.go
@@ -80,3 +80,26 @@ type IndexProvider interface {
 type HolidayProvider interface {
 	FetchMarketHolidays(ctx context.Context) ([]tradecron.MarketHoliday, error)
 }
+
+// FundamentalsByDateKeyProvider is implemented by providers that can
+// return fundamentals filtered to a specific reporting period (date_key).
+// The engine type-asserts on this interface from FetchByDateKey.
+type FundamentalsByDateKeyProvider interface {
+	// FetchFundamentalsByDateKey returns one row per asset for the given
+	// date_key + dimension. Only filings with event_date <= maxEventDate
+	// are included (point-in-time correctness). For dimensions where a
+	// single (figi, date_key) can have multiple filings (MR restatements),
+	// the row with the maximum event_date wins.
+	//
+	// metrics must contain only fundamental metrics. Metadata metrics
+	// (FundamentalsDateKey, FundamentalsReportPeriod) populate from the
+	// row's date_key/report_period columns.
+	FetchFundamentalsByDateKey(
+		ctx context.Context,
+		assets []asset.Asset,
+		metrics []Metric,
+		dateKey time.Time,
+		dimension string,
+		maxEventDate time.Time,
+	) (*DataFrame, error)
+}

--- a/data/metric.go
+++ b/data/metric.go
@@ -284,6 +284,21 @@ const (
 	MarketCapFundamental Metric = "MarketCapFundamental"
 )
 
+// Fundamentals metadata metrics (fundamentals table date columns).
+const (
+	// FundamentalsDateKey is the normalized calendar quarter boundary for
+	// the most recent fundamental filing as of the queried timestamp.
+	// Values are encoded as float64(t.Unix()); convert with
+	// time.Unix(int64(val), 0). NaN means no filing has been observed.
+	FundamentalsDateKey Metric = "FundamentalsDateKey"
+
+	// FundamentalsReportPeriod is the actual fiscal-period end date for
+	// the most recent fundamental filing as of the queried timestamp.
+	// Values are encoded as float64(t.Unix()); convert with
+	// time.Unix(int64(val), 0). NaN means no filing has been observed.
+	FundamentalsReportPeriod Metric = "FundamentalsReportPeriod"
+)
+
 // Computed aggregate metrics.
 const (
 	// Count is the metric used by CountWhere to store per-timestep counts.

--- a/data/metric_view_test.go
+++ b/data/metric_view_test.go
@@ -42,4 +42,9 @@ var _ = Describe("IsFundamental", func() {
 	It("returns false for unknown metrics", func() {
 		Expect(data.IsFundamental(data.Metric("nonexistent"))).To(BeFalse())
 	})
+
+	It("classifies fundamentals metadata metrics as fundamentals", func() {
+		Expect(data.IsFundamental(data.FundamentalsDateKey)).To(BeTrue())
+		Expect(data.IsFundamental(data.FundamentalsReportPeriod)).To(BeTrue())
+	})
 })

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -39,6 +39,7 @@ var _ BatchProvider = (*PVDataProvider)(nil)
 var _ AssetProvider = (*PVDataProvider)(nil)
 var _ RatingProvider = (*PVDataProvider)(nil)
 var _ IndexProvider = (*PVDataProvider)(nil)
+var _ interface{ Dimension() string } = (*PVDataProvider)(nil)
 
 // scanPgxAsset scans a full asset row from a pgx result set. All metadata
 // columns are nullable in the view, so we scan into pointers and fall back
@@ -138,6 +139,11 @@ func WithConfigFile(path string) PVDataOption {
 // Valid values: "ARQ", "ARY", "ART", "MRQ", "MRY", "MRT".
 func (p *PVDataProvider) SetDimension(dim string) {
 	p.dimension = dim
+}
+
+// Dimension returns the current fundamental dimension filter.
+func (p *PVDataProvider) Dimension() string {
+	return p.dimension
 }
 
 // NewPVDataProvider creates a provider that reads from a pv-data database.

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -17,6 +17,7 @@ package data
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -653,13 +654,18 @@ func (p *PVDataProvider) fetchFundamentals(
 	ensureCol func(string, Metric) map[int64]float64,
 	timeSet map[int64]time.Time,
 ) error {
-	// build the list of SQL columns we need
+	// build the list of SQL columns we need, skipping metadata metrics
+	// (date_key, report_period) which are always fetched by the fixed SELECT prefix.
 	var (
 		sqlCols     []string
 		metricOrder []Metric
 	)
 
 	for _, metric := range metrics {
+		if metric == FundamentalsDateKey || metric == FundamentalsReportPeriod {
+			continue
+		}
+
 		col, ok := metricColumn[metric]
 		if !ok {
 			continue
@@ -669,16 +675,31 @@ func (p *PVDataProvider) fetchFundamentals(
 		metricOrder = append(metricOrder, metric)
 	}
 
-	if len(sqlCols) == 0 {
+	wantDateKey := false
+	wantReportPeriod := false
+
+	for _, metric := range metrics {
+		switch metric {
+		case FundamentalsDateKey:
+			wantDateKey = true
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+		}
+	}
+
+	if len(sqlCols) == 0 && !wantDateKey && !wantReportPeriod {
 		return nil
 	}
 
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
 	query := fmt.Sprintf(
-		`SELECT composite_figi, event_date, date_key, %s
+		`SELECT %s
 		 FROM fundamentals
 		 WHERE composite_figi = ANY($1) AND event_date BETWEEN $2::date AND $3::date AND dimension = $4
 		 ORDER BY event_date`,
-		strings.Join(sqlCols, ", "),
+		strings.Join(cols, ", "),
 	)
 
 	rows, err := conn.Query(ctx, query, figis, start, end, p.dimension)
@@ -689,19 +710,21 @@ func (p *PVDataProvider) fetchFundamentals(
 
 	for rows.Next() {
 		var (
-			figi      string
-			eventDate time.Time
-			dateKey   time.Time
+			figi         string
+			eventDate    time.Time
+			dateKey      time.Time
+			reportPeriod sql.NullTime
 		)
 
-		vals := make([]any, len(sqlCols)+3)
+		vals := make([]any, 4+len(sqlCols))
 		vals[0] = &figi
 		vals[1] = &eventDate
 		vals[2] = &dateKey
+		vals[3] = &reportPeriod
 
 		floatVals := make([]*float64, len(sqlCols))
 		for idx := range sqlCols {
-			vals[idx+3] = &floatVals[idx]
+			vals[4+idx] = &floatVals[idx]
 		}
 
 		if err := rows.Scan(vals...); err != nil {
@@ -712,10 +735,18 @@ func (p *PVDataProvider) fetchFundamentals(
 		sec := eventDate.Unix()
 		timeSet[sec] = eventDate
 
-		for idx, m := range metricOrder {
+		for idx, mm := range metricOrder {
 			if floatVals[idx] != nil {
-				ensureCol(figi, m)[sec] = *floatVals[idx]
+				ensureCol(figi, mm)[sec] = *floatVals[idx]
 			}
+		}
+
+		if wantDateKey {
+			ensureCol(figi, FundamentalsDateKey)[sec] = float64(dateKey.Unix())
+		}
+
+		if wantReportPeriod && reportPeriod.Valid {
+			ensureCol(figi, FundamentalsReportPeriod)[sec] = float64(reportPeriod.Time.Unix())
 		}
 	}
 

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -712,7 +712,7 @@ func (p *PVDataProvider) fetchFundamentals(
 		var (
 			figi         string
 			eventDate    time.Time
-			dateKey      time.Time
+			dateKey      sql.NullTime
 			reportPeriod sql.NullTime
 		)
 
@@ -741,8 +741,8 @@ func (p *PVDataProvider) fetchFundamentals(
 			}
 		}
 
-		if wantDateKey {
-			ensureCol(figi, FundamentalsDateKey)[sec] = float64(dateKey.Unix())
+		if wantDateKey && dateKey.Valid {
+			ensureCol(figi, FundamentalsDateKey)[sec] = float64(dateKey.Time.Unix())
 		}
 
 		if wantReportPeriod && reportPeriod.Valid {

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -1007,6 +1007,8 @@ var metricView = map[Metric]string{
 	TangibleAssetValue:                  "fundamentals",
 	WorkingCapital:                      "fundamentals",
 	MarketCapFundamental:                "fundamentals",
+	FundamentalsDateKey:                 "fundamentals",
+	FundamentalsReportPeriod:            "fundamentals",
 }
 
 // IsFundamental reports whether the given metric is sourced from the
@@ -1109,6 +1111,8 @@ var metricColumn = map[Metric]string{
 	TangibleAssetValue:                  "tangible_asset_value",
 	WorkingCapital:                      "working_capital",
 	MarketCapFundamental:                "market_capitalization",
+	FundamentalsDateKey:                 "date_key",
+	FundamentalsReportPeriod:            "report_period",
 }
 
 // metricsColumn maps metrics-view Metrics to their SQL column names and

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -40,6 +40,7 @@ var _ AssetProvider = (*PVDataProvider)(nil)
 var _ RatingProvider = (*PVDataProvider)(nil)
 var _ IndexProvider = (*PVDataProvider)(nil)
 var _ interface{ Dimension() string } = (*PVDataProvider)(nil)
+var _ FundamentalsByDateKeyProvider = (*PVDataProvider)(nil)
 
 // scanPgxAsset scans a full asset row from a pgx result set. All metadata
 // columns are nullable in the view, so we scan into pointers and fall back
@@ -1188,4 +1189,148 @@ var eodLocation = mustLoadLocation("America/New_York")
 // eodTimestamp converts a database date to the market close timestamp (16:00 Eastern).
 func eodTimestamp(timestamp time.Time) time.Time {
 	return time.Date(timestamp.Year(), timestamp.Month(), timestamp.Day(), 16, 0, 0, 0, eodLocation)
+}
+
+// FetchFundamentalsByDateKey implements FundamentalsByDateKeyProvider.
+func (p *PVDataProvider) FetchFundamentalsByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []Metric,
+	dateKey time.Time,
+	dimension string,
+	maxEventDate time.Time,
+) (*DataFrame, error) {
+	figis := make([]string, len(assets))
+	for idx, aa := range assets {
+		figis[idx] = aa.CompositeFigi
+	}
+
+	var (
+		sqlCols     []string
+		metricOrder []Metric
+	)
+
+	wantDateKey := false
+	wantReportPeriod := false
+
+	for _, mm := range metrics {
+		switch mm {
+		case FundamentalsDateKey:
+			wantDateKey = true
+			continue
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+			continue
+		}
+
+		col, ok := metricColumn[mm]
+		if !ok {
+			return nil, fmt.Errorf("pvdata: no SQL column for fundamental metric %q", mm)
+		}
+
+		sqlCols = append(sqlCols, col)
+		metricOrder = append(metricOrder, mm)
+	}
+
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
+	// DISTINCT ON (composite_figi) keeps the most recent event_date per
+	// asset, which matters for MR dimensions where a single (figi,
+	// date_key) tuple may appear multiple times due to restatements.
+	query := fmt.Sprintf(
+		`SELECT DISTINCT ON (composite_figi) %s
+		 FROM fundamentals
+		 WHERE composite_figi = ANY($1)
+		   AND date_key = $2::date
+		   AND dimension = $3
+		   AND event_date <= $4::date
+		 ORDER BY composite_figi, event_date DESC`,
+		strings.Join(cols, ", "),
+	)
+
+	conn, err := p.pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pvdata: acquire conn for FetchFundamentalsByDateKey: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, query, figis, dateKey, dimension, maxEventDate)
+	if err != nil {
+		return nil, fmt.Errorf("pvdata: query fundamentals by date_key: %w", err)
+	}
+	defer rows.Close()
+
+	// Build a per-figi value map: figi -> metric -> float64.
+	perFigi := make(map[string]map[Metric]float64, len(assets))
+
+	for rows.Next() {
+		var (
+			figi         string
+			eventDate    time.Time
+			rowDateKey   time.Time
+			reportPeriod sql.NullTime
+		)
+
+		vals := make([]any, 4+len(sqlCols))
+		vals[0] = &figi
+		vals[1] = &eventDate
+		vals[2] = &rowDateKey
+		vals[3] = &reportPeriod
+
+		floatVals := make([]*float64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[4+idx] = &floatVals[idx]
+		}
+
+		if err := rows.Scan(vals...); err != nil {
+			return nil, fmt.Errorf("pvdata: scan fundamentals by date_key row: %w", err)
+		}
+
+		bucket, ok := perFigi[figi]
+		if !ok {
+			bucket = make(map[Metric]float64, len(metrics))
+			perFigi[figi] = bucket
+		}
+
+		for idx, mm := range metricOrder {
+			if floatVals[idx] != nil {
+				bucket[mm] = *floatVals[idx]
+			}
+		}
+
+		if wantDateKey {
+			bucket[FundamentalsDateKey] = float64(rowDateKey.Unix())
+		}
+
+		if wantReportPeriod && reportPeriod.Valid {
+			bucket[FundamentalsReportPeriod] = float64(reportPeriod.Time.Unix())
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pvdata: iterate fundamentals by date_key rows: %w", err)
+	}
+
+	// Assemble a single-row DataFrame at dateKey.
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, aa := range assets {
+		bucket := perFigi[aa.CompositeFigi]
+
+		for mIdx, mm := range metrics {
+			val := math.NaN()
+
+			if bucket != nil {
+				if vv, ok := bucket[mm]; ok {
+					val = vv
+				}
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return NewDataFrame(times, assets, metrics, Daily, columns)
 }

--- a/data/snapshot_provider.go
+++ b/data/snapshot_provider.go
@@ -19,11 +19,12 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ BatchProvider   = (*SnapshotProvider)(nil)
-	_ AssetProvider   = (*SnapshotProvider)(nil)
-	_ IndexProvider   = (*SnapshotProvider)(nil)
-	_ RatingProvider  = (*SnapshotProvider)(nil)
-	_ HolidayProvider = (*SnapshotProvider)(nil)
+	_ BatchProvider                 = (*SnapshotProvider)(nil)
+	_ AssetProvider                 = (*SnapshotProvider)(nil)
+	_ IndexProvider                 = (*SnapshotProvider)(nil)
+	_ RatingProvider                = (*SnapshotProvider)(nil)
+	_ HolidayProvider               = (*SnapshotProvider)(nil)
+	_ FundamentalsByDateKeyProvider = (*SnapshotProvider)(nil)
 )
 
 // SnapshotProvider replays data from a snapshot SQLite database.
@@ -711,4 +712,169 @@ func (p *SnapshotProvider) RatedAssets(ctx context.Context, analyst string, filt
 	}
 
 	return assets, rows.Err()
+}
+
+// FetchFundamentalsByDateKey implements FundamentalsByDateKeyProvider for
+// snapshot replay. The query mirrors the PVDataProvider implementation but
+// uses SQLite syntax (no DISTINCT ON; row_number window function instead).
+func (p *SnapshotProvider) FetchFundamentalsByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []Metric,
+	dateKey time.Time,
+	dimension string,
+	maxEventDate time.Time,
+) (*DataFrame, error) {
+	figis := make([]string, len(assets))
+	for idx, aa := range assets {
+		figis[idx] = aa.CompositeFigi
+	}
+
+	var (
+		sqlCols     []string
+		metricOrder []Metric
+	)
+
+	wantDateKey := false
+	wantReportPeriod := false
+
+	for _, metric := range metrics {
+		switch metric {
+		case FundamentalsDateKey:
+			wantDateKey = true
+			continue
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+			continue
+		}
+
+		col, ok := metricColumn[metric]
+		if !ok {
+			return nil, fmt.Errorf("snapshot: no SQL column for fundamental metric %q", metric)
+		}
+
+		sqlCols = append(sqlCols, col)
+		metricOrder = append(metricOrder, metric)
+	}
+
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
+	placeholders := make([]string, len(figis))
+	for idx := range figis {
+		placeholders[idx] = "?"
+	}
+
+	dateKeyStr := dateKey.UTC().Format("2006-01-02")
+	maxEventStr := maxEventDate.UTC().Format("2006-01-02")
+
+	// SQLite ranks by event_date DESC and picks rank 1 per figi.
+	query := fmt.Sprintf(
+		`SELECT %s FROM (
+		    SELECT %s,
+		           row_number() OVER (PARTITION BY composite_figi ORDER BY event_date DESC) AS rn
+		      FROM fundamentals
+		     WHERE composite_figi IN (%s)
+		       AND date_key = ?
+		       AND dimension = ?
+		       AND event_date <= ?
+		 ) WHERE rn = 1`,
+		strings.Join(cols, ", "),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	args := make([]any, 0, len(figis)+3)
+	for _, f := range figis {
+		args = append(args, f)
+	}
+
+	args = append(args, dateKeyStr, dimension, maxEventStr)
+
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: query fundamentals by date_key: %w", err)
+	}
+	defer rows.Close()
+
+	perFigi := make(map[string]map[Metric]float64, len(assets))
+
+	for rows.Next() {
+		var (
+			figi            string
+			eventDateStr    string
+			rowDateKeyStr   sql.NullString
+			reportPeriodStr sql.NullString
+		)
+
+		vals := make([]any, 4+len(sqlCols))
+		vals[0] = &figi
+		vals[1] = &eventDateStr
+		vals[2] = &rowDateKeyStr
+		vals[3] = &reportPeriodStr
+
+		floatVals := make([]sql.NullFloat64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[4+idx] = &floatVals[idx]
+		}
+
+		if err := rows.Scan(vals...); err != nil {
+			return nil, fmt.Errorf("snapshot: scan fundamentals by date_key row: %w", err)
+		}
+
+		bucket, ok := perFigi[figi]
+		if !ok {
+			bucket = make(map[Metric]float64, len(metrics))
+			perFigi[figi] = bucket
+		}
+
+		for idx, m := range metricOrder {
+			if floatVals[idx].Valid {
+				bucket[m] = floatVals[idx].Float64
+			}
+		}
+
+		if wantDateKey && rowDateKeyStr.Valid {
+			parsed, parseErr := parseSnapshotDate(rowDateKeyStr.String)
+			if parseErr != nil {
+				return nil, fmt.Errorf("snapshot: parse date_key %q: %w", rowDateKeyStr.String, parseErr)
+			}
+
+			bucket[FundamentalsDateKey] = float64(parsed.Unix())
+		}
+
+		if wantReportPeriod && reportPeriodStr.Valid {
+			parsed, parseErr := parseSnapshotDate(reportPeriodStr.String)
+			if parseErr != nil {
+				return nil, fmt.Errorf("snapshot: parse report_period %q: %w", reportPeriodStr.String, parseErr)
+			}
+
+			bucket[FundamentalsReportPeriod] = float64(parsed.Unix())
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("snapshot: iterate fundamentals by date_key rows: %w", err)
+	}
+
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, aa := range assets {
+		bucket := perFigi[aa.CompositeFigi]
+
+		for mIdx, m := range metrics {
+			val := math.NaN()
+
+			if bucket != nil {
+				if v, ok := bucket[m]; ok {
+					val = v
+				}
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return NewDataFrame(times, assets, metrics, Daily, columns)
 }

--- a/data/snapshot_provider_test.go
+++ b/data/snapshot_provider_test.go
@@ -610,6 +610,149 @@ var _ = Describe("SnapshotProvider", func() {
 			Expect(result.Len()).To(Equal(3), "old RFC3339 snapshots must still be readable")
 		})
 
+		It("FetchFundamentalsByDateKey returns fundamentals data for a date_key", func() {
+			nyc, err := time.LoadLocation("America/New_York")
+			Expect(err).NotTo(HaveOccurred())
+
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			// Dates stored as plain YYYY-MM-DD strings (canonical snapshot format).
+			dateKeyStr := "2024-03-31"
+			reportPeriodStr := "2024-03-31"
+			eventDateStr := "2024-04-15"
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.CreateSnapshotSchema(db)).To(Succeed())
+
+			_, err = db.Exec(`INSERT INTO assets
+				(composite_figi, ticker, name, asset_type, primary_exchange, sector, industry, sic_code, cik, listed, delisted)
+				VALUES ('BBG000BLNNH6', 'SPY', 'SPDR S&P 500 ETF Trust', 'ETF', 'NYSE', '', '', 6726, '0000884394', '1993-01-22', '')`)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = db.Exec(`INSERT INTO fundamentals
+				(composite_figi, event_date, date_key, report_period, dimension, working_capital)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+				"BBG000BLNNH6", eventDateStr, dateKeyStr, reportPeriodStr, "ARQ", 120000000.0)
+			Expect(err).NotTo(HaveOccurred())
+			db.Close()
+
+			snap, err := data.NewSnapshotProvider(dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer snap.Close()
+
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+			maxEventDate := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+			metrics := []data.Metric{data.WorkingCapital, data.FundamentalsDateKey, data.FundamentalsReportPeriod}
+
+			result, err := snap.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, "ARQ", maxEventDate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Len()).To(Equal(1), "expected one time-axis row at dateKey")
+
+			// WorkingCapital value should equal the inserted value.
+			wcCol := result.Column(spy, data.WorkingCapital)
+			Expect(wcCol).To(HaveLen(1))
+			Expect(wcCol[0]).To(BeNumerically("~", 120000000.0, 1.0))
+
+			// FundamentalsDateKey should equal the Unix timestamp of the parsed date_key.
+			expectedDateKey := time.Date(2024, 3, 31, 16, 0, 0, 0, nyc)
+			dkCol := result.Column(spy, data.FundamentalsDateKey)
+			Expect(dkCol).To(HaveLen(1))
+			Expect(dkCol[0]).To(BeNumerically("~", float64(expectedDateKey.Unix()), 1.0))
+
+			// FundamentalsReportPeriod should equal the Unix timestamp of the parsed report_period.
+			expectedReportPeriod := time.Date(2024, 3, 31, 16, 0, 0, 0, nyc)
+			rpCol := result.Column(spy, data.FundamentalsReportPeriod)
+			Expect(rpCol).To(HaveLen(1))
+			Expect(rpCol[0]).To(BeNumerically("~", float64(expectedReportPeriod.Unix()), 1.0))
+		})
+
+		It("FetchFundamentalsByDateKey returns NaN when event_date is after maxEventDate", func() {
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.CreateSnapshotSchema(db)).To(Succeed())
+
+			_, err = db.Exec(`INSERT INTO assets
+				(composite_figi, ticker, name, asset_type, primary_exchange, sector, industry, sic_code, cik, listed, delisted)
+				VALUES ('BBG000BLNNH6', 'SPY', 'SPDR S&P 500 ETF Trust', 'ETF', 'NYSE', '', '', 6726, '0000884394', '1993-01-22', '')`)
+			Expect(err).NotTo(HaveOccurred())
+
+			// event_date is in the future relative to maxEventDate.
+			_, err = db.Exec(`INSERT INTO fundamentals
+				(composite_figi, event_date, date_key, report_period, dimension, working_capital)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+				"BBG000BLNNH6", "2024-05-01", "2024-03-31", "2024-03-31", "ARQ", 120000000.0)
+			Expect(err).NotTo(HaveOccurred())
+			db.Close()
+
+			snap, err := data.NewSnapshotProvider(dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer snap.Close()
+
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+			// maxEventDate is before the filing's event_date — point-in-time cutoff.
+			maxEventDate := time.Date(2024, 4, 30, 0, 0, 0, 0, time.UTC)
+			metrics := []data.Metric{data.WorkingCapital}
+
+			result, err := snap.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, "ARQ", maxEventDate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			wcCol := result.Column(spy, data.WorkingCapital)
+			Expect(wcCol).To(HaveLen(1))
+			Expect(math.IsNaN(wcCol[0])).To(BeTrue(), "expected NaN when event_date is after maxEventDate")
+		})
+
+		It("FetchFundamentalsByDateKey returns the latest filing when a restatement exists", func() {
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data.CreateSnapshotSchema(db)).To(Succeed())
+
+			_, err = db.Exec(`INSERT INTO assets
+				(composite_figi, ticker, name, asset_type, primary_exchange, sector, industry, sic_code, cik, listed, delisted)
+				VALUES ('BBG000BLNNH6', 'SPY', 'SPDR S&P 500 ETF Trust', 'ETF', 'NYSE', '', '', 6726, '0000884394', '1993-01-22', '')`)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Two filings for the same (figi, date_key, dimension="MRQ") — a restatement.
+			// Original filing: event_date 2024-04-15, working_capital = 100000000.
+			// Restated filing: event_date 2024-05-01, working_capital = 120000000.
+			_, err = db.Exec(`INSERT INTO fundamentals
+				(composite_figi, event_date, date_key, report_period, dimension, working_capital)
+				VALUES
+				(?, ?, ?, ?, ?, ?),
+				(?, ?, ?, ?, ?, ?)`,
+				"BBG000BLNNH6", "2024-04-15", "2024-03-31", "2024-03-31", "MRQ", 100000000.0,
+				"BBG000BLNNH6", "2024-05-01", "2024-03-31", "2024-03-31", "MRQ", 120000000.0)
+			Expect(err).NotTo(HaveOccurred())
+			db.Close()
+
+			snap, err := data.NewSnapshotProvider(dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer snap.Close()
+
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+			maxEventDate := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+			metrics := []data.Metric{data.WorkingCapital}
+
+			result, err := snap.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, "MRQ", maxEventDate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			wcCol := result.Column(spy, data.WorkingCapital)
+			Expect(wcCol).To(HaveLen(1))
+			// Must return the restated (latest) value, not the original.
+			Expect(wcCol[0]).To(BeNumerically("~", 120000000.0, 1.0),
+				"expected latest restatement value (120000000), got original (100000000)?")
+		})
+
 		It("record then replay produces identical data", func() {
 			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
 			tlt := asset.Asset{CompositeFigi: "BBG000BHTK15", Ticker: "TLT"}

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -427,6 +427,9 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 		mIdx[metric] = idx
 	}
 
+	dateKeyDFIdx, hasDateKey := mIdx[FundamentalsDateKey]
+	reportPeriodDFIdx, hasReportPeriod := mIdx[FundamentalsReportPeriod]
+
 	// Build sorted column list from the metrics we have data for.
 	var (
 		colNames   []string
@@ -471,16 +474,41 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 		strings.Join(upsertCols, ", "),
 	)
 
-	for assetIdx, a := range df.assets {
+	dimension := "ARQ"
+
+	if dp, ok := r.batchProvider.(interface{ Dimension() string }); ok {
+		if dim := dp.Dimension(); dim != "" {
+			dimension = dim
+		}
+	}
+
+	for assetIdx, aa := range df.assets {
 		for timeIdx, timestamp := range df.times {
 			dateStr := timestamp.Format("2006-01-02")
 
 			args := make([]any, 5+len(colMetrics))
-			args[0] = a.CompositeFigi
+			args[0] = aa.CompositeFigi
 			args[1] = dateStr
-			args[2] = nil // date_key: populated when DataFrame metadata is available
-			args[3] = nil // report_period: populated when DataFrame metadata is available
-			args[4] = "ARQ"
+
+			args[2] = nil
+
+			if hasDateKey {
+				raw := df.columns[assetIdx*numDFMetrics+dateKeyDFIdx][timeIdx]
+				if !math.IsNaN(raw) {
+					args[2] = time.Unix(int64(raw), 0).UTC().Format("2006-01-02")
+				}
+			}
+
+			args[3] = nil
+
+			if hasReportPeriod {
+				raw := df.columns[assetIdx*numDFMetrics+reportPeriodDFIdx][timeIdx]
+				if !math.IsNaN(raw) {
+					args[3] = time.Unix(int64(raw), 0).UTC().Format("2006-01-02")
+				}
+			}
+
+			args[4] = dimension
 
 			for idx, metric := range colMetrics {
 				mi, ok := mIdx[metric]

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -437,6 +437,11 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 	)
 
 	for _, metric := range metrics {
+		// Skip metadata metrics; they map to structural columns already declared in the INSERT.
+		if metric == FundamentalsDateKey || metric == FundamentalsReportPeriod {
+			continue
+		}
+
 		colName, ok := metricColumn[metric]
 		if !ok {
 			continue

--- a/data/snapshot_recorder_test.go
+++ b/data/snapshot_recorder_test.go
@@ -315,6 +315,136 @@ var _ = Describe("SnapshotRecorder", func() {
 			Expect(result).To(BeNil())
 		})
 	})
+
+	Describe("fundamentals recording with metadata", func() {
+		It("persists date_key, report_period, and dimension from the wrapped provider", func() {
+			nyc, err := time.LoadLocation("America/New_York")
+			Expect(err).NotTo(HaveOccurred())
+
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			filing := time.Date(2024, 5, 2, 16, 0, 0, 0, nyc)
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, nyc)
+			reportPeriod := time.Date(2024, 3, 30, 0, 0, 0, 0, nyc)
+
+			times := []time.Time{filing}
+			metrics := []data.Metric{
+				data.WorkingCapital,
+				data.FundamentalsDateKey,
+				data.FundamentalsReportPeriod,
+			}
+
+			values := [][]float64{
+				{120_000_000.0},                // SPY WorkingCapital
+				{float64(dateKey.Unix())},      // SPY FundamentalsDateKey
+				{float64(reportPeriod.Unix())}, // SPY FundamentalsReportPeriod
+			}
+
+			df, err := data.NewDataFrame(times, assets, metrics, data.Daily, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			stub := &dimensionedTestProvider{
+				TestProvider: data.NewTestProvider(metrics, df),
+				dimension:    "MRQ",
+			}
+
+			recorder, err = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: stub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = recorder.Fetch(ctx, data.DataRequest{
+				Assets:    assets,
+				Metrics:   metrics,
+				Start:     filing,
+				End:       filing,
+				Frequency: data.Daily,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.Close()).To(Succeed())
+			recorder = nil
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer db.Close()
+
+			var (
+				dateKeyStr, reportPeriodStr, dimStr string
+				wc                                  float64
+			)
+			err = db.QueryRow(
+				`SELECT date_key, report_period, dimension, working_capital
+				   FROM fundamentals
+				  WHERE composite_figi = ?`,
+				spy.CompositeFigi,
+			).Scan(&dateKeyStr, &reportPeriodStr, &dimStr, &wc)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dateKeyStr).To(Equal("2024-03-31"))
+			Expect(reportPeriodStr).To(Equal("2024-03-30"))
+			Expect(dimStr).To(Equal("MRQ"))
+			Expect(wc).To(BeNumerically("==", 120_000_000.0))
+		})
+
+		It("writes NULL date_key/report_period when the DataFrame omits them", func() {
+			nyc, err := time.LoadLocation("America/New_York")
+			Expect(err).NotTo(HaveOccurred())
+
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			filing := time.Date(2024, 5, 2, 16, 0, 0, 0, nyc)
+			times := []time.Time{filing}
+			metrics := []data.Metric{data.WorkingCapital}
+			values := [][]float64{{120_000_000.0}}
+
+			df, err := data.NewDataFrame(times, assets, metrics, data.Daily, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			stub := data.NewTestProvider(metrics, df) // no Dimension() method
+
+			recorder, err = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: stub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = recorder.Fetch(ctx, data.DataRequest{
+				Assets:    assets,
+				Metrics:   metrics,
+				Start:     filing,
+				End:       filing,
+				Frequency: data.Daily,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.Close()).To(Succeed())
+			recorder = nil
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer db.Close()
+
+			var (
+				dateKeyNull, reportPeriodNull sql.NullString
+				dimStr                        string
+			)
+			err = db.QueryRow(
+				`SELECT date_key, report_period, dimension
+				   FROM fundamentals
+				  WHERE composite_figi = ?`,
+				spy.CompositeFigi,
+			).Scan(&dateKeyNull, &reportPeriodNull, &dimStr)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dateKeyNull.Valid).To(BeFalse())
+			Expect(reportPeriodNull.Valid).To(BeFalse())
+			Expect(dimStr).To(Equal("ARQ")) // fallback default
+		})
+	})
 })
 
 // -- stubs --
@@ -348,3 +478,10 @@ type stubRatingProvider struct {
 func (s *stubRatingProvider) RatedAssets(ctx context.Context, analyst string, filter data.RatingFilter, t time.Time) ([]asset.Asset, error) {
 	return s.assets, nil
 }
+
+type dimensionedTestProvider struct {
+	*data.TestProvider
+	dimension string
+}
+
+func (p *dimensionedTestProvider) Dimension() string { return p.dimension }

--- a/data/snapshot_schema.go
+++ b/data/snapshot_schema.go
@@ -105,9 +105,12 @@ func CreateSnapshotSchema(db *sql.DB) error {
 // fundamentals table from the metricColumn map. Columns are sorted
 // alphabetically for deterministic DDL output.
 func buildFundamentalColumns() string {
-	// Pre-seed with columns that are declared explicitly in the DDL so that
-	// metricColumn entries that map to those names (e.g. FundamentalsDateKey
-	// -> "date_key") are not emitted a second time.
+	// Pre-seed with every column that is already declared explicitly in the
+	// fundamentals CREATE TABLE statement above. Any metricColumn entry whose
+	// SQL name appears in this set (e.g. FundamentalsDateKey -> "date_key")
+	// will be skipped, preventing duplicate column definitions in the DDL.
+	// When adding a new structural column to the fundamentals table DDL,
+	// add its SQL name here too.
 	seen := map[string]bool{
 		"composite_figi": true,
 		"event_date":     true,

--- a/data/snapshot_schema.go
+++ b/data/snapshot_schema.go
@@ -105,7 +105,16 @@ func CreateSnapshotSchema(db *sql.DB) error {
 // fundamentals table from the metricColumn map. Columns are sorted
 // alphabetically for deterministic DDL output.
 func buildFundamentalColumns() string {
-	seen := make(map[string]bool)
+	// Pre-seed with columns that are declared explicitly in the DDL so that
+	// metricColumn entries that map to those names (e.g. FundamentalsDateKey
+	// -> "date_key") are not emitted a second time.
+	seen := map[string]bool{
+		"composite_figi": true,
+		"event_date":     true,
+		"date_key":       true,
+		"report_period":  true,
+		"dimension":      true,
+	}
 
 	var cols []string
 

--- a/data/snapshot_schema_internal_test.go
+++ b/data/snapshot_schema_internal_test.go
@@ -1,0 +1,41 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("buildFundamentalColumns", func() {
+	It("does not emit REAL definitions for structural DDL columns", func() {
+		cols := buildFundamentalColumns()
+
+		// Structural columns are declared explicitly in the fundamentals DDL
+		// template; emitting them again as REAL would produce invalid SQL.
+		Expect(cols).NotTo(ContainSubstring("date_key REAL"))
+		Expect(cols).NotTo(ContainSubstring("report_period REAL"))
+		Expect(cols).NotTo(ContainSubstring("dimension REAL"))
+	})
+
+	It("includes at least one known fundamental metric column", func() {
+		cols := buildFundamentalColumns()
+
+		// Sanity-check that the function is not returning an empty string,
+		// which would indicate all entries were incorrectly suppressed.
+		Expect(cols).To(ContainSubstring("working_capital REAL"))
+	})
+})

--- a/docs/data.md
+++ b/docs/data.md
@@ -72,6 +72,24 @@ Fundamental queries filter by dimension (default `"ARQ"` -- As Reported
 Quarterly). See `SetFundamentalDimension` in the strategy guide for how to
 change this.
 
+#### Reading the date metadata
+
+`event_date` is exposed as the DataFrame's time axis for fundamental fetches.
+`date_key` and `report_period` are exposed as two metrics:
+
+- `data.FundamentalsDateKey` -- normalized calendar quarter boundary.
+- `data.FundamentalsReportPeriod` -- actual fiscal period end as reported.
+
+Both are encoded as `float64(t.Unix())`. Convert with the standard library:
+
+```go
+dk := time.Unix(int64(df.Value(spy, data.FundamentalsDateKey, t)), 0)
+```
+
+NaN means no filing has been observed for that asset as of `t`. The engine
+forward-fills these metrics the same way as Revenue, WorkingCapital, etc., so
+the metadata travels with whatever value the strategy reads.
+
 ### Economic indicators
 
 Economic indicators like unemployment and CPI are not tied to a specific asset. They use the sentinel `asset.EconomicIndicator` in requests and DataFrames. From the DataFrame's perspective they look like any other asset -- the data layout stays uniform.

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -288,6 +288,45 @@ eng.SetFundamentalDimension("MRQ") // most-recent reported, quarterly
 | `MRY` | Most Recent Reported, Annual. |
 | `MRT` | Most Recent Reported, Trailing Twelve Months. |
 
+### Querying a specific reporting period
+
+When a strategy needs values for a particular fiscal quarter (e.g. Q1
+working capital across all candidates), use `Engine.FetchFundamentalsByDateKey`:
+
+```go
+func (s *NCAVE) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
+    q1 := mostRecentQ1(eng.CurrentDate())
+
+    df, err := eng.FetchFundamentalsByDateKey(ctx, s.universe, []data.Metric{
+        data.WorkingCapital,
+        data.TotalLiabilities,
+        data.FundamentalsDateKey,
+    }, q1)
+    if err != nil {
+        return err
+    }
+
+    for _, candidate := range s.universe {
+        wc := df.Value(candidate, data.WorkingCapital, q1)
+        if math.IsNaN(wc) {
+            continue // candidate has not filed Q1 yet as of CurrentDate
+        }
+
+        // ... use wc, df.Value(candidate, data.TotalLiabilities, q1), etc.
+    }
+
+    return nil
+}
+```
+
+`FetchFundamentalsByDateKey` returns a single time-axis row at `dateKey`, one value per
+asset per metric. Only filings with `event_date <= eng.CurrentDate()` are
+included; assets that have not filed for `dateKey` get NaN. All metrics in
+the call must be fundamentals; non-fundamental metrics return an error.
+
+The dimension used is whatever the strategy set with `SetFundamentalDimension`
+in `Setup` (defaults to `ARQ`).
+
 ### Asset lookup
 
 `eng.Asset(ticker)` resolves a ticker to an `asset.Asset` using the registered `AssetProvider`. It panics if the ticker is not found, which is appropriate in `Setup` since a missing benchmark or risk-free asset is a fatal configuration error.

--- a/docs/superpowers/plans/2026-04-18-fundamentals-metadata.md
+++ b/docs/superpowers/plans/2026-04-18-fundamentals-metadata.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Expose `date_key` and `report_period` as DataFrame metrics and add `Engine.FetchByDateKey` so strategies can request a specific reporting period (e.g. NCAVE Q1 working capital).
+**Goal:** Expose `date_key` and `report_period` as DataFrame metrics and add `Engine.FetchFundamentalsByDateKey` so strategies can request a specific reporting period (e.g. NCAVE Q1 working capital).
 
-**Architecture:** Two new fundamental metrics (`FundamentalsDateKey`, `FundamentalsReportPeriod`) encoded as `float64(t.Unix())`. Provider extends `fetchFundamentals` to select the metadata columns and populate them like any other metric. Engine adds `FetchByDateKey` via a new optional capability interface (`FundamentalsByDateKeyProvider`) implemented by `PVDataProvider` and `SnapshotProvider`. Snapshot recorder reads metadata from the DataFrame columns when present and reads the dimension from the wrapped provider via a `Dimension() string` interface.
+**Architecture:** Two new fundamental metrics (`FundamentalsDateKey`, `FundamentalsReportPeriod`) encoded as `float64(t.Unix())`. Provider extends `fetchFundamentals` to select the metadata columns and populate them like any other metric. Engine adds `FetchFundamentalsByDateKey` via a new optional capability interface (`FundamentalsByDateKeyProvider`) implemented by `PVDataProvider` and `SnapshotProvider`. Snapshot recorder reads metadata from the DataFrame columns when present and reads the dimension from the wrapped provider via a `Dimension() string` interface.
 
 **Tech Stack:** Go, PostgreSQL (pgx), SQLite (modernc.org/sqlite), Ginkgo/Gomega.
 
@@ -542,7 +542,7 @@ In `data/data_provider.go`, append at end of file:
 ```go
 // FundamentalsByDateKeyProvider is implemented by providers that can
 // return fundamentals filtered to a specific reporting period (date_key).
-// The engine type-asserts on this interface from FetchByDateKey.
+// The engine type-asserts on this interface from FetchFundamentalsByDateKey.
 type FundamentalsByDateKeyProvider interface {
 	// FetchFundamentalsByDateKey returns one row per asset for the given
 	// date_key + dimension. Only filings with event_date <= maxEventDate
@@ -738,7 +738,7 @@ git commit -m "feat: add FundamentalsByDateKeyProvider interface and PVDataProvi
 **Files:**
 - Modify: `data/snapshot_provider.go`
 
-The snapshot provider must implement the same interface so that snapshot-replayed backtests support `FetchByDateKey`.
+The snapshot provider must implement the same interface so that snapshot-replayed backtests support `FetchFundamentalsByDateKey`.
 
 - [ ] **Step 1: Append the implementation**
 
@@ -928,7 +928,7 @@ git commit -m "feat: add SnapshotProvider.FetchFundamentalsByDateKey for replay"
 
 ---
 
-### Task 7: Implement `Engine.FetchByDateKey`
+### Task 7: Implement `Engine.FetchFundamentalsByDateKey`
 
 **Files:**
 - Modify: `engine/engine.go`
@@ -972,7 +972,7 @@ func (s *fetchByDateKeyStrategy) Describe() engine.StrategyDescription {
 }
 
 func (s *fetchByDateKeyStrategy) Compute(ctx context.Context, eng *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
-	s.fetched, s.fetchErr = eng.FetchByDateKey(ctx, s.assets, s.metrics, s.dateKey)
+	s.fetched, s.fetchErr = eng.FetchFundamentalsByDateKey(ctx, s.assets, s.metrics, s.dateKey)
 	return nil
 }
 
@@ -1012,7 +1012,7 @@ func (p *fakeByDateKeyProvider) FetchFundamentalsByDateKey(
 	return data.NewDataFrame(times, assets, metrics, data.Daily, columns)
 }
 
-var _ = Describe("Engine.FetchByDateKey", func() {
+var _ = Describe("Engine.FetchFundamentalsByDateKey", func() {
 	var assetProv *mockAssetProvider
 
 	BeforeEach(func() {
@@ -1219,23 +1219,23 @@ Helpers used: `makeDailyDF` (engine test helpers, used by `dimension_test.go`), 
 - [ ] **Step 2: Run test to verify it fails**
 
 ```bash
-ginkgo run -race --focus "Engine.FetchByDateKey" ./engine/
+ginkgo run -race --focus "Engine.FetchFundamentalsByDateKey" ./engine/
 ```
 
-Expected: build error — `eng.FetchByDateKey` undefined.
+Expected: build error — `eng.FetchFundamentalsByDateKey` undefined.
 
-- [ ] **Step 3: Implement `FetchByDateKey`**
+- [ ] **Step 3: Implement `FetchFundamentalsByDateKey`**
 
 In `engine/engine.go`, append after the `FetchAt` method (around line 351):
 
 ```go
-// FetchByDateKey returns fundamental data for a specific reporting period.
+// FetchFundamentalsByDateKey returns fundamental data for a specific reporting period.
 // dateKey identifies the normalized quarter boundary (e.g. 2024-03-31 for
 // Q1 2024). All metrics must be fundamentals; non-fundamental metrics
 // produce an error. Subject to point-in-time correctness: only filings
 // with event_date <= eng.CurrentDate() are included. Assets that have not
 // filed for dateKey as of CurrentDate get NaN values.
-func (e *Engine) FetchByDateKey(
+func (e *Engine) FetchFundamentalsByDateKey(
 	ctx context.Context,
 	assets []asset.Asset,
 	metrics []data.Metric,
@@ -1243,7 +1243,7 @@ func (e *Engine) FetchByDateKey(
 ) (*data.DataFrame, error) {
 	for _, m := range metrics {
 		if !data.IsFundamental(m) {
-			return nil, fmt.Errorf("FetchByDateKey: metric %q is not a fundamental metric", m)
+			return nil, fmt.Errorf("FetchFundamentalsByDateKey: metric %q is not a fundamental metric", m)
 		}
 	}
 
@@ -1256,7 +1256,7 @@ func (e *Engine) FetchByDateKey(
 		if dp, ok := provider.(data.FundamentalsByDateKeyProvider); ok {
 			df, err := dp.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, dimension, e.currentDate)
 			if err != nil {
-				return nil, fmt.Errorf("FetchByDateKey: %w", err)
+				return nil, fmt.Errorf("FetchFundamentalsByDateKey: %w", err)
 			}
 
 			df.SetSource(e)
@@ -1265,7 +1265,7 @@ func (e *Engine) FetchByDateKey(
 		}
 	}
 
-	return nil, fmt.Errorf("FetchByDateKey: no provider supports FundamentalsByDateKeyProvider")
+	return nil, fmt.Errorf("FetchFundamentalsByDateKey: no provider supports FundamentalsByDateKeyProvider")
 }
 ```
 
@@ -1274,7 +1274,7 @@ The engine struct's provider slice is `e.providers []data.DataProvider` (`engine
 - [ ] **Step 4: Run tests to verify they pass**
 
 ```bash
-ginkgo run -race --focus "Engine.FetchByDateKey" ./engine/
+ginkgo run -race --focus "Engine.FetchFundamentalsByDateKey" ./engine/
 ```
 
 Expected: PASS for all four `It` blocks.
@@ -1291,7 +1291,7 @@ Expected: PASS.
 
 ```bash
 git add engine/engine.go engine/fetch_by_date_key_test.go
-git commit -m "feat: add Engine.FetchByDateKey for reporting-period fundamentals queries"
+git commit -m "feat: add Engine.FetchFundamentalsByDateKey for reporting-period fundamentals queries"
 ```
 
 ---
@@ -1419,13 +1419,13 @@ Append a new section after the existing "Fundamental dimension" section:
 ### Querying a specific reporting period
 
 When a strategy needs values for a particular fiscal quarter (e.g. Q1
-working capital across all candidates), use `Engine.FetchByDateKey`:
+working capital across all candidates), use `Engine.FetchFundamentalsByDateKey`:
 
 ```go
 func (s *NCAVE) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
     q1 := mostRecentQ1(eng.CurrentDate())
 
-    df, err := eng.FetchByDateKey(ctx, s.universe, []data.Metric{
+    df, err := eng.FetchFundamentalsByDateKey(ctx, s.universe, []data.Metric{
         data.WorkingCapital,
         data.TotalLiabilities,
         data.FundamentalsDateKey,
@@ -1447,7 +1447,7 @@ func (s *NCAVE) Compute(ctx context.Context, eng *engine.Engine, port portfolio.
 }
 ```
 
-`FetchByDateKey` returns a single time-axis row at `dateKey`, one value per
+`FetchFundamentalsByDateKey` returns a single time-axis row at `dateKey`, one value per
 asset per metric. Only filings with `event_date <= eng.CurrentDate()` are
 included; assets that have not filed for `dateKey` get NaN. All metrics in
 the call must be fundamentals; non-fundamental metrics return an error.
@@ -1461,7 +1461,7 @@ in `Setup` (defaults to `ARQ`).
 Add under `[Unreleased]` -> `### Added`:
 
 ```markdown
-- Strategies can request a specific fundamentals reporting period with `Engine.FetchByDateKey`. The call returns one row per asset for the given `date_key` (e.g. Q1 boundary), filtered to the engine's configured dimension and to filings public as of `CurrentDate()`.
+- Strategies can request a specific fundamentals reporting period with `Engine.FetchFundamentalsByDateKey`. The call returns one row per asset for the given `date_key` (e.g. Q1 boundary), filtered to the engine's configured dimension and to filings public as of `CurrentDate()`.
 - Two new fundamental metrics expose per-row date metadata: `data.FundamentalsDateKey` (normalized quarter boundary) and `data.FundamentalsReportPeriod` (actual fiscal period end). Values are encoded as Unix seconds in `float64`; convert with `time.Unix(int64(v), 0)`.
 - Snapshots now persist `date_key`, `report_period`, and the configured dimension instead of writing NULL/`"ARQ"` placeholders.
 ```
@@ -1470,7 +1470,7 @@ Add under `[Unreleased]` -> `### Added`:
 
 ```bash
 git add docs/data.md docs/strategy-guide.md CHANGELOG.md
-git commit -m "docs: document FetchByDateKey and fundamentals metadata metrics"
+git commit -m "docs: document FetchFundamentalsByDateKey and fundamentals metadata metrics"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-04-18-fundamentals-metadata.md
+++ b/docs/superpowers/plans/2026-04-18-fundamentals-metadata.md
@@ -1,0 +1,1511 @@
+# Fundamentals Metadata and Date-Key Queries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose `date_key` and `report_period` as DataFrame metrics and add `Engine.FetchByDateKey` so strategies can request a specific reporting period (e.g. NCAVE Q1 working capital).
+
+**Architecture:** Two new fundamental metrics (`FundamentalsDateKey`, `FundamentalsReportPeriod`) encoded as `float64(t.Unix())`. Provider extends `fetchFundamentals` to select the metadata columns and populate them like any other metric. Engine adds `FetchByDateKey` via a new optional capability interface (`FundamentalsByDateKeyProvider`) implemented by `PVDataProvider` and `SnapshotProvider`. Snapshot recorder reads metadata from the DataFrame columns when present and reads the dimension from the wrapped provider via a `Dimension() string` interface.
+
+**Tech Stack:** Go, PostgreSQL (pgx), SQLite (modernc.org/sqlite), Ginkgo/Gomega.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-fundamentals-metadata-design.md`
+
+---
+
+### Task 1: Add `FundamentalsDateKey` and `FundamentalsReportPeriod` metric constants
+
+**Files:**
+- Modify: `data/metric.go`
+- Modify: `data/pvdata_provider.go` (`metricView`, `metricColumn`)
+- Modify: `data/metric_view_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `data/metric_view_test.go` inside the existing `Describe("IsFundamental", ...)` block (after the closing `)` of the last `It`, before the file-end `})`):
+
+```go
+	It("classifies fundamentals metadata metrics as fundamentals", func() {
+		Expect(data.IsFundamental(data.FundamentalsDateKey)).To(BeTrue())
+		Expect(data.IsFundamental(data.FundamentalsReportPeriod)).To(BeTrue())
+	})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+ginkgo run -race --focus "classifies fundamentals metadata metrics" ./data/
+```
+
+Expected: build error or FAIL — `data.FundamentalsDateKey` undefined.
+
+- [ ] **Step 3: Add the constants**
+
+In `data/metric.go`, add a new const block after the "Invested capital metrics" block (after the `)` that closes the `MarketCapFundamental` const, currently at the end of that block):
+
+```go
+// Fundamentals metadata metrics (fundamentals table date columns).
+const (
+	// FundamentalsDateKey is the normalized calendar quarter boundary for
+	// the most recent fundamental filing as of the queried timestamp.
+	// Values are encoded as float64(t.Unix()); convert with
+	// time.Unix(int64(val), 0). NaN means no filing has been observed.
+	FundamentalsDateKey Metric = "FundamentalsDateKey"
+
+	// FundamentalsReportPeriod is the actual fiscal-period end date for
+	// the most recent fundamental filing as of the queried timestamp.
+	// Values are encoded as float64(t.Unix()); convert with
+	// time.Unix(int64(val), 0). NaN means no filing has been observed.
+	FundamentalsReportPeriod Metric = "FundamentalsReportPeriod"
+)
+```
+
+- [ ] **Step 4: Register in `metricView`**
+
+In `data/pvdata_provider.go`, add to the `// fundamentals view` block of `metricView` (immediately before the closing `}`, around line 1010 — alongside the other `"fundamentals"` entries):
+
+```go
+	FundamentalsDateKey:      "fundamentals",
+	FundamentalsReportPeriod: "fundamentals",
+```
+
+- [ ] **Step 5: Register in `metricColumn`**
+
+In `data/pvdata_provider.go`, add to the `metricColumn` map (the map starting at line 1020 — append two new entries):
+
+```go
+	FundamentalsDateKey:      "date_key",
+	FundamentalsReportPeriod: "report_period",
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+```bash
+ginkgo run -race --focus "classifies fundamentals metadata metrics" ./data/
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add data/metric.go data/pvdata_provider.go data/metric_view_test.go
+git commit -m "feat: add FundamentalsDateKey and FundamentalsReportPeriod metrics"
+```
+
+---
+
+### Task 2: Surface `report_period` and metadata cells from `fetchFundamentals`
+
+**Goal:** the SELECT pulls all three date columns (`event_date`, `date_key`, `report_period`); when the request includes `FundamentalsDateKey` or `FundamentalsReportPeriod`, the corresponding date is encoded as `float64(t.Unix())` and stored in the cache the same way Revenue is.
+
+**Files:**
+- Modify: `data/pvdata_provider.go` (`fetchFundamentals`, around lines 647–760)
+
+This task has no unit test — `fetchFundamentals` requires a live PostgreSQL connection. Coverage comes via the snapshot round-trip in Task 4 and the engine integration in Task 7.
+
+- [ ] **Step 1: Read the current implementation**
+
+Read `data/pvdata_provider.go` lines 647–760 to confirm the current scan layout. The current code SELECTs `composite_figi, event_date, date_key, {metric columns}` and scans into `figi`, `eventDate`, `dateKey`, then per-metric float pointers (the `dateKey` value is currently discarded).
+
+- [ ] **Step 2: Filter metadata metrics out of the SQL metric loop**
+
+Inside `fetchFundamentals`, when building `sqlCols`/`metricOrder`, the metadata metrics map to the date columns (`date_key`, `report_period`) which are already pulled by the SELECT separately — they must not be added a second time. Replace the loop that builds `sqlCols`/`metricOrder` with one that skips metadata metrics:
+
+```go
+	for _, metric := range metrics {
+		if metric == FundamentalsDateKey || metric == FundamentalsReportPeriod {
+			continue
+		}
+
+		col, ok := metricColumn[metric]
+		if !ok {
+			continue
+		}
+
+		sqlCols = append(sqlCols, col)
+		metricOrder = append(metricOrder, metric)
+	}
+```
+
+Then track which metadata columns are requested:
+
+```go
+	wantDateKey := false
+	wantReportPeriod := false
+
+	for _, metric := range metrics {
+		switch metric {
+		case FundamentalsDateKey:
+			wantDateKey = true
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+		}
+	}
+```
+
+If `len(sqlCols) == 0 && !wantDateKey && !wantReportPeriod`, return `nil` (current early-return preserved).
+
+- [ ] **Step 3: Add `report_period` to the SELECT**
+
+Replace the `query := fmt.Sprintf(...)` block with:
+
+```go
+	query := fmt.Sprintf(
+		`SELECT composite_figi, event_date, date_key, report_period, %s
+		 FROM fundamentals
+		 WHERE composite_figi = ANY($1) AND event_date BETWEEN $2::date AND $3::date AND dimension = $4
+		 ORDER BY event_date`,
+		strings.Join(sqlCols, ", "),
+	)
+```
+
+If `sqlCols` is empty (only metadata requested), the trailing `, %s` produces `, ` — strip the trailing comma by joining differently:
+
+```go
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
+	query := fmt.Sprintf(
+		`SELECT %s
+		 FROM fundamentals
+		 WHERE composite_figi = ANY($1) AND event_date BETWEEN $2::date AND $3::date AND dimension = $4
+		 ORDER BY event_date`,
+		strings.Join(cols, ", "),
+	)
+```
+
+Use the second form.
+
+- [ ] **Step 4: Update the scan loop**
+
+Replace the existing scan loop body with one that captures `reportPeriod` and stores both metadata values when requested. The full updated scan loop:
+
+```go
+	for rows.Next() {
+		var (
+			figi         string
+			eventDate    time.Time
+			dateKey      time.Time
+			reportPeriod sql.NullTime
+		)
+
+		vals := make([]any, 4+len(sqlCols))
+		vals[0] = &figi
+		vals[1] = &eventDate
+		vals[2] = &dateKey
+		vals[3] = &reportPeriod
+
+		floatVals := make([]*float64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[4+idx] = &floatVals[idx]
+		}
+
+		if err := rows.Scan(vals...); err != nil {
+			return fmt.Errorf("pvdata: scan fundamentals row: %w", err)
+		}
+
+		eventDate = eodTimestamp(eventDate)
+		sec := eventDate.Unix()
+		timeSet[sec] = eventDate
+
+		for idx, m := range metricOrder {
+			if floatVals[idx] != nil {
+				ensureCol(figi, m)[sec] = *floatVals[idx]
+			}
+		}
+
+		if wantDateKey {
+			ensureCol(figi, FundamentalsDateKey)[sec] = float64(dateKey.Unix())
+		}
+
+		if wantReportPeriod && reportPeriod.Valid {
+			ensureCol(figi, FundamentalsReportPeriod)[sec] = float64(reportPeriod.Time.Unix())
+		}
+	}
+```
+
+Add the `database/sql` import to the file if not already imported.
+
+- [ ] **Step 5: Run the data package tests**
+
+```bash
+ginkgo run -race ./data/
+```
+
+Expected: PASS (no behavioral change for callers that don't request the metadata metrics).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add data/pvdata_provider.go
+git commit -m "feat: scan report_period in fetchFundamentals and populate metadata metric cells"
+```
+
+---
+
+### Task 3: Add `Dimension()` accessor on `PVDataProvider`
+
+**Files:**
+- Modify: `data/pvdata_provider.go` (near `SetDimension`)
+
+`NewPVDataProvider` needs a real pgxpool connection or a config file, so a unit test would require integration setup. The recorder test in Task 4 exercises the contract through `dimensionedTestProvider`. A compile-time interface assertion is enough to verify the method exists with the right signature.
+
+- [ ] **Step 1: Implement `Dimension()`**
+
+In `data/pvdata_provider.go`, immediately after the existing `SetDimension` method (around line 140), add:
+
+```go
+// Dimension returns the current fundamental dimension filter.
+func (p *PVDataProvider) Dimension() string {
+	return p.dimension
+}
+```
+
+- [ ] **Step 2: Add a compile-time interface assertion**
+
+In `data/pvdata_provider.go`, near the top of the file (alongside other `var _ ... = (*PVDataProvider)(nil)` assertions if they exist, otherwise after the package-level imports block), add:
+
+```go
+var _ interface{ Dimension() string } = (*PVDataProvider)(nil)
+```
+
+- [ ] **Step 3: Build to verify**
+
+```bash
+go build ./...
+```
+
+Expected: clean build. If the assertion fails to compile, the method signature is wrong.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/pvdata_provider.go
+git commit -m "feat: expose PVDataProvider.Dimension"
+```
+
+---
+
+### Task 4: Snapshot recorder writes real `date_key`, `report_period`, and `dimension`
+
+**Goal:** when the recorded DataFrame includes `FundamentalsDateKey`/`FundamentalsReportPeriod`, persist the actual dates instead of NULL. Replace the hardcoded `"ARQ"` dimension with the wrapped provider's `Dimension()` when available.
+
+**Files:**
+- Modify: `data/snapshot_recorder.go` (around lines 422–510, `recordFundamentals`)
+- Modify: `data/snapshot_recorder_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new `Describe` block to `data/snapshot_recorder_test.go` (place it as a sibling to existing `Describe`s, before the file-end `})`):
+
+```go
+	Describe("fundamentals recording with metadata", func() {
+		It("persists date_key, report_period, and dimension from the wrapped provider", func() {
+			nyc, err := time.LoadLocation("America/New_York")
+			Expect(err).NotTo(HaveOccurred())
+
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			filing := time.Date(2024, 5, 2, 16, 0, 0, 0, nyc)
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, nyc)
+			reportPeriod := time.Date(2024, 3, 30, 0, 0, 0, 0, nyc)
+
+			times := []time.Time{filing}
+			metrics := []data.Metric{
+				data.WorkingCapital,
+				data.FundamentalsDateKey,
+				data.FundamentalsReportPeriod,
+			}
+
+			values := [][]float64{
+				{120_000_000.0},                  // SPY WorkingCapital
+				{float64(dateKey.Unix())},        // SPY FundamentalsDateKey
+				{float64(reportPeriod.Unix())},   // SPY FundamentalsReportPeriod
+			}
+
+			df, err := data.NewDataFrame(times, assets, metrics, data.Daily, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			stub := &dimensionedTestProvider{
+				TestProvider: data.NewTestProvider(metrics, df),
+				dimension:    "MRQ",
+			}
+
+			recorder, err = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: stub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = recorder.Fetch(ctx, data.DataRequest{
+				Assets:    assets,
+				Metrics:   metrics,
+				Start:     filing,
+				End:       filing,
+				Frequency: data.Daily,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.Close()).To(Succeed())
+			recorder = nil
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer db.Close()
+
+			var (
+				dateKeyStr, reportPeriodStr, dimStr string
+				wc                                   float64
+			)
+			err = db.QueryRow(
+				`SELECT date_key, report_period, dimension, working_capital
+				   FROM fundamentals
+				  WHERE composite_figi = ?`,
+				spy.CompositeFigi,
+			).Scan(&dateKeyStr, &reportPeriodStr, &dimStr, &wc)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dateKeyStr).To(Equal("2024-03-31"))
+			Expect(reportPeriodStr).To(Equal("2024-03-30"))
+			Expect(dimStr).To(Equal("MRQ"))
+			Expect(wc).To(BeNumerically("==", 120_000_000.0))
+		})
+
+		It("writes NULL date_key/report_period when the DataFrame omits them", func() {
+			nyc, err := time.LoadLocation("America/New_York")
+			Expect(err).NotTo(HaveOccurred())
+
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+
+			filing := time.Date(2024, 5, 2, 16, 0, 0, 0, nyc)
+			times := []time.Time{filing}
+			metrics := []data.Metric{data.WorkingCapital}
+			values := [][]float64{{120_000_000.0}}
+
+			df, err := data.NewDataFrame(times, assets, metrics, data.Daily, values)
+			Expect(err).NotTo(HaveOccurred())
+
+			stub := data.NewTestProvider(metrics, df) // no Dimension() method
+
+			recorder, err = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: stub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = recorder.Fetch(ctx, data.DataRequest{
+				Assets:    assets,
+				Metrics:   metrics,
+				Start:     filing,
+				End:       filing,
+				Frequency: data.Daily,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.Close()).To(Succeed())
+			recorder = nil
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer db.Close()
+
+			var (
+				dateKeyNull, reportPeriodNull sql.NullString
+				dimStr                        string
+			)
+			err = db.QueryRow(
+				`SELECT date_key, report_period, dimension
+				   FROM fundamentals
+				  WHERE composite_figi = ?`,
+				spy.CompositeFigi,
+			).Scan(&dateKeyNull, &reportPeriodNull, &dimStr)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dateKeyNull.Valid).To(BeFalse())
+			Expect(reportPeriodNull.Valid).To(BeFalse())
+			Expect(dimStr).To(Equal("ARQ")) // fallback default
+		})
+	})
+```
+
+Add a small helper type at the bottom of the same file (outside any `Describe`):
+
+```go
+type dimensionedTestProvider struct {
+	*data.TestProvider
+	dimension string
+}
+
+func (p *dimensionedTestProvider) Dimension() string { return p.dimension }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+ginkgo run -race --focus "fundamentals recording with metadata" ./data/
+```
+
+Expected: FAIL — current recorder writes NULL for `date_key`/`report_period` and hardcodes `"ARQ"`.
+
+- [ ] **Step 3: Update `recordFundamentals` to read metadata + dimension**
+
+In `data/snapshot_recorder.go`, modify `recordFundamentals` (lines ~422–510). Two changes:
+
+a) Detect metadata-metric column indices in the DataFrame (using the existing `mIdx` map):
+
+```go
+	dateKeyDFIdx, hasDateKey := mIdx[FundamentalsDateKey]
+	reportPeriodDFIdx, hasReportPeriod := mIdx[FundamentalsReportPeriod]
+```
+
+(Place these immediately after `mIdx` is built, around line 428.)
+
+b) Read the dimension from the wrapped provider; fall back to `"ARQ"`:
+
+Replace the existing `args[4] = "ARQ"` line with:
+
+```go
+	dimension := "ARQ"
+	if dp, ok := r.batchProvider.(interface{ Dimension() string }); ok {
+		if dim := dp.Dimension(); dim != "" {
+			dimension = dim
+		}
+	}
+```
+
+(Place this once outside the per-row loop — immediately before the `for assetIdx, a := range df.assets {` loop.)
+
+c) Inside the per-row loop, replace the two `args[2] = nil` / `args[3] = nil` lines with a lookup against the DataFrame:
+
+```go
+				args[2] = nil
+				if hasDateKey {
+					raw := df.columns[assetIdx*numDFMetrics+dateKeyDFIdx][timeIdx]
+					if !math.IsNaN(raw) {
+						args[2] = time.Unix(int64(raw), 0).UTC().Format("2006-01-02")
+					}
+				}
+
+				args[3] = nil
+				if hasReportPeriod {
+					raw := df.columns[assetIdx*numDFMetrics+reportPeriodDFIdx][timeIdx]
+					if !math.IsNaN(raw) {
+						args[3] = time.Unix(int64(raw), 0).UTC().Format("2006-01-02")
+					}
+				}
+
+				args[4] = dimension
+```
+
+Note: `df.columns` is a package-private field. Since `recordFundamentals` is in package `data`, the access is fine.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+ginkgo run -race --focus "fundamentals recording with metadata" ./data/
+```
+
+Expected: PASS for both `It` blocks.
+
+- [ ] **Step 5: Run full data tests for regressions**
+
+```bash
+ginkgo run -race ./data/
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add data/snapshot_recorder.go data/snapshot_recorder_test.go
+git commit -m "feat: snapshot recorder persists date_key, report_period, and dimension"
+```
+
+---
+
+### Task 5: Add `FundamentalsByDateKeyProvider` capability and implement on `PVDataProvider`
+
+**Goal:** define the optional provider interface, implement the SQL on `PVDataProvider`. Engine integration is Task 7.
+
+**Files:**
+- Modify: `data/data_provider.go`
+- Modify: `data/pvdata_provider.go`
+- Create: no new test file (covered by integration tests in Task 7)
+
+- [ ] **Step 1: Define the interface**
+
+In `data/data_provider.go`, append at end of file:
+
+```go
+// FundamentalsByDateKeyProvider is implemented by providers that can
+// return fundamentals filtered to a specific reporting period (date_key).
+// The engine type-asserts on this interface from FetchByDateKey.
+type FundamentalsByDateKeyProvider interface {
+	// FetchFundamentalsByDateKey returns one row per asset for the given
+	// date_key + dimension. Only filings with event_date <= maxEventDate
+	// are included (point-in-time correctness). For dimensions where a
+	// single (figi, date_key) can have multiple filings (MR restatements),
+	// the row with the maximum event_date wins.
+	//
+	// metrics must contain only fundamental metrics. Metadata metrics
+	// (FundamentalsDateKey, FundamentalsReportPeriod) populate from the
+	// row's date_key/report_period columns.
+	FetchFundamentalsByDateKey(
+		ctx context.Context,
+		assets []asset.Asset,
+		metrics []Metric,
+		dateKey time.Time,
+		dimension string,
+		maxEventDate time.Time,
+	) (*DataFrame, error)
+}
+```
+
+Add the necessary imports if missing (`context`, `time`, `github.com/penny-vault/pvbt/asset`).
+
+- [ ] **Step 2: Implement on `PVDataProvider`**
+
+In `data/pvdata_provider.go`, append at end of file:
+
+```go
+// FetchFundamentalsByDateKey implements FundamentalsByDateKeyProvider.
+func (p *PVDataProvider) FetchFundamentalsByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []Metric,
+	dateKey time.Time,
+	dimension string,
+	maxEventDate time.Time,
+) (*DataFrame, error) {
+	figis := make([]string, len(assets))
+	for idx, a := range assets {
+		figis[idx] = a.CompositeFigi
+	}
+
+	var (
+		sqlCols     []string
+		metricOrder []Metric
+	)
+
+	wantDateKey := false
+	wantReportPeriod := false
+
+	for _, m := range metrics {
+		switch m {
+		case FundamentalsDateKey:
+			wantDateKey = true
+			continue
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+			continue
+		}
+
+		col, ok := metricColumn[m]
+		if !ok {
+			return nil, fmt.Errorf("pvdata: no SQL column for fundamental metric %q", m)
+		}
+
+		sqlCols = append(sqlCols, col)
+		metricOrder = append(metricOrder, m)
+	}
+
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
+	// DISTINCT ON (composite_figi) keeps the most recent event_date per
+	// asset, which matters for MR dimensions where a single (figi,
+	// date_key) tuple may appear multiple times due to restatements.
+	query := fmt.Sprintf(
+		`SELECT DISTINCT ON (composite_figi) %s
+		 FROM fundamentals
+		 WHERE composite_figi = ANY($1)
+		   AND date_key = $2::date
+		   AND dimension = $3
+		   AND event_date <= $4::date
+		 ORDER BY composite_figi, event_date DESC`,
+		strings.Join(cols, ", "),
+	)
+
+	conn, err := p.pool.Acquire(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pvdata: acquire conn for FetchFundamentalsByDateKey: %w", err)
+	}
+	defer conn.Release()
+
+	rows, err := conn.Query(ctx, query, figis, dateKey, dimension, maxEventDate)
+	if err != nil {
+		return nil, fmt.Errorf("pvdata: query fundamentals by date_key: %w", err)
+	}
+	defer rows.Close()
+
+	// Build a per-figi value map: figi -> metric -> float64.
+	perFigi := make(map[string]map[Metric]float64, len(assets))
+
+	for rows.Next() {
+		var (
+			figi         string
+			eventDate    time.Time
+			rowDateKey   time.Time
+			reportPeriod sql.NullTime
+		)
+
+		vals := make([]any, 4+len(sqlCols))
+		vals[0] = &figi
+		vals[1] = &eventDate
+		vals[2] = &rowDateKey
+		vals[3] = &reportPeriod
+
+		floatVals := make([]*float64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[4+idx] = &floatVals[idx]
+		}
+
+		if err := rows.Scan(vals...); err != nil {
+			return nil, fmt.Errorf("pvdata: scan fundamentals by date_key row: %w", err)
+		}
+
+		bucket, ok := perFigi[figi]
+		if !ok {
+			bucket = make(map[Metric]float64, len(metrics))
+			perFigi[figi] = bucket
+		}
+
+		for idx, m := range metricOrder {
+			if floatVals[idx] != nil {
+				bucket[m] = *floatVals[idx]
+			}
+		}
+
+		if wantDateKey {
+			bucket[FundamentalsDateKey] = float64(rowDateKey.Unix())
+		}
+
+		if wantReportPeriod && reportPeriod.Valid {
+			bucket[FundamentalsReportPeriod] = float64(reportPeriod.Time.Unix())
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("pvdata: iterate fundamentals by date_key rows: %w", err)
+	}
+
+	// Assemble a single-row DataFrame at dateKey.
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, a := range assets {
+		bucket := perFigi[a.CompositeFigi]
+		for mIdx, m := range metrics {
+			val := math.NaN()
+			if bucket != nil {
+				if v, ok := bucket[m]; ok {
+					val = v
+				}
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return NewDataFrame(times, assets, metrics, Daily, columns)
+}
+```
+
+Required imports to confirm in `data/pvdata_provider.go`: `database/sql`, `math`. Add if missing.
+
+- [ ] **Step 3: Build to verify compile**
+
+```bash
+go build ./...
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add data/data_provider.go data/pvdata_provider.go
+git commit -m "feat: add FundamentalsByDateKeyProvider interface and PVDataProvider impl"
+```
+
+---
+
+### Task 6: Implement `SnapshotProvider.FetchFundamentalsByDateKey` for snapshot replay
+
+**Files:**
+- Modify: `data/snapshot_provider.go`
+
+The snapshot provider must implement the same interface so that snapshot-replayed backtests support `FetchByDateKey`.
+
+- [ ] **Step 1: Append the implementation**
+
+At the end of `data/snapshot_provider.go`, add:
+
+```go
+// FetchFundamentalsByDateKey implements FundamentalsByDateKeyProvider for
+// snapshot replay. The query mirrors the PVDataProvider implementation but
+// uses SQLite syntax (no DISTINCT ON; row_number window function instead).
+func (p *SnapshotProvider) FetchFundamentalsByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []Metric,
+	dateKey time.Time,
+	dimension string,
+	maxEventDate time.Time,
+) (*DataFrame, error) {
+	figis := make([]string, len(assets))
+	for idx, a := range assets {
+		figis[idx] = a.CompositeFigi
+	}
+
+	var (
+		sqlCols     []string
+		metricOrder []Metric
+	)
+
+	wantDateKey := false
+	wantReportPeriod := false
+
+	for _, m := range metrics {
+		switch m {
+		case FundamentalsDateKey:
+			wantDateKey = true
+			continue
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+			continue
+		}
+
+		col, ok := metricColumn[m]
+		if !ok {
+			return nil, fmt.Errorf("snapshot: no SQL column for fundamental metric %q", m)
+		}
+
+		sqlCols = append(sqlCols, col)
+		metricOrder = append(metricOrder, m)
+	}
+
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
+	placeholders := make([]string, len(figis))
+	for idx := range figis {
+		placeholders[idx] = "?"
+	}
+
+	dateKeyStr := dateKey.UTC().Format("2006-01-02")
+	maxEventStr := maxEventDate.UTC().Format("2006-01-02")
+
+	// SQLite ranks by event_date DESC and picks rank 1 per figi.
+	query := fmt.Sprintf(
+		`SELECT %s FROM (
+		    SELECT %s,
+		           row_number() OVER (PARTITION BY composite_figi ORDER BY event_date DESC) AS rn
+		      FROM fundamentals
+		     WHERE composite_figi IN (%s)
+		       AND date_key = ?
+		       AND dimension = ?
+		       AND event_date <= ?
+		 ) WHERE rn = 1`,
+		strings.Join(cols, ", "),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	args := make([]any, 0, len(figis)+3)
+	for _, f := range figis {
+		args = append(args, f)
+	}
+
+	args = append(args, dateKeyStr, dimension, maxEventStr)
+
+	rows, err := p.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot: query fundamentals by date_key: %w", err)
+	}
+	defer rows.Close()
+
+	perFigi := make(map[string]map[Metric]float64, len(assets))
+
+	for rows.Next() {
+		var (
+			figi             string
+			eventDateStr     string
+			rowDateKeyStr    sql.NullString
+			reportPeriodStr  sql.NullString
+		)
+
+		vals := make([]any, 4+len(sqlCols))
+		vals[0] = &figi
+		vals[1] = &eventDateStr
+		vals[2] = &rowDateKeyStr
+		vals[3] = &reportPeriodStr
+
+		floatVals := make([]sql.NullFloat64, len(sqlCols))
+		for idx := range sqlCols {
+			vals[4+idx] = &floatVals[idx]
+		}
+
+		if err := rows.Scan(vals...); err != nil {
+			return nil, fmt.Errorf("snapshot: scan fundamentals by date_key row: %w", err)
+		}
+
+		bucket, ok := perFigi[figi]
+		if !ok {
+			bucket = make(map[Metric]float64, len(metrics))
+			perFigi[figi] = bucket
+		}
+
+		for idx, m := range metricOrder {
+			if floatVals[idx].Valid {
+				bucket[m] = floatVals[idx].Float64
+			}
+		}
+
+		if wantDateKey && rowDateKeyStr.Valid {
+			parsed, parseErr := parseSnapshotDate(rowDateKeyStr.String)
+			if parseErr != nil {
+				return nil, fmt.Errorf("snapshot: parse date_key %q: %w", rowDateKeyStr.String, parseErr)
+			}
+
+			bucket[FundamentalsDateKey] = float64(parsed.Unix())
+		}
+
+		if wantReportPeriod && reportPeriodStr.Valid {
+			parsed, parseErr := parseSnapshotDate(reportPeriodStr.String)
+			if parseErr != nil {
+				return nil, fmt.Errorf("snapshot: parse report_period %q: %w", reportPeriodStr.String, parseErr)
+			}
+
+			bucket[FundamentalsReportPeriod] = float64(parsed.Unix())
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("snapshot: iterate fundamentals by date_key rows: %w", err)
+	}
+
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, a := range assets {
+		bucket := perFigi[a.CompositeFigi]
+		for mIdx, m := range metrics {
+			val := math.NaN()
+			if bucket != nil {
+				if v, ok := bucket[m]; ok {
+					val = v
+				}
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return NewDataFrame(times, assets, metrics, Daily, columns)
+}
+```
+
+Confirm `database/sql`, `math`, `context`, `time`, `fmt`, `strings`, and `github.com/penny-vault/pvbt/asset` are all imported. The file should already have all of them from existing code.
+
+- [ ] **Step 2: Build to verify compile**
+
+```bash
+go build ./...
+```
+
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add data/snapshot_provider.go
+git commit -m "feat: add SnapshotProvider.FetchFundamentalsByDateKey for replay"
+```
+
+---
+
+### Task 7: Implement `Engine.FetchByDateKey`
+
+**Files:**
+- Modify: `engine/engine.go`
+- Create: `engine/fetch_by_date_key_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `engine/fetch_by_date_key_test.go`:
+
+```go
+package engine_test
+
+import (
+	"context"
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+type fetchByDateKeyStrategy struct {
+	assets   []asset.Asset
+	metrics  []data.Metric
+	dateKey  time.Time
+	fetched  *data.DataFrame
+	fetchErr error
+}
+
+func (s *fetchByDateKeyStrategy) Name() string { return "fetchByDateKeyStrategy" }
+
+func (s *fetchByDateKeyStrategy) Setup(*engine.Engine) {}
+
+func (s *fetchByDateKeyStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5"}
+}
+
+func (s *fetchByDateKeyStrategy) Compute(ctx context.Context, eng *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	s.fetched, s.fetchErr = eng.FetchByDateKey(ctx, s.assets, s.metrics, s.dateKey)
+	return nil
+}
+
+// fakeByDateKeyProvider is a small in-memory FundamentalsByDateKeyProvider.
+type fakeByDateKeyProvider struct {
+	*data.TestProvider
+	rows map[string]map[time.Time]map[data.Metric]float64 // figi -> dateKey -> metric -> value
+}
+
+func (p *fakeByDateKeyProvider) FetchFundamentalsByDateKey(
+	_ context.Context,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	dateKey time.Time,
+	_ string,
+	_ time.Time,
+) (*data.DataFrame, error) {
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, a := range assets {
+		assetRows := p.rows[a.CompositeFigi]
+		for mIdx, m := range metrics {
+			val := math.NaN()
+			if assetRows != nil {
+				if dayMetrics, ok := assetRows[dateKey]; ok {
+					if v, ok := dayMetrics[m]; ok {
+						val = v
+					}
+				}
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return data.NewDataFrame(times, assets, metrics, data.Daily, columns)
+}
+
+var _ = Describe("Engine.FetchByDateKey", func() {
+	var assetProv *mockAssetProvider
+
+	BeforeEach(func() {
+		assetProv = &mockAssetProvider{}
+	})
+
+	It("returns the requested fundamentals at the date_key", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		msft := asset.Asset{CompositeFigi: "FIGI-MSFT", Ticker: "MSFT"}
+		testAssets := []asset.Asset{spy, msft}
+		assetProv.assets = testAssets
+
+		q1 := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital, data.FundamentalsDateKey},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{
+				spy.CompositeFigi: {
+					q1: {
+						data.WorkingCapital:      120_000_000,
+						data.FundamentalsDateKey: float64(q1.Unix()),
+					},
+				},
+				msft.CompositeFigi: {
+					q1: {
+						data.WorkingCapital:      80_000_000,
+						data.FundamentalsDateKey: float64(q1.Unix()),
+					},
+				},
+			},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital, data.FundamentalsDateKey},
+			dateKey: q1,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simDate := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+		spyWC := strategy.fetched.Column(spy, data.WorkingCapital)
+		Expect(spyWC).To(HaveLen(1))
+		Expect(spyWC[0]).To(BeNumerically("==", 120_000_000))
+
+		msftWC := strategy.fetched.Column(msft, data.WorkingCapital)
+		Expect(msftWC).To(HaveLen(1))
+		Expect(msftWC[0]).To(BeNumerically("==", 80_000_000))
+
+		spyDK := strategy.fetched.Column(spy, data.FundamentalsDateKey)
+		Expect(time.Unix(int64(spyDK[0]), 0).UTC()).To(Equal(q1))
+	})
+
+	It("returns NaN for assets with no filing at the date_key", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		msft := asset.Asset{CompositeFigi: "FIGI-MSFT", Ticker: "MSFT"}
+		testAssets := []asset.Asset{spy, msft}
+		assetProv.assets = testAssets
+
+		q1 := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{
+				spy.CompositeFigi: {
+					q1: {data.WorkingCapital: 120_000_000},
+				},
+				// MSFT has no Q1 row.
+			},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: q1,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simDate := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+		msftWC := strategy.fetched.Column(msft, data.WorkingCapital)
+		Expect(math.IsNaN(msftWC[0])).To(BeTrue())
+	})
+
+	It("errors when a non-fundamental metric is requested", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 30, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital, data.MetricClose},
+			dateKey: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simDate := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).To(HaveOccurred())
+		Expect(strategy.fetchErr.Error()).To(ContainSubstring("not a fundamental metric"))
+	})
+
+	It("errors when no provider supports FundamentalsByDateKey", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 30, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+		fundProvider := data.NewTestProvider(
+			[]data.Metric{data.WorkingCapital},
+			mustEmptyFundDF(testAssets),
+		)
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simDate := time.Date(2024, 6, 15, 0, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simDate, simDate)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).To(HaveOccurred())
+		Expect(strategy.fetchErr.Error()).To(ContainSubstring("no provider supports"))
+	})
+})
+
+// mustEmptyFundDF returns an empty fundamentals DataFrame for use as a
+// TestProvider seed. Real values come from fakeByDateKeyProvider.rows.
+func mustEmptyFundDF(assets []asset.Asset) *data.DataFrame {
+	df, err := data.NewDataFrame(
+		nil,
+		assets,
+		[]data.Metric{data.WorkingCapital, data.FundamentalsDateKey},
+		data.Daily,
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return df
+}
+```
+
+Helpers used: `makeDailyDF` (engine test helpers, used by `dimension_test.go`), `mockAssetProvider` (`engine/backtest_test.go:37`). Both are in the same test package; no import needed.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+ginkgo run -race --focus "Engine.FetchByDateKey" ./engine/
+```
+
+Expected: build error — `eng.FetchByDateKey` undefined.
+
+- [ ] **Step 3: Implement `FetchByDateKey`**
+
+In `engine/engine.go`, append after the `FetchAt` method (around line 351):
+
+```go
+// FetchByDateKey returns fundamental data for a specific reporting period.
+// dateKey identifies the normalized quarter boundary (e.g. 2024-03-31 for
+// Q1 2024). All metrics must be fundamentals; non-fundamental metrics
+// produce an error. Subject to point-in-time correctness: only filings
+// with event_date <= eng.CurrentDate() are included. Assets that have not
+// filed for dateKey as of CurrentDate get NaN values.
+func (e *Engine) FetchByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	dateKey time.Time,
+) (*data.DataFrame, error) {
+	for _, m := range metrics {
+		if !data.IsFundamental(m) {
+			return nil, fmt.Errorf("FetchByDateKey: metric %q is not a fundamental metric", m)
+		}
+	}
+
+	dimension := e.fundamentalDimension
+	if dimension == "" {
+		dimension = "ARQ"
+	}
+
+	for _, provider := range e.providers {
+		if dp, ok := provider.(data.FundamentalsByDateKeyProvider); ok {
+			df, err := dp.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, dimension, e.currentDate)
+			if err != nil {
+				return nil, fmt.Errorf("FetchByDateKey: %w", err)
+			}
+
+			df.SetSource(e)
+
+			return df, nil
+		}
+	}
+
+	return nil, fmt.Errorf("FetchByDateKey: no provider supports FundamentalsByDateKeyProvider")
+}
+```
+
+The engine struct's provider slice is `e.providers []data.DataProvider` (`engine/engine.go:39`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+ginkgo run -race --focus "Engine.FetchByDateKey" ./engine/
+```
+
+Expected: PASS for all four `It` blocks.
+
+- [ ] **Step 5: Run full engine test suite**
+
+```bash
+ginkgo run -race ./engine/
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add engine/engine.go engine/fetch_by_date_key_test.go
+git commit -m "feat: add Engine.FetchByDateKey for reporting-period fundamentals queries"
+```
+
+---
+
+### Task 8: Verify forward-fill carries metadata metrics through `Fetch`/`FetchAt`
+
+**Goal:** confirm that requesting `FundamentalsDateKey` alongside Revenue in a regular `Fetch` call returns the date_key forward-filled across non-filing days. No production code change expected — the existing forward-fill in `engine/engine.go` runs on any metric for which `data.IsFundamental` is true.
+
+**Files:**
+- Modify: `engine/fetch_test.go`
+
+- [ ] **Step 1: Write the test**
+
+Append to `engine/fetch_test.go` inside the existing `Context("with sparse fundamental data", ...)` block (after the last `It`, before the closing `})` of the Context):
+
+```go
+		It("forward-fills FundamentalsDateKey alongside the value", func() {
+			spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+			fundamentalAssets := []asset.Asset{spy}
+			assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+			closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			closeDF := makeDailyDF(closeStart, 90, fundamentalAssets, []data.Metric{data.MetricClose})
+			closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+			filingDate := time.Date(2024, 2, 1, 16, 0, 0, 0, time.UTC)
+			dateKey := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC) // Q4 2023 filing on Feb 1
+
+			fundDF, err := data.NewDataFrame(
+				[]time.Time{filingDate},
+				fundamentalAssets,
+				[]data.Metric{data.Revenue, data.FundamentalsDateKey},
+				data.Daily,
+				[][]float64{
+					{500_000_000},
+					{float64(dateKey.Unix())},
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			fundProvider := data.NewTestProvider(
+				[]data.Metric{data.Revenue, data.FundamentalsDateKey},
+				fundDF,
+			)
+
+			strategy := &fetchStrategy{
+				lookback: portfolio.Days(30),
+				metrics:  []data.Metric{data.MetricClose, data.Revenue, data.FundamentalsDateKey},
+				assets:   fundamentalAssets,
+			}
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(closeProvider, fundProvider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			)
+
+			simDate := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+			_, btErr := eng.Backtest(context.Background(), simDate, simDate)
+			Expect(btErr).NotTo(HaveOccurred())
+			Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+			dkCol := strategy.fetched.Column(spy, data.FundamentalsDateKey)
+			Expect(len(dkCol)).To(BeNumerically(">", 1))
+
+			expected := float64(dateKey.Unix())
+			for _, v := range dkCol {
+				Expect(v).To(BeNumerically("==", expected))
+			}
+		})
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+ginkgo run -race --focus "forward-fills FundamentalsDateKey" ./engine/
+```
+
+Expected: PASS (no production change — Task 1 already classified the metric as fundamental, so forward-fill applies automatically).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add engine/fetch_test.go
+git commit -m "test: cover forward-fill of FundamentalsDateKey through Fetch"
+```
+
+---
+
+### Task 9: Documentation
+
+**Files:**
+- Modify: `docs/data.md`
+- Modify: `docs/strategy-guide.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update `docs/data.md`**
+
+Find the existing "Fundamental data semantics" section (added by the prior plan). Append the following subsection at the end of that section:
+
+```markdown
+#### Reading the date metadata
+
+`event_date` is exposed as the DataFrame's time axis for fundamental fetches.
+`date_key` and `report_period` are exposed as two metrics:
+
+- `data.FundamentalsDateKey` -- normalized calendar quarter boundary.
+- `data.FundamentalsReportPeriod` -- actual fiscal period end as reported.
+
+Both are encoded as `float64(t.Unix())`. Convert with the standard library:
+
+```go
+dk := time.Unix(int64(df.Value(spy, data.FundamentalsDateKey, t)), 0)
+```
+
+NaN means no filing has been observed for that asset as of `t`. The engine
+forward-fills these metrics the same way as Revenue, WorkingCapital, etc., so
+the metadata travels with whatever value the strategy reads.
+```
+
+- [ ] **Step 2: Update `docs/strategy-guide.md`**
+
+Append a new section after the existing "Fundamental dimension" section:
+
+```markdown
+### Querying a specific reporting period
+
+When a strategy needs values for a particular fiscal quarter (e.g. Q1
+working capital across all candidates), use `Engine.FetchByDateKey`:
+
+```go
+func (s *NCAVE) Compute(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
+    q1 := mostRecentQ1(eng.CurrentDate())
+
+    df, err := eng.FetchByDateKey(ctx, s.universe, []data.Metric{
+        data.WorkingCapital,
+        data.TotalLiabilities,
+        data.FundamentalsDateKey,
+    }, q1)
+    if err != nil {
+        return err
+    }
+
+    for _, candidate := range s.universe {
+        wc := df.Value(candidate, data.WorkingCapital, q1)
+        if math.IsNaN(wc) {
+            continue // candidate has not filed Q1 yet as of CurrentDate
+        }
+
+        // ... use wc, df.Value(candidate, data.TotalLiabilities, q1), etc.
+    }
+
+    return nil
+}
+```
+
+`FetchByDateKey` returns a single time-axis row at `dateKey`, one value per
+asset per metric. Only filings with `event_date <= eng.CurrentDate()` are
+included; assets that have not filed for `dateKey` get NaN. All metrics in
+the call must be fundamentals; non-fundamental metrics return an error.
+
+The dimension used is whatever the strategy set with `SetFundamentalDimension`
+in `Setup` (defaults to `ARQ`).
+```
+
+- [ ] **Step 3: Update `CHANGELOG.md`**
+
+Add under `[Unreleased]` -> `### Added`:
+
+```markdown
+- Strategies can request a specific fundamentals reporting period with `Engine.FetchByDateKey`. The call returns one row per asset for the given `date_key` (e.g. Q1 boundary), filtered to the engine's configured dimension and to filings public as of `CurrentDate()`.
+- Two new fundamental metrics expose per-row date metadata: `data.FundamentalsDateKey` (normalized quarter boundary) and `data.FundamentalsReportPeriod` (actual fiscal period end). Values are encoded as Unix seconds in `float64`; convert with `time.Unix(int64(v), 0)`.
+- Snapshots now persist `date_key`, `report_period`, and the configured dimension instead of writing NULL/`"ARQ"` placeholders.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/data.md docs/strategy-guide.md CHANGELOG.md
+git commit -m "docs: document FetchByDateKey and fundamentals metadata metrics"
+```
+
+---
+
+### Task 10: Final verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+ginkgo run -race ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Lint**
+
+```bash
+golangci-lint run ./...
+```
+
+Expected: 0 issues. Fix anything reported (no `//nolint` directives — fix the underlying issue per project convention).
+
+- [ ] **Step 3: Build**
+
+```bash
+go build ./...
+```
+
+Expected: clean build.
+
+- [ ] **Step 4: If any fixes were needed, commit them**
+
+```bash
+git add -A
+git commit -m "fix: address lint or test issues from fundamentals metadata changes"
+```

--- a/docs/superpowers/plans/2026-04-18-fundamentals-metadata.md
+++ b/docs/superpowers/plans/2026-04-18-fundamentals-metadata.md
@@ -185,7 +185,7 @@ Replace the existing scan loop body with one that captures `reportPeriod` and st
 		var (
 			figi         string
 			eventDate    time.Time
-			dateKey      time.Time
+			dateKey      sql.NullTime
 			reportPeriod sql.NullTime
 		)
 
@@ -214,8 +214,8 @@ Replace the existing scan loop body with one that captures `reportPeriod` and st
 			}
 		}
 
-		if wantDateKey {
-			ensureCol(figi, FundamentalsDateKey)[sec] = float64(dateKey.Unix())
+		if wantDateKey && dateKey.Valid {
+			ensureCol(figi, FundamentalsDateKey)[sec] = float64(dateKey.Time.Unix())
 		}
 
 		if wantReportPeriod && reportPeriod.Valid {

--- a/docs/superpowers/specs/2026-04-18-fundamentals-metadata-design.md
+++ b/docs/superpowers/specs/2026-04-18-fundamentals-metadata-design.md
@@ -1,0 +1,92 @@
+# Fundamentals Metadata and Date-Key Queries
+
+## Problem
+
+The 2026-04-10 point-in-time work deferred two pieces:
+
+1. **Metadata exposure.** The `fundamentals` table has three date columns -- `event_date` (filing date), `date_key` (normalized calendar quarter boundary), and `report_period` (actual fiscal period end). Only `event_date` is exposed to strategies (it lives on the DataFrame's time axis). `date_key` is read from SQL by `fetchFundamentals` but discarded after scan. `report_period` is not selected at all. The snapshot recorder has columns for both but writes NULL.
+
+2. **Reporting-period queries.** Strategies cannot ask for "Q1 working capital." After forward-fill, every daily timestamp carries the most recent fundamental value, but the strategy has no way to know which fiscal period that value belongs to, and no way to filter to a specific period. The first concrete need is the NCAVE strategy: it requires Q1 working capital, which is the most recent filing whose `date_key` matches Q1 of the current fiscal year (subject to the filing being public as of the simulation date).
+
+## Design
+
+### 1. Two new metrics
+
+Add `data.FundamentalsDateKey` and `data.FundamentalsReportPeriod` as ordinary `Metric` values alongside the other fundamentals (`data/metric.go`). Names use the `Fundamentals` prefix to avoid collision with the existing `data.DateKey()` helper that converts `time.Time` to YYYYMMDD.
+
+Both are routed through `metricView` to the `"fundamentals"` view. `IsFundamental` returns true for them. The engine's existing forward-fill applies, so the metadata travels with the value: at any daily timestamp, the value of `FundamentalsDateKey` for asset A is the date_key of the most recent filing for A as of that timestamp.
+
+**Encoding.** Stored as `float64(t.Unix())`. Strategies round-trip with `time.Unix(int64(df.Value(asset, data.FundamentalsDateKey, t)), 0)`. No custom helper. NaN means no filing has been observed.
+
+### 2. Provider changes
+
+Add `report_period` to the `fetchFundamentals` SELECT, and register both new metrics in `metricColumn`:
+
+```go
+metricColumn[FundamentalsDateKey]      = "date_key"
+metricColumn[FundamentalsReportPeriod] = "report_period"
+```
+
+`fetchFundamentals` already special-cases `event_date` and `date_key` outside the metric loop. Refactor so all three date columns are scanned generically: when a request includes `FundamentalsDateKey` or `FundamentalsReportPeriod`, the date column is converted to `float64(t.Unix())` and stored in the cache exactly like a regular metric value. When the request does not include them, no extra cost.
+
+### 3. Engine: `FetchByDateKey`
+
+```go
+func (e *Engine) FetchByDateKey(
+    ctx context.Context,
+    assets []asset.Asset,
+    metrics []data.Metric,
+    dateKey time.Time,
+) (*data.DataFrame, error)
+```
+
+Behavior:
+
+- Validates that every metric in `metrics` is fundamental (`data.IsFundamental(m)`). Returns `fmt.Errorf("FetchByDateKey: metric %q is not a fundamental metric", m)` otherwise.
+- Uses the engine's configured dimension (set via `SetFundamentalDimension`).
+- Returns a DataFrame with a single time-axis row at `dateKey`. One value per asset per metric.
+- SQL filter: `dimension = $1 AND date_key = $2 AND event_date <= $3`, where `$3` is `eng.CurrentDate()`. For MR dimensions a single asset can have multiple matching rows (restatements); take the row with the maximum `event_date` per asset (`DISTINCT ON (composite_figi)` with `ORDER BY composite_figi, event_date DESC` on PostgreSQL; equivalent window function on SQLite for snapshot replay).
+- Assets that have not filed for `dateKey` as of `CurrentDate()` get NaN values. The strategy filters with `math.IsNaN`.
+
+`FetchByDateKey` reuses the existing column cache: the cache key gains a `dateKey` discriminator alongside the existing `(figi, metric, dimension)` tuple so that range queries and date-key queries do not collide.
+
+### 4. Existing `Fetch` and `FetchAt`
+
+No new methods or arguments. `Fetch`/`FetchAt` callers gain access to `FundamentalsDateKey` and `FundamentalsReportPeriod` simply by including them in the metric list. They flow through the same forward-fill path as Revenue, WorkingCapital, etc.
+
+### 5. Snapshot recorder
+
+`recordFundamentals` (`data/snapshot_recorder.go`) currently writes `nil` for `date_key` and `report_period`. Change it to read those values from the DataFrame's `FundamentalsDateKey`/`FundamentalsReportPeriod` columns when present:
+
+- If the DataFrame includes `FundamentalsDateKey`, read the float for the (asset, time) cell, convert to `time.Time` via `time.Unix`, format as `2006-01-02`, write to the `date_key` column. NaN -> NULL.
+- Same for `FundamentalsReportPeriod`.
+- If the DataFrame does not include those columns, write NULL (current behavior). Snapshots taken without explicitly requesting metadata stay backward-compatible.
+
+The `dimension` column written by the recorder also stops being hardcoded `"ARQ"`. The recorder reads it from the wrapped batch provider via a `Dimension() string` interface (`PVDataProvider` implements it; the existing `SetDimension` already mutates the same field). Providers that do not implement the interface fall back to `"ARQ"` so existing code paths still work.
+
+### 6. Documentation
+
+- `docs/data.md`: document `FundamentalsDateKey` and `FundamentalsReportPeriod` as metrics, including the Unix-seconds encoding and the `time.Unix(int64(...), 0)` round-trip pattern.
+- `docs/strategy-guide.md`: document `FetchByDateKey` with a worked NCAVE-style example (compute Q1 date_key for `eng.CurrentDate()`, fetch, filter NaN, use values).
+- `CHANGELOG.md`: entries under `Added` for the new metrics and `FetchByDateKey`.
+
+### 7. Testing
+
+- **Provider:** request `FundamentalsDateKey`/`FundamentalsReportPeriod` alongside Revenue; verify cells contain the expected `float64(t.Unix())`. Verify that requests omitting the metadata metrics still work and do not pay for extra columns.
+- **Engine forward-fill:** sparse fundamental input on filing dates D1, D2, D3. Fetch a daily range covering all three. Verify `FundamentalsDateKey` forward-fills the same way Revenue does; the value at any non-filing day equals the previous filing's date_key.
+- **`FetchByDateKey`:**
+  - Valid request returns one time-axis row at `dateKey`, expected values per asset.
+  - Non-fundamental metric in the list returns the documented error.
+  - Asset with no filing for that `dateKey` gets NaN.
+  - MR dimension with restatement: most recent `event_date` <= `CurrentDate()` wins.
+  - Filing whose `event_date` is strictly after `CurrentDate()` is excluded (point-in-time correctness).
+- **Snapshot:** record a fundamentals DataFrame that includes `FundamentalsDateKey` and `FundamentalsReportPeriod`; read it back via the snapshot provider; verify non-NULL values match.
+
+## What does not change
+
+- DataFrame struct -- no new fields. Metadata is just two more value columns.
+- `DataSource` interface signatures.
+- `DataRequest` struct -- `FetchByDateKey` lives on `*Engine`, not on the provider interface. It builds an internal request with the necessary filter.
+- Cache key shape beyond the added `dateKey` discriminator.
+- `SetFundamentalDimension` -- still a strategy-level setting in `Setup`.
+- `fetchEod` and `fetchMetrics` queries.

--- a/docs/superpowers/specs/2026-04-18-fundamentals-metadata-design.md
+++ b/docs/superpowers/specs/2026-04-18-fundamentals-metadata-design.md
@@ -29,10 +29,10 @@ metricColumn[FundamentalsReportPeriod] = "report_period"
 
 `fetchFundamentals` already special-cases `event_date` and `date_key` outside the metric loop. Refactor so all three date columns are scanned generically: when a request includes `FundamentalsDateKey` or `FundamentalsReportPeriod`, the date column is converted to `float64(t.Unix())` and stored in the cache exactly like a regular metric value. When the request does not include them, no extra cost.
 
-### 3. Engine: `FetchByDateKey`
+### 3. Engine: `FetchFundamentalsByDateKey`
 
 ```go
-func (e *Engine) FetchByDateKey(
+func (e *Engine) FetchFundamentalsByDateKey(
     ctx context.Context,
     assets []asset.Asset,
     metrics []data.Metric,
@@ -42,13 +42,13 @@ func (e *Engine) FetchByDateKey(
 
 Behavior:
 
-- Validates that every metric in `metrics` is fundamental (`data.IsFundamental(m)`). Returns `fmt.Errorf("FetchByDateKey: metric %q is not a fundamental metric", m)` otherwise.
+- Validates that every metric in `metrics` is fundamental (`data.IsFundamental(m)`). Returns `fmt.Errorf("FetchFundamentalsByDateKey: metric %q is not a fundamental metric", m)` otherwise.
 - Uses the engine's configured dimension (set via `SetFundamentalDimension`).
 - Returns a DataFrame with a single time-axis row at `dateKey`. One value per asset per metric.
 - SQL filter: `dimension = $1 AND date_key = $2 AND event_date <= $3`, where `$3` is `eng.CurrentDate()`. For MR dimensions a single asset can have multiple matching rows (restatements); take the row with the maximum `event_date` per asset (`DISTINCT ON (composite_figi)` with `ORDER BY composite_figi, event_date DESC` on PostgreSQL; equivalent window function on SQLite for snapshot replay).
 - Assets that have not filed for `dateKey` as of `CurrentDate()` get NaN values. The strategy filters with `math.IsNaN`.
 
-`FetchByDateKey` reuses the existing column cache: the cache key gains a `dateKey` discriminator alongside the existing `(figi, metric, dimension)` tuple so that range queries and date-key queries do not collide.
+`FetchFundamentalsByDateKey` reuses the existing column cache: the cache key gains a `dateKey` discriminator alongside the existing `(figi, metric, dimension)` tuple so that range queries and date-key queries do not collide.
 
 ### 4. Existing `Fetch` and `FetchAt`
 
@@ -67,14 +67,14 @@ The `dimension` column written by the recorder also stops being hardcoded `"ARQ"
 ### 6. Documentation
 
 - `docs/data.md`: document `FundamentalsDateKey` and `FundamentalsReportPeriod` as metrics, including the Unix-seconds encoding and the `time.Unix(int64(...), 0)` round-trip pattern.
-- `docs/strategy-guide.md`: document `FetchByDateKey` with a worked NCAVE-style example (compute Q1 date_key for `eng.CurrentDate()`, fetch, filter NaN, use values).
-- `CHANGELOG.md`: entries under `Added` for the new metrics and `FetchByDateKey`.
+- `docs/strategy-guide.md`: document `FetchFundamentalsByDateKey` with a worked NCAVE-style example (compute Q1 date_key for `eng.CurrentDate()`, fetch, filter NaN, use values).
+- `CHANGELOG.md`: entries under `Added` for the new metrics and `FetchFundamentalsByDateKey`.
 
 ### 7. Testing
 
 - **Provider:** request `FundamentalsDateKey`/`FundamentalsReportPeriod` alongside Revenue; verify cells contain the expected `float64(t.Unix())`. Verify that requests omitting the metadata metrics still work and do not pay for extra columns.
 - **Engine forward-fill:** sparse fundamental input on filing dates D1, D2, D3. Fetch a daily range covering all three. Verify `FundamentalsDateKey` forward-fills the same way Revenue does; the value at any non-filing day equals the previous filing's date_key.
-- **`FetchByDateKey`:**
+- **`FetchFundamentalsByDateKey`:**
   - Valid request returns one time-axis row at `dateKey`, expected values per asset.
   - Non-fundamental metric in the list returns the documented error.
   - Asset with no filing for that `dateKey` gets NaN.
@@ -86,7 +86,7 @@ The `dimension` column written by the recorder also stops being hardcoded `"ARQ"
 
 - DataFrame struct -- no new fields. Metadata is just two more value columns.
 - `DataSource` interface signatures.
-- `DataRequest` struct -- `FetchByDateKey` lives on `*Engine`, not on the provider interface. It builds an internal request with the necessary filter.
+- `DataRequest` struct -- `FetchFundamentalsByDateKey` lives on `*Engine`, not on the provider interface. It builds an internal request with the necessary filter.
 - Cache key shape beyond the added `dateKey` discriminator.
 - `SetFundamentalDimension` -- still a strategy-level setting in `Setup`.
 - `fetchEod` and `fetchMetrics` queries.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -357,6 +357,10 @@ func (e *Engine) FetchAt(ctx context.Context, assets []asset.Asset, timestamp ti
 // correctness: only filings with event_date <= eng.CurrentDate() are
 // included. Assets that have not filed for dateKey as of CurrentDate
 // get NaN values.
+//
+// This call bypasses the engine's column cache and issues a fresh provider
+// query each time. Strategies that need the result across multiple Compute
+// invocations should cache it themselves.
 func (e *Engine) FetchFundamentalsByDateKey(
 	ctx context.Context,
 	assets []asset.Asset,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -350,6 +350,46 @@ func (e *Engine) FetchAt(ctx context.Context, assets []asset.Asset, timestamp ti
 	return result, nil
 }
 
+// FetchFundamentalsByDateKey returns fundamental data for a specific
+// reporting period. dateKey identifies the normalized quarter boundary
+// (e.g. 2024-03-31 for Q1 2024). All metrics must be fundamentals;
+// non-fundamental metrics produce an error. Subject to point-in-time
+// correctness: only filings with event_date <= eng.CurrentDate() are
+// included. Assets that have not filed for dateKey as of CurrentDate
+// get NaN values.
+func (e *Engine) FetchFundamentalsByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	dateKey time.Time,
+) (*data.DataFrame, error) {
+	for _, mm := range metrics {
+		if !data.IsFundamental(mm) {
+			return nil, fmt.Errorf("FetchFundamentalsByDateKey: metric %q is not a fundamental metric", mm)
+		}
+	}
+
+	dimension := e.fundamentalDimension
+	if dimension == "" {
+		dimension = "ARQ"
+	}
+
+	for _, provider := range e.providers {
+		if dp, ok := provider.(data.FundamentalsByDateKeyProvider); ok {
+			df, err := dp.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, dimension, e.currentDate)
+			if err != nil {
+				return nil, fmt.Errorf("FetchFundamentalsByDateKey: %w", err)
+			}
+
+			df.SetSource(e)
+
+			return df, nil
+		}
+	}
+
+	return nil, fmt.Errorf("FetchFundamentalsByDateKey: no provider supports FundamentalsByDateKeyProvider")
+}
+
 // sliceRiskFree returns the cumulative risk-free values for the given
 // timestamps. Returns nil if no risk-free series is available or if
 // timestamps fall outside the precomputed range. Uses the pre-built

--- a/engine/fetch_by_date_key_test.go
+++ b/engine/fetch_by_date_key_test.go
@@ -1,0 +1,294 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine_test
+
+import (
+	"context"
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+type fetchByDateKeyStrategy struct {
+	assets   []asset.Asset
+	metrics  []data.Metric
+	dateKey  time.Time
+	fetched  *data.DataFrame
+	fetchErr error
+}
+
+func (s *fetchByDateKeyStrategy) Name() string { return "fetchByDateKeyStrategy" }
+
+func (s *fetchByDateKeyStrategy) Setup(*engine.Engine) {}
+
+func (s *fetchByDateKeyStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5"}
+}
+
+func (s *fetchByDateKeyStrategy) Compute(ctx context.Context, eng *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	s.fetched, s.fetchErr = eng.FetchFundamentalsByDateKey(ctx, s.assets, s.metrics, s.dateKey)
+	return nil
+}
+
+// fakeByDateKeyProvider is a small in-memory FundamentalsByDateKeyProvider.
+type fakeByDateKeyProvider struct {
+	*data.TestProvider
+	rows map[string]map[time.Time]map[data.Metric]float64 // figi -> dateKey -> metric -> value
+}
+
+func (p *fakeByDateKeyProvider) FetchFundamentalsByDateKey(
+	_ context.Context,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	dateKey time.Time,
+	_ string,
+	_ time.Time,
+) (*data.DataFrame, error) {
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, aa := range assets {
+		assetRows := p.rows[aa.CompositeFigi]
+		for mIdx, mm := range metrics {
+			val := math.NaN()
+			if assetRows != nil {
+				if dayMetrics, ok := assetRows[dateKey]; ok {
+					if vv, ok := dayMetrics[mm]; ok {
+						val = vv
+					}
+				}
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return data.NewDataFrame(times, assets, metrics, data.Daily, columns)
+}
+
+var _ = Describe("Engine.FetchFundamentalsByDateKey", func() {
+	var assetProv *mockAssetProvider
+
+	BeforeEach(func() {
+		assetProv = &mockAssetProvider{}
+	})
+
+	It("returns the requested fundamentals at the date_key", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		msft := asset.Asset{CompositeFigi: "FIGI-MSFT", Ticker: "MSFT"}
+		testAssets := []asset.Asset{spy, msft}
+		assetProv.assets = testAssets
+
+		q1 := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital, data.FundamentalsDateKey},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{
+				spy.CompositeFigi: {
+					q1: {
+						data.WorkingCapital:      120_000_000,
+						data.FundamentalsDateKey: float64(q1.Unix()),
+					},
+				},
+				msft.CompositeFigi: {
+					q1: {
+						data.WorkingCapital:      80_000_000,
+						data.FundamentalsDateKey: float64(q1.Unix()),
+					},
+				},
+			},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital, data.FundamentalsDateKey},
+			dateKey: q1,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simStart := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 6, 17, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+		spyWC := strategy.fetched.Column(spy, data.WorkingCapital)
+		Expect(spyWC).To(HaveLen(1))
+		Expect(spyWC[0]).To(BeNumerically("==", 120_000_000))
+
+		msftWC := strategy.fetched.Column(msft, data.WorkingCapital)
+		Expect(msftWC).To(HaveLen(1))
+		Expect(msftWC[0]).To(BeNumerically("==", 80_000_000))
+
+		spyDK := strategy.fetched.Column(spy, data.FundamentalsDateKey)
+		Expect(time.Unix(int64(spyDK[0]), 0).UTC()).To(Equal(q1))
+	})
+
+	It("returns NaN for assets with no filing at the date_key", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		msft := asset.Asset{CompositeFigi: "FIGI-MSFT", Ticker: "MSFT"}
+		testAssets := []asset.Asset{spy, msft}
+		assetProv.assets = testAssets
+
+		q1 := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{
+				spy.CompositeFigi: {
+					q1: {data.WorkingCapital: 120_000_000},
+				},
+				// MSFT has no Q1 row.
+			},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: q1,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simStart := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 6, 17, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+		msftWC := strategy.fetched.Column(msft, data.WorkingCapital)
+		Expect(math.IsNaN(msftWC[0])).To(BeTrue())
+	})
+
+	It("errors when a non-fundamental metric is requested", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 30, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital, data.MetricClose},
+			dateKey: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		// Jan 22 2024 is a Monday; 30-day closeDF covers through Jan 31.
+		simStart := time.Date(2024, 1, 22, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 1, 22, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).To(HaveOccurred())
+		Expect(strategy.fetchErr.Error()).To(ContainSubstring("not a fundamental metric"))
+	})
+
+	It("errors when no provider supports FundamentalsByDateKey", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 30, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+		fundProvider := data.NewTestProvider(
+			[]data.Metric{data.WorkingCapital},
+			mustEmptyFundDF(testAssets),
+		)
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC),
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		// Jan 22 2024 is a Monday; 30-day closeDF covers through Jan 31.
+		simStart := time.Date(2024, 1, 22, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 1, 22, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).To(HaveOccurred())
+		Expect(strategy.fetchErr.Error()).To(ContainSubstring("no provider supports"))
+	})
+})
+
+// mustEmptyFundDF returns an empty fundamentals DataFrame for use as a
+// TestProvider seed. Real values come from fakeByDateKeyProvider.rows.
+func mustEmptyFundDF(assets []asset.Asset) *data.DataFrame {
+	df, err := data.NewDataFrame(
+		nil,
+		assets,
+		[]data.Metric{data.WorkingCapital, data.FundamentalsDateKey},
+		data.Daily,
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return df
+}

--- a/engine/fetch_test.go
+++ b/engine/fetch_test.go
@@ -643,6 +643,62 @@ var _ = Describe("Fetch", func() {
 			closeCol := strategy.fetched.Column(spy, data.MetricClose)
 			Expect(closeCol).To(HaveLen(2))
 		})
+
+		It("forward-fills FundamentalsDateKey alongside the value", func() {
+			spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+			fundamentalAssets := []asset.Asset{spy}
+			assetProvider = &mockAssetProvider{assets: fundamentalAssets}
+
+			closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			closeDF := makeDailyDF(closeStart, 90, fundamentalAssets, []data.Metric{data.MetricClose})
+			closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+			filingDate := time.Date(2024, 1, 15, 16, 0, 0, 0, time.UTC)
+			dateKey := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC) // Q4 2023 filing on Jan 15
+
+			fundDF, err := data.NewDataFrame(
+				[]time.Time{filingDate},
+				fundamentalAssets,
+				[]data.Metric{data.Revenue, data.FundamentalsDateKey},
+				data.Daily,
+				[][]float64{
+					{500_000_000},
+					{float64(dateKey.Unix())},
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			fundProvider := data.NewTestProvider(
+				[]data.Metric{data.Revenue, data.FundamentalsDateKey},
+				fundDF,
+			)
+
+			strategy := &fetchStrategy{
+				lookback: portfolio.Days(30),
+				metrics:  []data.Metric{data.MetricClose, data.Revenue, data.FundamentalsDateKey},
+				assets:   fundamentalAssets,
+			}
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(closeProvider, fundProvider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			)
+
+			// Sim date Mar 1; lookback starts Jan 31 -- well after the Jan 15 filing.
+			simStart := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+			simEnd := time.Date(2024, 3, 1, 23, 0, 0, 0, time.UTC)
+			_, btErr := eng.Backtest(context.Background(), simStart, simEnd)
+			Expect(btErr).NotTo(HaveOccurred())
+			Expect(strategy.fetchErr).NotTo(HaveOccurred())
+
+			dkCol := strategy.fetched.Column(spy, data.FundamentalsDateKey)
+			Expect(len(dkCol)).To(BeNumerically(">", 1))
+
+			expected := float64(dateKey.Unix())
+			for _, vv := range dkCol {
+				Expect(vv).To(BeNumerically("==", expected))
+			}
+		})
 	})
 
 	Context("FetchAt point-in-time fast path", func() {


### PR DESCRIPTION
## Summary

Completes the fundamentals story that 0.7.0 started. After 0.7.0 made fundamentals point-in-time correct, strategies could fetch values but had no way to know which reporting period they came from, and no way to query a specific period directly. This release adds both.

- `Engine.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey)` — returns one row per asset for a specific reporting period, subject to point-in-time correctness.
- `data.FundamentalsDateKey` / `data.FundamentalsReportPeriod` — metadata metrics that carry the reporting period alongside any fundamental value (forward-filled with the data).
- Snapshots persist `date_key`, `report_period`, and the configured dimension instead of NULL/`"ARQ"` placeholders, so replays match live queries.

Spec: `docs/superpowers/specs/2026-04-18-fundamentals-metadata-design.md`.
Plan: `docs/superpowers/plans/2026-04-18-fundamentals-metadata.md`.