### PR TITLE
Release v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-04-18
+
 ### Fixed
 
 - Snapshot capture no longer fails with "no provider supports FundamentalsByDateKeyProvider" for strategies that call `Engine.FetchFundamentalsByDateKey`. The recorder now delegates the call to the wrapped provider and stores the result so replay sees the same values.


### PR DESCRIPTION
Snapshot capture was broken in v0.7.3 for any strategy that called `Engine.FetchFundamentalsByDateKey` — NCAV-style screens and anything else exercising the API introduced in v0.7.2. The engine type-asserts on `FundamentalsByDateKeyProvider`, the recorder did not implement it, and the call errored with `no provider supports FundamentalsByDateKeyProvider` on the first by-date-key fetch. This release makes the recorder implement the interface: it delegates to whichever wrapped provider satisfies it and stores the returned rows so replay sees the same values.