### PR TITLE
Release v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-04-18
+
 ### Fixed
 
 - Snapshot replay no longer returns an empty screen when a `FetchFundamentalsByDateKey` call targets a reporting period that falls on a trading day (e.g. `2024-12-31`). The recorder's upsert now propagates `date_key` and `report_period` into existing rows instead of leaving them NULL on conflict.


### PR DESCRIPTION
v0.7.4 made snapshot capture work for strategies using `Engine.FetchFundamentalsByDateKey`, but only for reporting periods that fall on non-trading days. When `dateKey` hits a trading day — `2024-12-31`, for example — a row at that `event_date` already exists from the daily Fetch pass with `date_key = NULL`, and v0.7.4's upsert only updated metric columns on conflict. The new `date_key` and `report_period` values were silently dropped, so replay found no row for the reporting period and strategies like NCAV returned an empty screen on the affected years. v0.7.5 fixes the upsert to carry `date_key` and `report_period` through with `COALESCE(excluded, existing)` semantics.