### PR TITLE
Release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-04-18
+
 ### Added
 
 - Strategies can cap which filings are considered available to `Engine.FetchFundamentalsByDateKey` by passing `engine.WithAsOfDate`. This lets a screen use an earlier "formation date" (e.g. March 31 fundamentals) even when the strategy rebalances later in the year.
+
+### Fixed
+
+- The engine-package documentation now lists `WithBenchmarkTicker`, `WithFillModel`, `WithMiddlewareConfig`, and `WithProgressCallback`; describes `SetFundamentalDimension`; and shows the correct `MarginCallHandler` signature and discovery mechanism.
 
 ## [0.7.2] - 2026-04-18
 


### PR DESCRIPTION
Release v0.7.3.

0.7.2 shipped `FetchFundamentalsByDateKey` with a hardcoded point-in-time cap at the engine's current date. That is the right default for most strategies, but strategies care about a subtler distinction: they rebalance in mid-year but want to look only at filings that were public by an earlier "formation date." Without a way to cap the event-date, the June rebalance silently picks up companies that filed their prior-year 10-K between April and June, and that shift materially changes results.

0.7.3 closes the gap with `engine.WithAsOfDate`. Strategies can now emulate an earlier as-of-date cleanly instead of falling back to the legacy `FetchAt` + forward-fill workaround. The call rejects values in the future (no look-ahead) and zero times (caller bug).

Along the way the engine-package documentation is corrected: four options that shipped in 0.7.0 (`WithBenchmarkTicker`, `WithFillModel`, `WithMiddlewareConfig`, `WithProgressCallback`) are now listed, `SetFundamentalDimension` is documented as an engine method, and the `MarginCallHandler` section shows the correct interface signature and discovery mechanism (type assertion on the Strategy, not a registered option).