### PR TITLE
feat(cli): add --json flag to backtest for JSON Lines output

### DIFF
--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -38,6 +38,7 @@ func newBacktestCmd(strategy engine.Strategy) *cobra.Command {
 	cmd.Flags().Float64("cash", 100000, "Initial cash balance")
 	cmd.Flags().String("output", "", "Output file path (default: auto-generated)")
 	cmd.Flags().Bool("no-progress", false, "Disable the interactive progress bar (logs go straight to stderr)")
+	cmd.Flags().Bool("json", false, "Output JSON Lines to stdout (for programmatic consumers)")
 
 	registerStrategyFlags(cmd, strategy)
 	cmd.Flags().String("preset", "", "Apply a named parameter preset")
@@ -93,6 +94,19 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		return err
 	}
 
+	jsonMode, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
+
+	var reporter *jsonReporter
+	if jsonMode {
+		savedLogger := log.Logger
+		log.Logger = zerolog.New(os.Stdout).With().Str("type", "log").Timestamp().Logger()
+		defer func() { log.Logger = savedLogger }()
+		reporter = newJSONReporter(os.Stdout)
+	}
+
 	fullID, shortID := runID()
 
 	outputPath, err := cmd.Flags().GetString("output")
@@ -119,6 +133,10 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		Str("output", outputPath).
 		Str("run_id", fullID).
 		Msg("starting backtest")
+
+	if jsonMode {
+		reporter.Started(fullID, strategy.Name(), start.Format("2006-01-02"), end.Format("2006-01-02"), cash, outputPath)
+	}
 
 	if err := applyPreset(cmd, strategy); err != nil {
 		return err
@@ -165,7 +183,7 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		engineOpts = append(engineOpts, engine.WithBenchmarkTicker(benchmarkTicker))
 	}
 
-	useProgress := !noProgress && stderrIsTerminal()
+	useProgress := !noProgress && !jsonMode && stderrIsTerminal()
 
 	var (
 		program   *tea.Program
@@ -200,6 +218,12 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		fmt.Fprintf(os.Stderr, "Logs: %s\n", logPath)
 	}
 
+	if jsonMode {
+		engineOpts = append(engineOpts, engine.WithProgressCallback(func(ev engine.ProgressEvent) {
+			reporter.Progress(ev)
+		}))
+	}
+
 	eng := engine.New(strategy, engineOpts...)
 	defer eng.Close()
 
@@ -207,6 +231,9 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 
 	result, err := runEngineBacktest(eng, program, logWriter, start, end)
 	if err != nil {
+		if jsonMode {
+			reporter.Error(fullID, err)
+		}
 		return fmt.Errorf("backtest failed: %w", err)
 	}
 
@@ -231,8 +258,12 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 
 	log.Info().Str("path", outputPath).Msg("backtest output written")
 
