### PR TITLE
feat: add WithAsOfDate option to FetchFundamentalsByDateKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Strategies can cap which filings are considered available to `Engine.FetchFundamentalsByDateKey` by passing `engine.WithAsOfDate`. This lets a screen use an earlier "formation date" (e.g. March 31 fundamentals) even when the strategy rebalances later in the year.
+
 ## [0.7.2] - 2026-04-18
 
 ### Added

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -24,9 +24,13 @@ defer eng.Close()
 | `WithInitialDeposit(amount float64)` | Starting cash balance. |
 | `WithBroker(b broker.Broker)` | Broker for order execution. Defaults to a simulated broker. |
 | `WithCacheMaxBytes(n int64)` | Maximum memory for the data cache. Defaults to 512MB. |
-| `WithPortfolioSnapshot(snap)` | Restore portfolio from a previous run's snapshot. |
-| `WithAccount(acct *portfolio.Account)` | Use a pre-configured Account (overrides deposit, snapshot, and broker). |
+| `WithPortfolioSnapshot(snap)` | Restore portfolio from a previous run's snapshot. Mutually exclusive with `WithInitialDeposit`. |
+| `WithAccount(acct portfolio.PortfolioManager)` | Use a pre-configured Account (overrides deposit, snapshot, and broker). |
 | `WithDateRangeMode(mode DateRangeMode)` | How to handle insufficient warmup data: `DateRangeModeStrict` (default) errors, `DateRangeModePermissive` adjusts the start date forward. |
+| `WithBenchmarkTicker(ticker string)` | Override the benchmark by ticker. Takes priority over the benchmark declared in `Describe()`. |
+| `WithFillModel(base broker.BaseModel, adjusters ...broker.Adjuster)` | Configure the fill pipeline used by the simulated broker. Ignored when `WithBroker` supplies a non-default broker. |
+| `WithMiddlewareConfig(cfg MiddlewareConfig)` | Attach risk- and tax-management middleware (see `pvbt.toml` / `--risk-profile` / `--tax`). Replaces any strategy-declared middleware. |
+| `WithProgressCallback(fn ProgressCallback)` | Register a callback invoked after each simulation step with a `ProgressEvent` (step index, total steps, current date, measurement count). Must return quickly; runs inside the step loop. |
 
 ## Running a backtest
 
@@ -68,24 +72,17 @@ At every step the engine performs housekeeping in a fixed order before updating 
 
 ### Margin calls and auto-liquidation
 
-When a margin check fails, the engine calls the registered `MarginCallHandler`:
+When a margin check fails, the engine first looks for a `MarginCallHandler` on the strategy itself. The interface is opt-in -- implement it on your strategy type to take over margin-call handling:
 
 ```go
 type MarginCallHandler interface {
-    OnMarginCall(ctx context.Context, eng *Engine, port portfolio.Portfolio, deficit float64) error
+    OnMarginCall(ctx context.Context, eng *Engine, port portfolio.Portfolio, batch *portfolio.Batch) error
 }
 ```
 
-The handler receives the engine, the current portfolio (read-only), and the equity deficit in dollars. The default implementation auto-liquidates the largest short position at market until the deficit is resolved. A custom handler can be registered with `engine.WithMarginCallHandler(h)`:
+The handler receives the engine, the current portfolio (read-only), and a dedicated batch on which to queue orders. The batch bypasses middleware (it must not be further transformed by risk/tax rules) and is executed immediately after `OnMarginCall` returns. If the handler clears the deficiency the step continues; otherwise the engine falls back to automatic liquidation.
 
-```go
-eng := engine.New(&MyStrategy{},
-    engine.WithMarginCallHandler(myHandler),
-    // ...
-)
-```
-
-The handler may submit orders through the engine or return an error to halt the run. If no handler is registered, the default auto-liquidation behavior applies.
+If the strategy does not implement `MarginCallHandler`, the engine auto-liquidates short positions proportionally until the deficiency is resolved. Returning an error from the handler halts the run.
 
 ### Stock split handling
 
