### PR TITLE
fix: SnapshotRecorder implements FundamentalsByDateKeyProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Snapshot capture no longer fails with "no provider supports FundamentalsByDateKeyProvider" for strategies that call `Engine.FetchFundamentalsByDateKey`. The recorder now delegates the call to the wrapped provider and stores the result so replay sees the same values.
+
 ## [0.7.3] - 2026-04-18
 
 ### Added

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -17,11 +17,12 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ BatchProvider   = (*SnapshotRecorder)(nil)
-	_ AssetProvider   = (*SnapshotRecorder)(nil)
-	_ IndexProvider   = (*SnapshotRecorder)(nil)
-	_ RatingProvider  = (*SnapshotRecorder)(nil)
-	_ HolidayProvider = (*SnapshotRecorder)(nil)
+	_ BatchProvider                 = (*SnapshotRecorder)(nil)
+	_ AssetProvider                 = (*SnapshotRecorder)(nil)
+	_ IndexProvider                 = (*SnapshotRecorder)(nil)
+	_ RatingProvider                = (*SnapshotRecorder)(nil)
+	_ HolidayProvider               = (*SnapshotRecorder)(nil)
+	_ FundamentalsByDateKeyProvider = (*SnapshotRecorder)(nil)
 )
 
 // SnapshotRecorderConfig holds the providers to wrap.
@@ -537,6 +538,170 @@ func (r *SnapshotRecorder) recordFundamentals(tx *sql.Tx, df *DataFrame, metrics
 	}
 
 	return nil
+}
+
+// FetchFundamentalsByDateKey delegates to a wrapped FundamentalsByDateKeyProvider
+// and records the returned values so SnapshotProvider can replay the same call.
+// Returns an error when no wrapped provider implements the interface.
+//
+// The recorder writes one row per asset at event_date = dateKey (the reporting
+// period itself). This is synthetic: the true filing date is consumed inside
+// the provider's DISTINCT ON ordering and not exposed on the returned
+// DataFrame. Because replay queries filter with event_date <= maxEventDate
+// and every sensible caller passes a maxEventDate on or after the reporting
+// period, the recorded row always matches. A replay under a custom as-of date
+// returns the same value the recording saw; it cannot reconstruct filings
+// that the recording never observed.
+func (r *SnapshotRecorder) FetchFundamentalsByDateKey(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []Metric,
+	dateKey time.Time,
+	dimension string,
+	maxEventDate time.Time,
+) (*DataFrame, error) {
+	provider := r.fundamentalsByDateKeyProvider()
+	if provider == nil {
+		return nil, fmt.Errorf("snapshot recorder: no wrapped provider supports FundamentalsByDateKey")
+	}
+
+	df, err := provider.FetchFundamentalsByDateKey(ctx, assets, metrics, dateKey, dimension, maxEventDate)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.recordFundamentalsByDateKey(df, metrics, dateKey, dimension); err != nil {
+		return nil, fmt.Errorf("snapshot recorder: record fundamentals by date_key: %w", err)
+	}
+
+	return df, nil
+}
+
+func (r *SnapshotRecorder) fundamentalsByDateKeyProvider() FundamentalsByDateKeyProvider {
+	if provider, ok := r.batchProvider.(FundamentalsByDateKeyProvider); ok {
+		return provider
+	}
+
+	if provider, ok := r.assetProvider.(FundamentalsByDateKeyProvider); ok {
+		return provider
+	}
+
+	return nil
+}
+
+func (r *SnapshotRecorder) recordFundamentalsByDateKey(df *DataFrame, metrics []Metric, dateKey time.Time, dimension string) error {
+	if df == nil || len(df.assets) == 0 {
+		return nil
+	}
+
+	if err := r.recordAssets(df.assets); err != nil {
+		return err
+	}
+
+	numDFMetrics := len(df.metrics)
+
+	mIdx := make(map[Metric]int, len(df.metrics))
+	for idx, metric := range df.metrics {
+		mIdx[metric] = idx
+	}
+
+	reportPeriodDFIdx, hasReportPeriod := mIdx[FundamentalsReportPeriod]
+
+	var (
+		colNames   []string
+		colMetrics []Metric
+	)
+
+	for _, metric := range metrics {
+		if metric == FundamentalsDateKey || metric == FundamentalsReportPeriod {
+			continue
+		}
+
+		colName, ok := metricColumn[metric]
+		if !ok {
+			continue
+		}
+
+		colNames = append(colNames, colName)
+		colMetrics = append(colMetrics, metric)
+	}
+
+	if len(colNames) == 0 {
+		return nil
+	}
+
+	placeholders := make([]string, 5+len(colNames))
+	for idx := range placeholders {
+		placeholders[idx] = "?"
+	}
+
+	upsertCols := make([]string, len(colNames))
+	for idx, col := range colNames {
+		upsertCols[idx] = fmt.Sprintf("%s = COALESCE(excluded.%s, %s)", col, col, col)
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO fundamentals (composite_figi, event_date, date_key, report_period, dimension, %s) VALUES (%s) ON CONFLICT(composite_figi, event_date, dimension) DO UPDATE SET %s",
+		strings.Join(colNames, ", "),
+		strings.Join(placeholders, ", "),
+		strings.Join(upsertCols, ", "),
+	)
+
+	effectiveDimension := dimension
+	if effectiveDimension == "" {
+		effectiveDimension = "ARQ"
+	}
+
+	dateKeyStr := dateKey.UTC().Format("2006-01-02")
+
+	tx, err := r.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil {
+			_ = rollbackErr
+		}
+	}()
+
+	for assetIdx, aa := range df.assets {
+		args := make([]any, 5+len(colMetrics))
+		args[0] = aa.CompositeFigi
+		args[1] = dateKeyStr
+		args[2] = dateKeyStr
+		args[3] = nil
+
+		if hasReportPeriod {
+			raw := df.columns[assetIdx*numDFMetrics+reportPeriodDFIdx][0]
+			if !math.IsNaN(raw) {
+				args[3] = time.Unix(int64(raw), 0).UTC().Format("2006-01-02")
+			}
+		}
+
+		args[4] = effectiveDimension
+
+		for idx, metric := range colMetrics {
+			mi, ok := mIdx[metric]
+			if !ok {
+				args[5+idx] = nil
+				continue
+			}
+
+			val := df.columns[assetIdx*numDFMetrics+mi][0]
+			if math.IsNaN(val) {
+				args[5+idx] = nil
+			} else {
+				args[5+idx] = val
+			}
+		}
+
+		if _, err := tx.Exec(query, args...); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
 }
 
 // -- IndexProvider --