-	if err := summary.Render(acct, os.Stdout); err != nil {
-		return fmt.Errorf("rendering report: %w", err)
+	if jsonMode {
+		reporter.Completed(fullID, outputPath)
+	} else {
+		if err := summary.Render(acct, os.Stdout); err != nil {
+			return fmt.Errorf("rendering report: %w", err)
+		}
 	}
 
 	return nil
@@ -274,10 +305,11 @@ func strategyParams(strategy engine.Strategy) map[string]any {
 
 // runEngineBacktest runs the engine, optionally rendering a bubble tea
 // progress bar. When program is nil the engine is run inline and zerolog
-// continues writing to its existing destination. When program is non-nil,
-// zerolog is redirected to logWriter (a plain-text file) before the context
-// is created, so all engine code using zerolog.Ctx(ctx) also writes to the
-// file rather than stderr.
+// continues writing to its existing destination — intentionally, so that
+// callers (e.g. the --json path) can pre-configure log.Logger before the
+// call. When program is non-nil, zerolog is redirected to logWriter (a
+// plain-text file) before the context is created, so all engine code using
+// zerolog.Ctx(ctx) also writes to the file rather than stderr.
 func runEngineBacktest(eng *engine.Engine, program *tea.Program, logWriter io.Writer, start, end time.Time) (portfolio.Portfolio, error) {
 	if program == nil {
 		ctx := log.Logger.WithContext(context.Background())

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -100,10 +100,13 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 	}
 
 	var reporter *jsonReporter
+
 	if jsonMode {
 		savedLogger := log.Logger
 		log.Logger = zerolog.New(os.Stdout).With().Str("type", "log").Timestamp().Logger()
+
 		defer func() { log.Logger = savedLogger }()
+
 		reporter = newJSONReporter(os.Stdout)
 	}
 
@@ -234,6 +237,7 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		if jsonMode {
 			reporter.Error(fullID, err)
 		}
+
 		return fmt.Errorf("backtest failed: %w", err)
 	}
 

--- a/cli/json_reporter.go
+++ b/cli/json_reporter.go
@@ -1,0 +1,167 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/rs/zerolog/log"
+)
+
+type jsonReporter struct {
+	w         io.Writer
+	startTime time.Time
+}
+
+func newJSONReporter(w io.Writer) *jsonReporter {
+	return &jsonReporter{w: w, startTime: time.Now()}
+}
+
+type statusStartedMsg struct {
+	Type     string  `json:"type"`
+	Event    string  `json:"event"`
+	RunID    string  `json:"run_id"`
+	Strategy string  `json:"strategy"`
+	Start    string  `json:"start"`
+	End      string  `json:"end"`
+	Cash     float64 `json:"cash"`
+	Output   string  `json:"output"`
+	Time     string  `json:"time"`
+}
+
+type statusCompletedMsg struct {
+	Type      string `json:"type"`
+	Event     string `json:"event"`
+	RunID     string `json:"run_id"`
+	Output    string `json:"output"`
+	ElapsedMS int64  `json:"elapsed_ms"`
+	Time      string `json:"time"`
+}
+
+type statusErrorMsg struct {
+	Type   string `json:"type"`
+	Event  string `json:"event"`
+	RunID  string `json:"run_id"`
+	Error  string `json:"error"`
+	Time   string `json:"time"`
+}
+
+type progressLineMsg struct {
+	Type         string  `json:"type"`
+	Step         int     `json:"step"`
+	TotalSteps   int     `json:"total_steps"`
+	CurrentDate  string  `json:"current_date"`
+	TargetDate   string  `json:"target_date"`
+	Pct          float64 `json:"pct"`
+	ElapsedMS    int64   `json:"elapsed_ms"`
+	EtaMS        int64   `json:"eta_ms"`
+	Measurements int     `json:"measurements"`
+}
+
+func (r *jsonReporter) Started(runID, strategy, startDate, endDate string, cash float64, output string) {
+	r.writeJSON(statusStartedMsg{
+		Type:     "status",
+		Event:    "started",
+		RunID:    runID,
+		Strategy: strategy,
+		Start:    startDate,
+		End:      endDate,
+		Cash:     cash,
+		Output:   output,
+		Time:     time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (r *jsonReporter) Completed(runID, output string) {
+	r.writeJSON(statusCompletedMsg{
+		Type:      "status",
+		Event:     "completed",
+		RunID:     runID,
+		Output:    output,
+		ElapsedMS: time.Since(r.startTime).Milliseconds(),
+		Time:      time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (r *jsonReporter) Error(runID string, err error) {
+	r.writeJSON(statusErrorMsg{
+		Type:   "status",
+		Event:  "error",
+		RunID:  runID,
+		Error:  err.Error(),
+		Time:   time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (r *jsonReporter) Progress(ev engine.ProgressEvent) {
+	pct := progressFraction(ev)
+	elapsed := time.Since(r.startTime)
+	r.writeJSON(progressLineMsg{
+		Type:         "progress",
+		Step:         ev.Step,
+		TotalSteps:   ev.TotalSteps,
+		CurrentDate:  ev.Date.Format("2006-01-02"),
+		TargetDate:   ev.End.Format("2006-01-02"),
+		Pct:          math.Round(pct*10000) / 100,
+		ElapsedMS:    elapsed.Milliseconds(),
+		EtaMS:        computeEtaMS(elapsed, pct),
+		Measurements: ev.MeasurementsEvaluated,
+	})
+}
+
+func (r *jsonReporter) writeJSON(v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		log.Error().Err(err).Msg("json reporter: marshal failed")
+		return
+	}
+	if _, err := fmt.Fprintln(r.w, string(b)); err != nil {
+		log.Error().Err(err).Msg("json reporter: write failed")
+	}
+}
+
+// progressFraction computes completion as a fraction in [0,1] from the date span.
+func progressFraction(ev engine.ProgressEvent) float64 {
+	if ev.Date.IsZero() || !ev.End.After(ev.Start) {
+		return 0
+	}
+	span := ev.End.Sub(ev.Start).Seconds()
+	if span <= 0 {
+		return 0
+	}
+	frac := ev.Date.Sub(ev.Start).Seconds() / span
+	switch {
+	case frac < 0:
+		return 0
+	case frac > 1:
+		return 1
+	default:
+		return frac
+	}
+}
+
+// computeEtaMS returns estimated milliseconds remaining, or 0 if pct is 0 or 1.
+func computeEtaMS(elapsed time.Duration, pct float64) int64 {
+	if pct <= 0 || pct >= 1 {
+		return 0
+	}
+	return time.Duration(float64(elapsed) / pct * (1 - pct)).Milliseconds()
+}

--- a/cli/json_reporter.go
+++ b/cli/json_reporter.go
@@ -57,11 +57,11 @@ type statusCompletedMsg struct {
 }
 
 type statusErrorMsg struct {
-	Type   string `json:"type"`
-	Event  string `json:"event"`
-	RunID  string `json:"run_id"`
-	Error  string `json:"error"`
-	Time   string `json:"time"`
+	Type  string `json:"type"`
+	Event string `json:"event"`
+	RunID string `json:"run_id"`
+	Error string `json:"error"`
+	Time  string `json:"time"`
 }
 
 type progressLineMsg struct {
@@ -103,11 +103,11 @@ func (r *jsonReporter) Completed(runID, output string) {
 
 func (r *jsonReporter) Error(runID string, err error) {
 	r.writeJSON(statusErrorMsg{
-		Type:   "status",
-		Event:  "error",
-		RunID:  runID,
-		Error:  err.Error(),
-		Time:   time.Now().UTC().Format(time.RFC3339),
+		Type:  "status",
+		Event: "error",
+		RunID: runID,
+		Error: err.Error(),
+		Time:  time.Now().UTC().Format(time.RFC3339),
 	})
 }
 

--- a/cli/json_reporter.go
+++ b/cli/json_reporter.go
@@ -133,6 +133,7 @@ func (r *jsonReporter) writeJSON(v any) {
 		log.Error().Err(err).Msg("json reporter: marshal failed")
 		return
 	}
+
 	if _, err := fmt.Fprintln(r.w, string(b)); err != nil {
 		log.Error().Err(err).Msg("json reporter: write failed")
 	}
@@ -143,10 +144,12 @@ func progressFraction(ev engine.ProgressEvent) float64 {
 	if ev.Date.IsZero() || !ev.End.After(ev.Start) {
 		return 0
 	}
+
 	span := ev.End.Sub(ev.Start).Seconds()
 	if span <= 0 {
 		return 0
 	}
+
 	frac := ev.Date.Sub(ev.Start).Seconds() / span
 	switch {
 	case frac < 0:
@@ -163,5 +166,6 @@ func computeEtaMS(elapsed time.Duration, pct float64) int64 {
 	if pct <= 0 || pct >= 1 {
 		return 0
 	}
+
 	return time.Duration(float64(elapsed) / pct * (1 - pct)).Milliseconds()
 }

--- a/cli/json_reporter.go
+++ b/cli/json_reporter.go
@@ -128,13 +128,13 @@ func (r *jsonReporter) Progress(ev engine.ProgressEvent) {
 }
 
 func (r *jsonReporter) writeJSON(v any) {
-	b, err := json.Marshal(v)
+	jsonBytes, err := json.Marshal(v)
 	if err != nil {
 		log.Error().Err(err).Msg("json reporter: marshal failed")
 		return
 	}
 
-	if _, err := fmt.Fprintln(r.w, string(b)); err != nil {
+	if _, err := fmt.Fprintln(r.w, string(jsonBytes)); err != nil {
 		log.Error().Err(err).Msg("json reporter: write failed")
 	}
 }

--- a/cli/json_reporter_test.go
+++ b/cli/json_reporter_test.go
@@ -1,0 +1,187 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/penny-vault/pvbt/engine"
+)
+
+// parseLines parses all newline-delimited JSON objects written to buf.
+func parseLines(buf *bytes.Buffer) []map[string]any {
+	GinkgoHelper()
+	var results []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		Expect(json.Unmarshal([]byte(line), &m)).To(Succeed())
+		results = append(results, m)
+	}
+	return results
+}
+
+var _ = Describe("progressFraction", func() {
+	It("returns 0 when Date is zero", func() {
+		ev := engine.ProgressEvent{
+			Start: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		Expect(progressFraction(ev)).To(Equal(0.0))
+	})
+
+	It("returns 0 when End is not after Start", func() {
+		t := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		ev := engine.ProgressEvent{Start: t, End: t, Date: t}
+		Expect(progressFraction(ev)).To(Equal(0.0))
+	})
+
+	It("returns ~0.5 for the midpoint date", func() {
+		start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		mid := start.Add(end.Sub(start) / 2)
+		ev := engine.ProgressEvent{Start: start, End: end, Date: mid}
+		Expect(progressFraction(ev)).To(BeNumerically("~", 0.5, 0.01))
+	})
+
+	It("clamps to 1 when Date exceeds End", func() {
+		start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		ev := engine.ProgressEvent{Start: start, End: end, Date: end.AddDate(1, 0, 0)}
+		Expect(progressFraction(ev)).To(Equal(1.0))
+	})
+})
+
+var _ = Describe("computeEtaMS", func() {
+	It("returns 0 when pct is 0", func() {
+		Expect(computeEtaMS(10*time.Second, 0)).To(Equal(int64(0)))
+	})
+
+	It("returns 0 when pct is 1", func() {
+		Expect(computeEtaMS(10*time.Second, 1.0)).To(Equal(int64(0)))
+	})
+
+	It("returns approximate remaining ms at 25% completion", func() {
+		// 25% done in 10s → 30s remaining
+		eta := computeEtaMS(10*time.Second, 0.25)
+		Expect(eta).To(BeNumerically("~", int64(30000), int64(100)))
+	})
+})
+
+var _ = Describe("jsonReporter", func() {
+	var (
+		buf      *bytes.Buffer
+		reporter *jsonReporter
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		reporter = newJSONReporter(buf)
+	})
+
+	Describe("Started", func() {
+		It("emits a started status line with all fields", func() {
+			reporter.Started("run123", "my-strategy", "2020-01-01", "2025-01-01", 100000, "/tmp/out.db")
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("status"))
+			Expect(m["event"]).To(Equal("started"))
+			Expect(m["run_id"]).To(Equal("run123"))
+			Expect(m["strategy"]).To(Equal("my-strategy"))
+			Expect(m["start"]).To(Equal("2020-01-01"))
+			Expect(m["end"]).To(Equal("2025-01-01"))
+			Expect(m["cash"]).To(BeNumerically("~", 100000.0, 0.01))
+			Expect(m["output"]).To(Equal("/tmp/out.db"))
+			Expect(m["time"]).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Completed", func() {
+		It("emits a completed status line with elapsed_ms", func() {
+			reporter.Completed("run123", "/tmp/out.db")
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("status"))
+			Expect(m["event"]).To(Equal("completed"))
+			Expect(m["run_id"]).To(Equal("run123"))
+			Expect(m["output"]).To(Equal("/tmp/out.db"))
+			Expect(m["elapsed_ms"]).To(BeNumerically(">=", float64(0)))
+			Expect(m["time"]).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Error", func() {
+		It("emits an error status line with the error message", func() {
+			reporter.Error("run123", fmt.Errorf("data provider unavailable"))
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("status"))
+			Expect(m["event"]).To(Equal("error"))
+			Expect(m["run_id"]).To(Equal("run123"))
+			Expect(m["error"]).To(Equal("data provider unavailable"))
+			Expect(m["time"]).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Progress", func() {
+		It("emits a progress line with all fields", func() {
+			start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			end := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			mid := start.Add(end.Sub(start) / 2)
+			ev := engine.ProgressEvent{
+				Step:                  500,
+				TotalSteps:            1000,
+				Date:                  mid,
+				Start:                 start,
+				End:                   end,
+				MeasurementsEvaluated: 12345,
+			}
+			reporter.Progress(ev)
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("progress"))
+			Expect(m["step"]).To(BeNumerically("~", float64(500), 1))
+			Expect(m["total_steps"]).To(BeNumerically("~", float64(1000), 1))
+			Expect(m["current_date"]).To(Equal(mid.Format("2006-01-02")))
+			Expect(m["target_date"]).To(Equal("2025-01-01"))
+			Expect(m["pct"]).To(BeNumerically("~", float64(50), 1))
+			Expect(m["elapsed_ms"]).To(BeNumerically(">=", float64(0)))
+			Expect(m["measurements"]).To(BeNumerically("~", float64(12345), 1))
+		})
+	})
+})
+
+var _ = Describe("backtest --json flag", func() {
+	It("is registered on the backtest command", func() {
+		strategy := &testStrategy{}
+		cmd := newBacktestCmd(strategy)
+		f := cmd.Flags().Lookup("json")
+		Expect(f).NotTo(BeNil())
+		Expect(f.Value.Type()).To(Equal("bool"))
+	})
+})

--- a/docs/superpowers/plans/2026-04-22-backtest-json-mode.md
+++ b/docs/superpowers/plans/2026-04-22-backtest-json-mode.md
@@ -1,0 +1,666 @@
+# Backtest JSON Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `--json` flag to the `backtest` subcommand that switches stdout to a JSON Lines stream of progress, log, and lifecycle messages for consumption by a web UI.
+
+**Architecture:** A `jsonReporter` helper in `cli/` handles all structured writes to stdout; zerolog is reconfigured to output native JSON (with a `"type":"log"` context field) instead of the styled console writer; the existing progress callback abstraction routes engine events through the reporter instead of the bubble tea model.
+
+**Tech Stack:** Go stdlib `encoding/json`, `github.com/rs/zerolog`, `github.com/penny-vault/pvbt/engine.ProgressEvent`, Ginkgo/Gomega for tests.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `cli/json_reporter.go` | Create | `jsonReporter` struct, `progressFraction`, `computeEtaMS` |
+| `cli/json_reporter_test.go` | Create | Unit tests for all reporter methods and helpers |
+| `cli/backtest.go` | Modify | Register `--json` flag, wire reporter and progress callback |
+
+---
+
+## Task 1: Write failing tests for `jsonReporter`
+
+**Files:**
+- Create: `cli/json_reporter_test.go`
+
+- [ ] **Step 1.1: Create the test file**
+
+```go
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/penny-vault/pvbt/engine"
+)
+
+// parseLines parses all newline-delimited JSON objects written to buf.
+func parseLines(buf *bytes.Buffer) []map[string]any {
+	GinkgoHelper()
+	var results []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		Expect(json.Unmarshal([]byte(line), &m)).To(Succeed())
+		results = append(results, m)
+	}
+	return results
+}
+
+var _ = Describe("progressFraction", func() {
+	It("returns 0 when Date is zero", func() {
+		ev := engine.ProgressEvent{
+			Start: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		Expect(progressFraction(ev)).To(Equal(0.0))
+	})
+
+	It("returns 0 when End is not after Start", func() {
+		t := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		ev := engine.ProgressEvent{Start: t, End: t, Date: t}
+		Expect(progressFraction(ev)).To(Equal(0.0))
+	})
+
+	It("returns ~0.5 for the midpoint date", func() {
+		start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		mid := start.Add(end.Sub(start) / 2)
+		ev := engine.ProgressEvent{Start: start, End: end, Date: mid}
+		Expect(progressFraction(ev)).To(BeNumerically("~", 0.5, 0.01))
+	})
+
+	It("clamps to 1 when Date exceeds End", func() {
+		start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		ev := engine.ProgressEvent{Start: start, End: end, Date: end.AddDate(1, 0, 0)}
+		Expect(progressFraction(ev)).To(Equal(1.0))
+	})
+})
+
+var _ = Describe("computeEtaMS", func() {
+	It("returns 0 when pct is 0", func() {
+		Expect(computeEtaMS(10*time.Second, 0)).To(Equal(int64(0)))
+	})
+
+	It("returns 0 when pct is 1", func() {
+		Expect(computeEtaMS(10*time.Second, 1.0)).To(Equal(int64(0)))
+	})
+
+	It("returns approximate remaining ms at 25% completion", func() {
+		// 25% done in 10s → 30s remaining
+		eta := computeEtaMS(10*time.Second, 0.25)
+		Expect(eta).To(BeNumerically("~", int64(30000), int64(100)))
+	})
+})
+
+var _ = Describe("jsonReporter", func() {
+	var (
+		buf      *bytes.Buffer
+		reporter *jsonReporter
+	)
+
+	BeforeEach(func() {
+		buf = &bytes.Buffer{}
+		reporter = newJSONReporter(buf)
+	})
+
+	Describe("Started", func() {
+		It("emits a started status line with all fields", func() {
+			reporter.Started("run123", "my-strategy", "2020-01-01", "2025-01-01", 100000, "/tmp/out.db")
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("status"))
+			Expect(m["event"]).To(Equal("started"))
+			Expect(m["run_id"]).To(Equal("run123"))
+			Expect(m["strategy"]).To(Equal("my-strategy"))
+			Expect(m["start"]).To(Equal("2020-01-01"))
+			Expect(m["end"]).To(Equal("2025-01-01"))
+			Expect(m["cash"]).To(BeNumerically("~", 100000.0, 0.01))
+			Expect(m["output"]).To(Equal("/tmp/out.db"))
+			Expect(m["time"]).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Completed", func() {
+		It("emits a completed status line with elapsed_ms", func() {
+			reporter.Completed("run123", "/tmp/out.db")
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("status"))
+			Expect(m["event"]).To(Equal("completed"))
+			Expect(m["run_id"]).To(Equal("run123"))
+			Expect(m["output"]).To(Equal("/tmp/out.db"))
+			Expect(m["elapsed_ms"]).NotTo(BeNil())
+			Expect(m["time"]).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Error", func() {
+		It("emits an error status line with the error message", func() {
+			reporter.Error("run123", fmt.Errorf("data provider unavailable"))
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("status"))
+			Expect(m["event"]).To(Equal("error"))
+			Expect(m["run_id"]).To(Equal("run123"))
+			Expect(m["error"]).To(Equal("data provider unavailable"))
+			Expect(m["time"]).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Progress", func() {
+		It("emits a progress line with all fields", func() {
+			start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			end := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			mid := start.Add(end.Sub(start) / 2)
+			ev := engine.ProgressEvent{
+				Step:                  500,
+				TotalSteps:            1000,
+				Date:                  mid,
+				Start:                 start,
+				End:                   end,
+				MeasurementsEvaluated: 12345,
+			}
+			reporter.Progress(ev)
+			lines := parseLines(buf)
+			Expect(lines).To(HaveLen(1))
+			m := lines[0]
+			Expect(m["type"]).To(Equal("progress"))
+			Expect(m["step"]).To(BeNumerically("~", float64(500), 1))
+			Expect(m["total_steps"]).To(BeNumerically("~", float64(1000), 1))
+			Expect(m["current_date"]).To(Equal(mid.Format("2006-01-02")))
+			Expect(m["target_date"]).To(Equal("2025-01-01"))
+			Expect(m["pct"]).To(BeNumerically("~", float64(50), 1))
+			Expect(m["elapsed_ms"]).NotTo(BeNil())
+			Expect(m["measurements"]).To(BeNumerically("~", float64(12345), 1))
+		})
+	})
+})
+
+var _ = Describe("backtest --json flag", func() {
+	It("is registered on the backtest command", func() {
+		strategy := &testStrategy{}
+		cmd := newBacktestCmd(strategy)
+		f := cmd.Flags().Lookup("json")
+		Expect(f).NotTo(BeNil())
+		Expect(f.Value.Type()).To(Equal("bool"))
+	})
+})
+```
+
+- [ ] **Step 1.2: Run the tests to confirm they fail**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+go test ./cli/... -run "progressFraction|computeEtaMS|jsonReporter|backtest.*json" -v 2>&1 | head -40
+```
+
+Expected: compile errors — `progressFraction`, `computeEtaMS`, `newJSONReporter`, and `reporter.Started/Completed/Error/Progress` are undefined.
+
+---
+
+## Task 2: Implement `cli/json_reporter.go`
+
+**Files:**
+- Create: `cli/json_reporter.go`
+
+- [ ] **Step 2.1: Create the implementation file**
+
+```go
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"time"
+
+	"github.com/penny-vault/pvbt/engine"
+)
+
+type jsonReporter struct {
+	w         io.Writer
+	startTime time.Time
+}
+
+func newJSONReporter(w io.Writer) *jsonReporter {
+	return &jsonReporter{w: w, startTime: time.Now()}
+}
+
+type statusStartedMsg struct {
+	Type     string  `json:"type"`
+	Event    string  `json:"event"`
+	RunID    string  `json:"run_id"`
+	Strategy string  `json:"strategy"`
+	Start    string  `json:"start"`
+	End      string  `json:"end"`
+	Cash     float64 `json:"cash"`
+	Output   string  `json:"output"`
+	Time     string  `json:"time"`
+}
+
+type statusCompletedMsg struct {
+	Type      string `json:"type"`
+	Event     string `json:"event"`
+	RunID     string `json:"run_id"`
+	Output    string `json:"output"`
+	ElapsedMS int64  `json:"elapsed_ms"`
+	Time      string `json:"time"`
+}
+
+type statusErrorMsg struct {
+	Type   string `json:"type"`
+	Event  string `json:"event"`
+	RunID  string `json:"run_id"`
+	Error  string `json:"error"`
+	Time   string `json:"time"`
+}
+
+type progressLineMsg struct {
+	Type         string  `json:"type"`
+	Step         int     `json:"step"`
+	TotalSteps   int     `json:"total_steps"`
+	CurrentDate  string  `json:"current_date"`
+	TargetDate   string  `json:"target_date"`
+	Pct          float64 `json:"pct"`
+	ElapsedMS    int64   `json:"elapsed_ms"`
+	EtaMS        int64   `json:"eta_ms"`
+	Measurements int     `json:"measurements"`
+}
+
+func (r *jsonReporter) Started(runID, strategy, startDate, endDate string, cash float64, output string) {
+	r.writeJSON(statusStartedMsg{
+		Type:     "status",
+		Event:    "started",
+		RunID:    runID,
+		Strategy: strategy,
+		Start:    startDate,
+		End:      endDate,
+		Cash:     cash,
+		Output:   output,
+		Time:     time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (r *jsonReporter) Completed(runID, output string) {
+	r.writeJSON(statusCompletedMsg{
+		Type:      "status",
+		Event:     "completed",
+		RunID:     runID,
+		Output:    output,
+		ElapsedMS: time.Since(r.startTime).Milliseconds(),
+		Time:      time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (r *jsonReporter) Error(runID string, err error) {
+	r.writeJSON(statusErrorMsg{
+		Type:   "status",
+		Event:  "error",
+		RunID:  runID,
+		Error:  err.Error(),
+		Time:   time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (r *jsonReporter) Progress(ev engine.ProgressEvent) {
+	pct := progressFraction(ev)
+	elapsed := time.Since(r.startTime)
+	r.writeJSON(progressLineMsg{
+		Type:         "progress",
+		Step:         ev.Step,
+		TotalSteps:   ev.TotalSteps,
+		CurrentDate:  ev.Date.Format("2006-01-02"),
+		TargetDate:   ev.End.Format("2006-01-02"),
+		Pct:          math.Round(pct*10000) / 100,
+		ElapsedMS:    elapsed.Milliseconds(),
+		EtaMS:        computeEtaMS(elapsed, pct),
+		Measurements: ev.MeasurementsEvaluated,
+	})
+}
+
+func (r *jsonReporter) writeJSON(v any) {
+	b, _ := json.Marshal(v)
+	fmt.Fprintln(r.w, string(b))
+}
+
+// progressFraction computes completion as a fraction in [0,1] from the date span.
+func progressFraction(ev engine.ProgressEvent) float64 {
+	if ev.Date.IsZero() || !ev.End.After(ev.Start) {
+		return 0
+	}
+	span := ev.End.Sub(ev.Start).Seconds()
+	if span <= 0 {
+		return 0
+	}
+	frac := ev.Date.Sub(ev.Start).Seconds() / span
+	switch {
+	case frac < 0:
+		return 0
+	case frac > 1:
+		return 1
+	default:
+		return frac
+	}
+}
+
+// computeEtaMS returns estimated milliseconds remaining, or 0 if pct is 0 or 1.
+func computeEtaMS(elapsed time.Duration, pct float64) int64 {
+	if pct <= 0 || pct >= 1 {
+		return 0
+	}
+	return time.Duration(float64(elapsed) / pct * (1 - pct)).Milliseconds()
+}
+```
+
+- [ ] **Step 2.2: Run the tests to confirm they pass**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+go test ./cli/... -run "progressFraction|computeEtaMS|jsonReporter" -v 2>&1 | tail -20
+```
+
+Expected: all `progressFraction`, `computeEtaMS`, and `jsonReporter` specs PASS.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+git add cli/json_reporter.go cli/json_reporter_test.go
+git commit -m "feat(cli): add jsonReporter with progress, status, and log helpers"
+```
+
+---
+
+## Task 3: Wire `--json` into `cli/backtest.go`
+
+**Files:**
+- Modify: `cli/backtest.go`
+
+- [ ] **Step 3.1: Run the `--json` flag test to confirm it fails**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+go test ./cli/... -run "backtest.*json" -v 2>&1
+```
+
+Expected: FAIL — `Lookup("json")` returns nil.
+
+- [ ] **Step 3.2: Register `--json` flag in `newBacktestCmd`**
+
+In `newBacktestCmd`, after the `no-progress` flag registration, add:
+
+```go
+cmd.Flags().Bool("json", false, "Output JSON Lines to stdout (for programmatic consumers)")
+```
+
+The block becomes:
+
+```go
+cmd.Flags().String("start", fiveYearsAgo.Format("2006-01-02"), "Backtest start date (YYYY-MM-DD)")
+cmd.Flags().String("end", now.Format("2006-01-02"), "Backtest end date (YYYY-MM-DD)")
+cmd.Flags().Float64("cash", 100000, "Initial cash balance")
+cmd.Flags().String("output", "", "Output file path (default: auto-generated)")
+cmd.Flags().Bool("no-progress", false, "Disable the interactive progress bar (logs go straight to stderr)")
+cmd.Flags().Bool("json", false, "Output JSON Lines to stdout (for programmatic consumers)")
+```
+
+- [ ] **Step 3.3: Run the flag test to confirm it passes**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+go test ./cli/... -run "backtest.*json" -v 2>&1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.4: Wire the reporter into `runBacktest`**
+
+Replace the body of `runBacktest` in `cli/backtest.go` with the version below. The changes are:
+1. Read `--json` flag after `cash`
+2. Configure zerolog for JSON mode before the first `log.Info()` call
+3. Create reporter and emit `started` before the engine runs
+4. `useProgress` now also checks `!jsonMode`
+5. Add JSON progress callback block after the TUI block
+6. Emit `reporter.Error` on engine failure
+7. Replace `summary.Render()` with `reporter.Completed()` in JSON mode
+
+```go
+func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
+	nyc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		return fmt.Errorf("load America/New_York timezone: %w", err)
+	}
+
+	startStr, err := cmd.Flags().GetString("start")
+	if err != nil {
+		return err
+	}
+
+	start, err := time.ParseInLocation("2006-01-02", startStr, nyc)
+	if err != nil {
+		return fmt.Errorf("invalid start date: %w", err)
+	}
+
+	endStr, err := cmd.Flags().GetString("end")
+	if err != nil {
+		return err
+	}
+
+	end, err := time.ParseInLocation("2006-01-02", endStr, nyc)
+	if err != nil {
+		return fmt.Errorf("invalid end date: %w", err)
+	}
+
+	cash, err := cmd.Flags().GetFloat64("cash")
+	if err != nil {
+		return err
+	}
+
+	jsonMode, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
+
+	var reporter *jsonReporter
+	if jsonMode {
+		savedLogger := log.Logger
+		log.Logger = zerolog.New(os.Stdout).With().Str("type", "log").Timestamp().Logger()
+		defer func() { log.Logger = savedLogger }()
+		reporter = newJSONReporter(os.Stdout)
+	}
+
+	fullID, shortID := runID()
+
+	outputPath, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return err
+	}
+
+	if outputPath == "" {
+		info := engine.DescribeStrategy(strategy)
+
+		filePrefix := info.ShortCode
+		if filePrefix == "" {
+			filePrefix = strategy.Name()
+		}
+
+		outputPath = defaultOutputPath(filePrefix, start, end, shortID)
+	}
+
+	log.Info().
+		Str("strategy", strategy.Name()).
+		Time("start", start).
+		Time("end", end).
+		Float64("cash", cash).
+		Str("output", outputPath).
+		Str("run_id", fullID).
+		Msg("starting backtest")
+
+	if jsonMode {
+		reporter.Started(fullID, strategy.Name(), start.Format("2006-01-02"), end.Format("2006-01-02"), cash, outputPath)
+	}
+
+	if err := applyPreset(cmd, strategy); err != nil {
+		return err
+	}
+
+	applyStrategyFlags(cmd, strategy)
+
+	cfg, err := loadMiddlewareConfigFromCommand(cmd)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	noProgress, err := cmd.Flags().GetBool("no-progress")
+	if err != nil {
+		return err
+	}
+
+	provider, err := data.NewPVDataProvider(nil)
+	if err != nil {
+		return fmt.Errorf("create data provider: %w", err)
+	}
+
+	acct := portfolio.New(
+		portfolio.WithCash(cash, start),
+		portfolio.WithAllMetrics(),
+	)
+
+	engineOpts := []engine.Option{
+		engine.WithDataProvider(provider),
+		engine.WithAssetProvider(provider),
+		engine.WithAccount(acct),
+	}
+
+	if cfg.HasMiddleware() {
+		engineOpts = append(engineOpts, engine.WithMiddlewareConfig(*cfg))
+	}
+
+	benchmarkTicker, err := cmd.Flags().GetString("benchmark")
+	if err != nil {
+		return err
+	}
+
+	if benchmarkTicker != "" {
+		engineOpts = append(engineOpts, engine.WithBenchmarkTicker(benchmarkTicker))
+	}
+
+	useProgress := !noProgress && !jsonMode && stderrIsTerminal()
+
+	var (
+		program   *tea.Program
+		logWriter io.Writer
+	)
+
+	if useProgress {
+		title := fmt.Sprintf("Backtest: %s", strategy.Name())
+		model := newProgressModel(title, start, end)
+		program = tea.NewProgram(model, tea.WithOutput(os.Stderr))
+
+		engineOpts = append(engineOpts, engine.WithProgressCallback(func(ev engine.ProgressEvent) {
+			program.Send(progressUpdateMsg{
+				step:         ev.Step,
+				totalSteps:   ev.TotalSteps,
+				date:         ev.Date,
+				measurements: ev.MeasurementsEvaluated,
+			})
+		}))
+
+		logPath := strings.TrimSuffix(outputPath, filepath.Ext(outputPath)) + ".log"
+
+		lf, err := os.Create(logPath)
+		if err != nil {
+			return fmt.Errorf("create log file %q: %w", logPath, err)
+		}
+
+		defer lf.Close()
+
+		logWriter = lf
+
+		fmt.Fprintf(os.Stderr, "Logs: %s\n", logPath)
+	}
+
+	if jsonMode {
+		engineOpts = append(engineOpts, engine.WithProgressCallback(func(ev engine.ProgressEvent) {
+			reporter.Progress(ev)
+		}))
+	}
+
+	eng := engine.New(strategy, engineOpts...)
+	defer eng.Close()
+
+	startTime := time.Now()
+
+	result, err := runEngineBacktest(eng, program, logWriter, start, end)
+	if err != nil {
+		if jsonMode {
+			reporter.Error(fullID, err)
+		}
+		return fmt.Errorf("backtest failed: %w", err)
+	}
+
+	elapsed := time.Since(startTime)
+
+	// Set metadata on the portfolio.
+	result.SetMetadata(portfolio.MetaRunElapsed, elapsed.String())
+	result.SetMetadata(portfolio.MetaRunInitialCash, fmt.Sprintf("%.2f", cash))
+	result.SetMetadata("run_id", fullID)
+	result.SetMetadata(portfolio.MetaStrategyName, strategy.Name())
+	result.SetMetadata(portfolio.MetaRunStart, start.Format("2006-01-02"))
+	result.SetMetadata(portfolio.MetaRunEnd, end.Format("2006-01-02"))
+
+	params := strategyParams(strategy)
+	for k, v := range params {
+		result.SetMetadata(fmt.Sprintf("param_%s", k), fmt.Sprintf("%v", v))
+	}
+
+	if err := acct.ToSQLite(outputPath); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+
+	log.Info().Str("path", outputPath).Msg("backtest output written")
+
+	if jsonMode {
+		reporter.Completed(fullID, outputPath)
+	} else {
+		if err := summary.Render(acct, os.Stdout); err != nil {
+			return fmt.Errorf("rendering report: %w", err)
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 3.5: Confirm the full CLI test suite passes**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+go test ./cli/... -v 2>&1 | tail -30
+```
+
+Expected: all specs PASS, no compile errors.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+cd /Users/jdf/Developer/penny-vault/pvbt
+git add cli/backtest.go
+git commit -m "feat(cli): add --json flag to backtest for JSON Lines output"
+```

--- a/docs/superpowers/specs/2026-04-22-backtest-json-mode-design.md
+++ b/docs/superpowers/specs/2026-04-22-backtest-json-mode-design.md
@@ -1,0 +1,95 @@
+# Design: `backtest --json` mode
+
+**Date:** 2026-04-22
+**Status:** Approved
+
+## Overview
+
+Add a `--json` flag to the `backtest` subcommand that switches stdout to a JSON Lines stream. All log messages and lifecycle/progress events are emitted as single-line JSON objects. This is intended for consumption by a web UI that spawns the backtest process and reads its stdout. Full metrics and the equity curve are fetched from the SQLite output file after the run completes.
+
+## Activation
+
+`--json` is a boolean flag on `newBacktestCmd()`. When set:
+
+- The bubble tea TUI is skipped (equivalent to `--no-progress`)
+- zerolog is configured with `zerolog.New(os.Stdout)` (native JSON output, no console writer)
+- `summary.Render()` is suppressed
+- A `jsonReporter` helper (private, in `cli/`) handles all structured writes to stdout
+
+The flag is mutually exclusive with the interactive TUI. If both would otherwise activate, `--json` wins.
+
+## Message Schema
+
+All messages are single-line JSON objects. A `type` field discriminates between message kinds. Consumers should ignore unknown `type` values to allow forward compatibility.
+
+### `status` — lifecycle events
+
+Emitted at key points in the run lifecycle.
+
+**started** — emitted before engine execution begins:
+```json
+{"type":"status","event":"started","run_id":"abc12","strategy":"momentum-factor","start":"2020-01-01","end":"2025-01-01","cash":100000,"output":"/path/to/run.db","time":"2026-04-22T14:01:02Z"}
+```
+
+**completed** — emitted after SQLite output is written:
+```json
+{"type":"status","event":"completed","run_id":"abc12","output":"/path/to/run.db","elapsed_ms":14200,"time":"2026-04-22T14:01:16Z"}
+```
+
+**error** — emitted instead of `completed` when the run fails:
+```json
+{"type":"status","event":"error","run_id":"abc12","error":"data provider unavailable","time":"2026-04-22T14:01:06Z"}
+```
+
+### `progress` — backtest execution progress
+
+Emitted on each progress callback invocation from the engine. Fields mirror what the bubble tea TUI displays.
+
+```json
+{"type":"progress","step":1234,"total_steps":5000,"current_date":"2023-05-15","target_date":"2025-01-01","pct":24.68,"elapsed_ms":3200,"eta_ms":9800,"measurements":45231}
+```
+
+Fields:
+- `step` / `total_steps` — current and total engine steps
+- `current_date` — the trading date currently being processed (YYYY-MM-DD)
+- `target_date` — the backtest end date (YYYY-MM-DD)
+- `pct` — completion percentage (0–100, two decimal places)
+- `elapsed_ms` — wall-clock milliseconds since engine start
+- `eta_ms` — estimated milliseconds remaining (0 if unknown)
+- `measurements` — number of data measurements processed so far
+
+### `log` — structured log messages
+
+zerolog's native JSON output. All log events that would normally go to stderr as formatted text instead go to stdout as JSON.
+
+```json
+{"type":"log","level":"info","time":"2026-04-22T14:01:05Z","message":"running backtest","strategy":"momentum-factor"}
+```
+
+Additional zerolog fields (e.g. `strategy`, `start`, `end`, `path`) are included as top-level keys when present.
+
+## Implementation
+
+### Files changed
+
+**`cli/backtest.go`**
+- Register `--json` boolean flag in `newBacktestCmd()`
+- In `runBacktest()`: when `--json` is set, configure zerolog as `zerolog.New(os.Stdout).With().Str("type", "log").Logger()` (adds `"type":"log"` to every log line), construct a `jsonReporter`, emit `started`, swap the progress callback to call `reporter.Progress()`, skip `summary.Render()`, emit `completed` or `error` at the end
+
+**`cli/json_reporter.go`** (new file)
+- `jsonReporter` struct with an `io.Writer` (stdout)
+- `Status(event string, fields map[string]any)` — marshals and writes a status line
+- `Progress(update progressUpdateMsg)` — marshals and writes a progress line
+- All writes are a single `json.Marshal` + `fmt.Fprintln`; no buffering
+
+### No changes needed
+
+`engine/`, `portfolio/`, `summary/`, and `cli/progress.go` are unchanged. The existing progress callback abstraction is sufficient.
+
+## Constraints
+
+- Output must be JSON Lines (one JSON object per line, newline-terminated)
+- No ANSI escape codes in JSON mode
+- `elapsed_ms` and `eta_ms` are integers (milliseconds); consumers should not rely on sub-millisecond precision
+- Dates are RFC 3339 for timestamps, YYYY-MM-DD for trading dates
+- Unknown fields should be tolerated by consumers (forward compatibility)


### PR DESCRIPTION
## Summary

- Adds a `--json` flag to the `backtest` subcommand that switches stdout to a JSON Lines stream
- Emits four message types: `status` (started/completed/error), `progress` (per engine step), and `log` (zerolog JSON output with `"type":"log"` discriminator)
- Progress messages mirror the TUI progress bar fields: step, total\_steps, current\_date, target\_date, pct, elapsed\_ms, eta\_ms, measurements
- `summary.Render` and the bubble tea TUI are suppressed in JSON mode; full metrics are read from the SQLite output file by the consumer

## Design

See `docs/superpowers/specs/2026-04-22-backtest-json-mode-design.md` for the full message schema and architecture.

## Test Plan

- [ ] `go test ./cli/...` — 94 tests pass
- [ ] `go build ./...` — clean build
- [ ] Verify `backtest --json` emits `started`, `progress`, and `completed` lines on a real run
- [ ] Verify log messages on stdout have `"type":"log"` field
- [ ] Verify normal `backtest` (no flag) still renders the terminal summary unchanged