@@ -183,9 +180,22 @@ df, err := eng.Fetch(ctx, assets, portfolio.Months(6), []data.Metric{data.Metric
 
 // Single point in time
 df, err := eng.FetchAt(ctx, assets, eng.CurrentDate(), []data.Metric{data.MetricClose})
+
+// Specific fundamentals reporting period (e.g. Q4 prior year)
+df, err := eng.FetchFundamentalsByDateKey(ctx, assets, []data.Metric{data.WorkingCapital}, q4)
 ```
 
 Most strategies fetch data through universes (`universe.Window`, `universe.At`) rather than calling `Fetch`/`FetchAt` directly. The universe methods are higher-level and handle membership resolution automatically.
+
+`FetchFundamentalsByDateKey` returns one value per asset for a given `date_key`, filtered to filings available by `eng.CurrentDate()`. Pass `engine.WithAsOfDate(t)` to cap availability at an earlier formation date (must be non-zero and not later than `CurrentDate()`). See the strategy guide for a worked example.
+
+### Fundamental dimension
+
+```go
+eng.SetFundamentalDimension("MRQ")
+```
+
+Selects the dimension used for all subsequent fundamental fetches on this engine. Valid values: `ARQ`, `ARY`, `ART` (As Reported, point-in-time on SEC filing date) and `MRQ`, `MRY`, `MRT` (Most Recent Reported, indexed to fiscal period end). Call from `Setup`; defaults to `ARQ`. See the strategy guide for the full table and guidance on backtest correctness.
 
 ### Benchmark
 

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -327,6 +327,25 @@ the call must be fundamentals; non-fundamental metrics return an error.
 The dimension used is whatever the strategy set with `SetFundamentalDimension`
 in `Setup` (defaults to `ARQ`).
 
+#### Overriding the as-of date
+
+Some screens deliberately ignore filings that arrive between an earlier
+"formation date" and the rebalance date. The classic Graham NCAV
+formulation, for example, rebalances in mid-year but screens on filings
+available by March 31, not on everything available at the June rebalance.
+Pass `engine.WithAsOfDate` to cap which filings are considered available:
+
+```go
+formation := time.Date(eng.CurrentDate().Year(), time.March, 31, 0, 0, 0, 0, time.UTC)
+
+df, err := eng.FetchFundamentalsByDateKey(ctx, s.universe, metrics, q4PriorYear,
+    engine.WithAsOfDate(formation))
+```
+
+The as-of date must be non-zero and not later than `eng.CurrentDate()`;
+otherwise the call returns an error. When the option is not set,
+`eng.CurrentDate()` is used as the cap.
+
 ### Asset lookup
 
 `eng.Asset(ticker)` resolves a ticker to an `asset.Asset` using the registered `AssetProvider`. It panics if the ticker is not found, which is appropriate in `Setup` since a missing benchmark or risk-free asset is a fatal configuration error.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -350,13 +350,38 @@ func (e *Engine) FetchAt(ctx context.Context, assets []asset.Asset, timestamp ti
 	return result, nil
 }
 
+// FundamentalsByDateKeyOption configures a call to
+// Engine.FetchFundamentalsByDateKey.
+type FundamentalsByDateKeyOption func(*fundamentalsByDateKeyOpts)
+
+type fundamentalsByDateKeyOpts struct {
+	asOfDate    time.Time
+	asOfDateSet bool
+}
+
+// WithAsOfDate caps which filings are considered available to the call.
+// Only filings with event_date <= asOfDate are returned. This lets
+// strategies emulate a "formation date" earlier than the current
+// rebalance date -- for example, screening on prior-year fundamentals
+// that were available by March 31 even when the rebalance runs in June.
+//
+// asOfDate must be non-zero and not later than Engine.CurrentDate();
+// otherwise the fetch returns an error. When the option is not set,
+// Engine.CurrentDate() is used as the cap.
+func WithAsOfDate(asOfDate time.Time) FundamentalsByDateKeyOption {
+	return func(opts *fundamentalsByDateKeyOpts) {
+		opts.asOfDate = asOfDate
+		opts.asOfDateSet = true
+	}
+}
+
 // FetchFundamentalsByDateKey returns fundamental data for a specific
 // reporting period. dateKey identifies the normalized quarter boundary
 // (e.g. 2024-03-31 for Q1 2024). All metrics must be fundamentals;
 // non-fundamental metrics produce an error. Subject to point-in-time
 // correctness: only filings with event_date <= eng.CurrentDate() are
-// included. Assets that have not filed for dateKey as of CurrentDate
-// get NaN values.
+// included by default, overridable via WithAsOfDate. Assets that have
+// not filed for dateKey as of that cap get NaN values.
 //
 // This call bypasses the engine's column cache and issues a fresh provider
 // query each time. Strategies that need the result across multiple Compute
@@ -366,11 +391,32 @@ func (e *Engine) FetchFundamentalsByDateKey(
 	assets []asset.Asset,
 	metrics []data.Metric,
 	dateKey time.Time,
+	options ...FundamentalsByDateKeyOption,
 ) (*data.DataFrame, error) {
 	for _, mm := range metrics {
 		if !data.IsFundamental(mm) {
 			return nil, fmt.Errorf("FetchFundamentalsByDateKey: metric %q is not a fundamental metric", mm)
 		}
+	}
+
+	opts := fundamentalsByDateKeyOpts{}
+	for _, apply := range options {
+		apply(&opts)
+	}
+
+	maxEventDate := e.currentDate
+
+	if opts.asOfDateSet {
+		if opts.asOfDate.IsZero() {
+			return nil, fmt.Errorf("FetchFundamentalsByDateKey: as-of date must be non-zero")
+		}
+
+		if opts.asOfDate.After(e.currentDate) {
+			return nil, fmt.Errorf("FetchFundamentalsByDateKey: as-of date %s is after CurrentDate %s (would leak future data)",
+				opts.asOfDate.Format("2006-01-02"), e.currentDate.Format("2006-01-02"))
+		}
+
+		maxEventDate = opts.asOfDate
 	}
 
 	dimension := e.fundamentalDimension
@@ -380,7 +426,7 @@ func (e *Engine) FetchFundamentalsByDateKey(
 
 	for _, provider := range e.providers {
 		if dp, ok := provider.(data.FundamentalsByDateKeyProvider); ok {
-			df, err := dp.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, dimension, e.currentDate)
+			df, err := dp.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, dimension, maxEventDate)
 			if err != nil {
 				return nil, fmt.Errorf("FetchFundamentalsByDateKey: %w", err)
 			}

--- a/engine/fetch_by_date_key_test.go
+++ b/engine/fetch_by_date_key_test.go
@@ -30,11 +30,13 @@ import (
 )
 
 type fetchByDateKeyStrategy struct {
-	assets   []asset.Asset
-	metrics  []data.Metric
-	dateKey  time.Time
-	fetched  *data.DataFrame
-	fetchErr error
+	assets          []asset.Asset
+	metrics         []data.Metric
+	dateKey         time.Time
+	opts            []engine.FundamentalsByDateKeyOption
+	fetched         *data.DataFrame
+	fetchErr        error
+	capturedCurrent time.Time
 }
 
 func (s *fetchByDateKeyStrategy) Name() string { return "fetchByDateKeyStrategy" }
@@ -46,14 +48,16 @@ func (s *fetchByDateKeyStrategy) Describe() engine.StrategyDescription {
 }
 
 func (s *fetchByDateKeyStrategy) Compute(ctx context.Context, eng *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
-	s.fetched, s.fetchErr = eng.FetchFundamentalsByDateKey(ctx, s.assets, s.metrics, s.dateKey)
+	s.capturedCurrent = eng.CurrentDate()
+	s.fetched, s.fetchErr = eng.FetchFundamentalsByDateKey(ctx, s.assets, s.metrics, s.dateKey, s.opts...)
 	return nil
 }
 
 // fakeByDateKeyProvider is a small in-memory FundamentalsByDateKeyProvider.
 type fakeByDateKeyProvider struct {
 	*data.TestProvider
-	rows map[string]map[time.Time]map[data.Metric]float64 // figi -> dateKey -> metric -> value
+	rows         map[string]map[time.Time]map[data.Metric]float64 // figi -> dateKey -> metric -> value
+	lastMaxEvent time.Time
 }
 
 func (p *fakeByDateKeyProvider) FetchFundamentalsByDateKey(
@@ -62,8 +66,9 @@ func (p *fakeByDateKeyProvider) FetchFundamentalsByDateKey(
 	metrics []data.Metric,
 	dateKey time.Time,
 	_ string,
-	_ time.Time,
+	maxEventDate time.Time,
 ) (*data.DataFrame, error) {
+	p.lastMaxEvent = maxEventDate
 	times := []time.Time{dateKey}
 	columns := make([][]float64, len(assets)*len(metrics))
 
@@ -239,6 +244,169 @@ var _ = Describe("Engine.FetchFundamentalsByDateKey", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(strategy.fetchErr).To(HaveOccurred())
 		Expect(strategy.fetchErr.Error()).To(ContainSubstring("not a fundamental metric"))
+	})
+
+	It("forwards e.CurrentDate() as the event-date cap when no option is set", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		q1 := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{
+				spy.CompositeFigi: {q1: {data.WorkingCapital: 120_000_000}},
+			},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: q1,
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simStart := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 6, 17, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+		Expect(fundProvider.lastMaxEvent).To(Equal(strategy.capturedCurrent))
+	})
+
+	It("forwards the WithAsOfDate value as the event-date cap", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		q4 := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{
+				spy.CompositeFigi: {q4: {data.WorkingCapital: 50_000_000}},
+			},
+		}
+
+		formationDate := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: q4,
+			opts:    []engine.FundamentalsByDateKeyOption{engine.WithAsOfDate(formationDate)},
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simStart := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 6, 17, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).NotTo(HaveOccurred())
+		Expect(fundProvider.lastMaxEvent).To(Equal(formationDate))
+		Expect(strategy.capturedCurrent.After(formationDate)).To(BeTrue(),
+			"test precondition: currentDate should be later than formationDate")
+	})
+
+	It("rejects WithAsOfDate later than CurrentDate() to prevent look-ahead", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{},
+		}
+
+		future := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+			opts:    []engine.FundamentalsByDateKeyOption{engine.WithAsOfDate(future)},
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simStart := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 6, 17, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).To(HaveOccurred())
+		Expect(strategy.fetchErr.Error()).To(ContainSubstring("as-of date"))
+	})
+
+	It("rejects WithAsOfDate with a zero time", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+		assetProv.assets = testAssets
+
+		closeStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		closeDF := makeDailyDF(closeStart, 180, testAssets, []data.Metric{data.MetricClose})
+		closeProvider := data.NewTestProvider([]data.Metric{data.MetricClose}, closeDF)
+
+		fundProvider := &fakeByDateKeyProvider{
+			TestProvider: data.NewTestProvider(
+				[]data.Metric{data.WorkingCapital},
+				mustEmptyFundDF(testAssets),
+			),
+			rows: map[string]map[time.Time]map[data.Metric]float64{},
+		}
+
+		strategy := &fetchByDateKeyStrategy{
+			assets:  testAssets,
+			metrics: []data.Metric{data.WorkingCapital},
+			dateKey: time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC),
+			opts:    []engine.FundamentalsByDateKeyOption{engine.WithAsOfDate(time.Time{})},
+		}
+
+		eng := engine.New(strategy,
+			engine.WithDataProvider(closeProvider, fundProvider),
+			engine.WithAssetProvider(assetProv),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		simStart := time.Date(2024, 6, 17, 0, 0, 0, 0, time.UTC)
+		simEnd := time.Date(2024, 6, 17, 23, 0, 0, 0, time.UTC)
+		_, err := eng.Backtest(context.Background(), simStart, simEnd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(strategy.fetchErr).To(HaveOccurred())
+		Expect(strategy.fetchErr.Error()).To(ContainSubstring("as-of date"))
 	})
 
 	It("errors when no provider supports FundamentalsByDateKey", func() {


### PR DESCRIPTION
## Summary

- Adds `engine.WithAsOfDate` for `Engine.FetchFundamentalsByDateKey`, letting strategies cap which filings are considered available (e.g. Graham NCAV using March 31 filings for a June rebalance). Validates the cap against `CurrentDate()` and rejects a zero time.
- Fixes pre-existing documentation gaps in `docs/engine.md`: adds `WithBenchmarkTicker`, `WithFillModel`, `WithMiddlewareConfig`, `WithProgressCallback` to the options table; adds a `SetFundamentalDimension` subsection; corrects the `MarginCallHandler` subsection (no `WithMarginCallHandler` option exists, and the `OnMarginCall` signature takes a `*portfolio.Batch`, not a `deficit float64`).
- Documents the new option in `docs/strategy-guide.md` with a Graham-style formation-date example, and adds a `CHANGELOG.md` entry under `[Unreleased]`.