### PR TITLE
fix: propagate date_key/report_period on snapshot upsert conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Snapshot replay no longer returns an empty screen when a `FetchFundamentalsByDateKey` call targets a reporting period that falls on a trading day (e.g. `2024-12-31`). The recorder's upsert now propagates `date_key` and `report_period` into existing rows instead of leaving them NULL on conflict.
+
 ## [0.7.4] - 2026-04-18
 
 ### Fixed

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -635,9 +635,14 @@ func (r *SnapshotRecorder) recordFundamentalsByDateKey(df *DataFrame, metrics []
 		placeholders[idx] = "?"
 	}
 
-	upsertCols := make([]string, len(colNames))
-	for idx, col := range colNames {
-		upsertCols[idx] = fmt.Sprintf("%s = COALESCE(excluded.%s, %s)", col, col, col)
+	upsertCols := make([]string, 0, 2+len(colNames))
+	upsertCols = append(upsertCols,
+		"date_key = COALESCE(excluded.date_key, date_key)",
+		"report_period = COALESCE(excluded.report_period, report_period)",
+	)
+
+	for _, col := range colNames {
+		upsertCols = append(upsertCols, fmt.Sprintf("%s = COALESCE(excluded.%s, %s)", col, col, col))
 	}
 
 	query := fmt.Sprintf(

--- a/data/snapshot_recorder_test.go
+++ b/data/snapshot_recorder_test.go
@@ -499,6 +499,63 @@ var _ = Describe("SnapshotRecorder", func() {
 			Expect(wc).To(BeNumerically("==", 120_000_000.0))
 		})
 
+		It("populates date_key when a row already exists from the daily Fetch path", func() {
+			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
+			assets := []asset.Asset{spy}
+			dateKey := time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)
+
+			dailyDF, err := data.NewDataFrame(
+				[]time.Time{dateKey},
+				assets,
+				[]data.Metric{data.WorkingCapital},
+				data.Daily,
+				[][]float64{{50_000_000}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			stub := &stubFundamentalsByDateKeyProvider{
+				TestProvider: data.NewTestProvider([]data.Metric{data.WorkingCapital}, dailyDF),
+				values:       map[string]float64{spy.CompositeFigi: 120_000_000.0},
+				dimension:    "ARQ",
+			}
+
+			var recErr error
+			recorder, recErr = data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				BatchProvider: stub,
+				AssetProvider: &stubAssetProvider{assets: assets},
+			})
+			Expect(recErr).NotTo(HaveOccurred())
+
+			_, err = recorder.Fetch(ctx, data.DataRequest{
+				Assets:    assets,
+				Metrics:   []data.Metric{data.WorkingCapital},
+				Start:     dateKey,
+				End:       dateKey,
+				Frequency: data.Daily,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = recorder.FetchFundamentalsByDateKey(ctx, assets,
+				[]data.Metric{data.WorkingCapital}, dateKey, "ARQ", dateKey)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.Close()).To(Succeed())
+			recorder = nil
+
+			db, err := sql.Open("sqlite", dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer db.Close()
+
+			var dateKeyStr sql.NullString
+			err = db.QueryRow(
+				`SELECT date_key FROM fundamentals WHERE composite_figi = ?`,
+				spy.CompositeFigi,
+			).Scan(&dateKeyStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dateKeyStr.Valid).To(BeTrue(), "date_key should be populated by FetchFundamentalsByDateKey even when a row already exists")
+			Expect(dateKeyStr.String).To(Equal("2024-12-31"))
+		})
+
 		It("errors when no wrapped provider supports FundamentalsByDateKey", func() {
 			spy := asset.Asset{CompositeFigi: "BBG000BLNNH6", Ticker: "SPY"}
 			assets := []asset.Asset{spy}


### PR DESCRIPTION
## Summary

- `SnapshotRecorder.FetchFundamentalsByDateKey` writes rows at `event_date = dateKey`. When `dateKey` falls on a trading day (e.g. `2024-12-31`), a row at that event_date typically already exists from the daily Fetch pass with `date_key = NULL`. The previous `ON CONFLICT` clause only updated metric columns, so the incoming `date_key` and `report_period` values were silently discarded — and replay returned no row for that reporting period, breaking strategies like NCAV on years where the rebalance dateKey happens to be a trading day.
- The upsert now includes `date_key = COALESCE(excluded.date_key, date_key)` and the same for `report_period`. A non-null incoming value fills in the existing NULL; a NULL incoming value leaves the existing value intact.
- Covered by a new test that writes via the daily Fetch path first, then via `FetchFundamentalsByDateKey`, and asserts the final row has the correct `date_key`.