--- a/data/snapshot_recorder_test.go
+++ b/data/snapshot_recorder_test.go
@@ -445,6 +445,80 @@ var _ = Describe("SnapshotRecorder", func() {
 			Expect(dimStr).To(Equal("ARQ")) // fallback default
 		})
 	})
+
+	Describe("FetchFundamentalsByDateKey", func() {
+		It("implements FundamentalsByDateKeyProvider so Engine can snapshot by-date-key queries", func() {
+			var _ data.FundamentalsByDateKeyProvider = (*data.SnapshotRecorder)(nil)
+		})
+
+		It("delegates to the wrapped provider and records the result for replay", func() {
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+			maxEventDate := time.Date(2024, 6, 30, 0, 0, 0, 0, time.UTC)
+
+			stub := &stubFundamentalsByDateKeyProvider{
+				values:    map[string]float64{spy.CompositeFigi: 120_000_000.0},
+				dimension: "ARQ",
+			}
+
+			var recErr error
+			recorder, recErr = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: stub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(recErr).NotTo(HaveOccurred())
+
+			df, err := recorder.FetchFundamentalsByDateKey(ctx, assets,
+				[]data.Metric{data.WorkingCapital}, dateKey, "ARQ", maxEventDate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(df.Column(spy, data.WorkingCapital)[0]).To(BeNumerically("==", 120_000_000.0))
+			Expect(stub.calls).To(Equal(1))
+
+			Expect(recorder.Close()).To(Succeed())
+			recorder = nil
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer db.Close()
+
+			var (
+				dateKeyStr, dimStr string
+				wc                 float64
+			)
+			err = db.QueryRow(
+				`SELECT date_key, dimension, working_capital
+				   FROM fundamentals
+				  WHERE composite_figi = ?`,
+				spy.CompositeFigi,
+			).Scan(&dateKeyStr, &dimStr, &wc)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(dateKeyStr).To(Equal("2024-03-31"))
+			Expect(dimStr).To(Equal("ARQ"))
+			Expect(wc).To(BeNumerically("==", 120_000_000.0))
+		})
+
+		It("errors when no wrapped provider supports FundamentalsByDateKey", func() {
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+			dateKey := time.Date(2024, 3, 31, 0, 0, 0, 0, time.UTC)
+
+			plainStub := data.NewTestProvider([]data.Metric{data.WorkingCapital}, nil)
+
+			var recErr error
+			recorder, recErr = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: plainStub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(recErr).NotTo(HaveOccurred())
+
+			_, err := recorder.FetchFundamentalsByDateKey(ctx, assets,
+				[]data.Metric{data.WorkingCapital}, dateKey, "ARQ", dateKey)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no wrapped provider"))
+		})
+	})
 })
 
 // -- stubs --
@@ -485,3 +559,40 @@ type dimensionedTestProvider struct {
 }
 
 func (p *dimensionedTestProvider) Dimension() string { return p.dimension }
+
+type stubFundamentalsByDateKeyProvider struct {
+	*data.TestProvider
+	values    map[string]float64
+	dimension string
+	calls     int
+}
+
+func (p *stubFundamentalsByDateKeyProvider) Dimension() string { return p.dimension }
+
+func (p *stubFundamentalsByDateKeyProvider) FetchFundamentalsByDateKey(
+	_ context.Context,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	dateKey time.Time,
+	_ string,
+	_ time.Time,
+) (*data.DataFrame, error) {
+	p.calls++
+
+	times := []time.Time{dateKey}
+	columns := make([][]float64, len(assets)*len(metrics))
+
+	for aIdx, aa := range assets {
+		for mIdx := range metrics {
+			val, ok := p.values[aa.CompositeFigi]
+			if !ok {
+				columns[aIdx*len(metrics)+mIdx] = []float64{0.0}
+				continue
+			}
+
+			columns[aIdx*len(metrics)+mIdx] = []float64{val}
+		}
+	}
+
+	return data.NewDataFrame(times, assets, metrics, data.Daily, columns)
+}


### PR DESCRIPTION
## Summary

- `Engine.FetchFundamentalsByDateKey` type-asserts on `FundamentalsByDateKeyProvider`. The recorder did not implement it, so any strategy using the API (e.g. NCAV) errored out with `no provider supports FundamentalsByDateKeyProvider` during snapshot capture.
- The recorder now delegates the call to whichever wrapped provider satisfies the interface (batch first, asset fallback) and writes the returned rows to the snapshot's `fundamentals` table so `SnapshotProvider` returns the same values on replay.
- Rows are written with `event_date = dateKey` since the real filing date isn't exposed on the returned DataFrame. Any replay `maxEventDate` on or after the reporting period matches the recorded row.