### PR TITLE
fix(engine): tolerate 1-2 days of trailing stale data instead of delisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A backtest whose end date runs ahead of the data feed by one or two trading days now stops at the last fully-priced day instead of liquidating every held position as delisted. Larger gaps still trigger the existing delisting behavior.
+
 ## [0.8.1] - 2026-05-01
 
 ### Changed

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -171,6 +171,11 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 
 	start = adjustedStart
 
+	// 5d. Detect a stale trailing data feed (1-2 trading days behind the
+	// requested end) and truncate end so we stop at the last fully-priced
+	// day instead of spuriously liquidating every held position.
+	end = e.adjustEndForStaleData(ctx, end)
+
 	// 6. Create and configure account.
 	acct := e.createAccount(start)
 

--- a/engine/backtest_test.go
+++ b/engine/backtest_test.go
@@ -275,6 +275,31 @@ func (s *buyOnceStrategy) Compute(ctx context.Context, _ *engine.Engine, _ portf
 	return nil
 }
 
+// BuyOnceExportedStrategy mirrors buyOnceStrategy but exports its Target
+// field so collectStrategyAssets can discover it for data-freshness
+// probing.
+type BuyOnceExportedStrategy struct {
+	Target asset.Asset
+	Qty    float64
+	bought bool
+}
+
+func (s *BuyOnceExportedStrategy) Name() string { return "buy-once-exported" }
+
+func (s *BuyOnceExportedStrategy) Setup(_ *engine.Engine) {}
+
+func (s *BuyOnceExportedStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5"}
+}
+
+func (s *BuyOnceExportedStrategy) Compute(ctx context.Context, _ *engine.Engine, _ portfolio.Portfolio, batch *portfolio.Batch) error {
+	if !s.bought {
+		s.bought = true
+		return batch.Order(ctx, s.Target, portfolio.Buy, s.Qty)
+	}
+	return nil
+}
+
 // shortOnceStrategy sells (shorts) a fixed number of shares on the
 // first Compute call and then does nothing. This leaves a short
 // position open for housekeeping to process borrow fees and dividends.
@@ -1512,6 +1537,162 @@ var _ = Describe("Backtest", func() {
 			// Verify position is 0 after delisting.
 			Expect(fund.Position(testStock)).To(BeNumerically("==", 0),
 				"position should be zero after delisting liquidation")
+		})
+
+		It("ends the backtest early when trailing prices are stale by 1-2 days", func() {
+			testStock := asset.Asset{CompositeFigi: "FIGI-STALE1", Ticker: "STALE1"}
+			staleAssets := []asset.Asset{testStock}
+			staleProvider := &mockAssetProvider{assets: staleAssets}
+
+			staleMetrics := []data.Metric{
+				data.MetricClose, data.AdjClose, data.Dividend,
+				data.MetricHigh, data.MetricLow, data.SplitFactor, data.Volume,
+			}
+
+			// Two weeks of trading data, with the last 2 trading days NaN
+			// to simulate a data feed that is one weekend behind.
+			nDays := 17
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			times := make([]time.Time, nDays)
+			for idx := range times {
+				day := dataStart.AddDate(0, 0, idx)
+				times[idx] = time.Date(day.Year(), day.Month(), day.Day(), 16, 0, 0, 0, time.UTC)
+			}
+
+			nMetrics := len(staleMetrics)
+			vals := make([]float64, nDays*len(staleAssets)*nMetrics)
+			lastFreshIdx := nDays - 3 // last 2 trading days are stale
+			for dayIdx := 0; dayIdx < nDays; dayIdx++ {
+				closePrice := 100.0
+				if dayIdx > lastFreshIdx {
+					closePrice = math.NaN()
+				}
+				vals[(0*nMetrics+0)*nDays+dayIdx] = closePrice
+				vals[(0*nMetrics+1)*nDays+dayIdx] = closePrice
+				vals[(0*nMetrics+2)*nDays+dayIdx] = 0.0
+				if !math.IsNaN(closePrice) {
+					vals[(0*nMetrics+3)*nDays+dayIdx] = closePrice + 2.0
+					vals[(0*nMetrics+4)*nDays+dayIdx] = closePrice - 2.0
+				} else {
+					vals[(0*nMetrics+3)*nDays+dayIdx] = math.NaN()
+					vals[(0*nMetrics+4)*nDays+dayIdx] = math.NaN()
+				}
+				vals[(0*nMetrics+5)*nDays+dayIdx] = 1.0
+				vals[(0*nMetrics+6)*nDays+dayIdx] = 1_000_000.0
+			}
+
+			staleDF, dfErr := data.NewDataFrame(times, staleAssets, staleMetrics, data.Daily,
+				data.SlabToColumns(vals, len(staleAssets)*nMetrics, nDays))
+			Expect(dfErr).NotTo(HaveOccurred())
+			staleDataProvider := data.NewTestProvider(staleMetrics, staleDF)
+
+			acct := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+			strategy := &BuyOnceExportedStrategy{Target: testStock, Qty: 50}
+			eng := engine.New(strategy,
+				engine.WithDataProvider(staleDataProvider),
+				engine.WithAssetProvider(staleProvider),
+				engine.WithAccount(acct),
+			)
+
+			btStart := dataStart
+			btEnd := times[nDays-1]
+
+			fund, err := eng.Backtest(context.Background(), btStart, btEnd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fund).NotTo(BeNil())
+
+			txns := fund.Transactions()
+
+			// Stale data should NOT cause delisting; truncating end avoids
+			// the NaN-priced trailing days entirely.
+			for _, tx := range txns {
+				if tx.Type == asset.SellTransaction && tx.Asset == testStock {
+					Expect(tx.Justification).NotTo(ContainSubstring("delisted"),
+						"stale trailing data must not produce a delisting transaction")
+				}
+			}
+
+			// Position should still be held; nothing was liquidated.
+			Expect(fund.Position(testStock)).To(BeNumerically("==", 50),
+				"position should remain intact when trailing data is merely stale")
+		})
+
+		It("still delists when trailing prices are missing for more than two days", func() {
+			testStock := asset.Asset{CompositeFigi: "FIGI-STALE2", Ticker: "STALE2"}
+			staleAssets := []asset.Asset{testStock}
+			staleProvider := &mockAssetProvider{assets: staleAssets}
+
+			staleMetrics := []data.Metric{
+				data.MetricClose, data.AdjClose, data.Dividend,
+				data.MetricHigh, data.MetricLow, data.SplitFactor, data.Volume,
+			}
+
+			nDays := 17
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			times := make([]time.Time, nDays)
+			for idx := range times {
+				day := dataStart.AddDate(0, 0, idx)
+				times[idx] = time.Date(day.Year(), day.Month(), day.Day(), 16, 0, 0, 0, time.UTC)
+			}
+
+			nMetrics := len(staleMetrics)
+			vals := make([]float64, nDays*len(staleAssets)*nMetrics)
+			// Five trailing days are missing -- well beyond the freshness
+			// tolerance, so the engine should delist instead of truncating.
+			lastFreshIdx := nDays - 6
+			for dayIdx := 0; dayIdx < nDays; dayIdx++ {
+				closePrice := 100.0
+				if dayIdx > lastFreshIdx {
+					closePrice = math.NaN()
+				}
+				vals[(0*nMetrics+0)*nDays+dayIdx] = closePrice
+				vals[(0*nMetrics+1)*nDays+dayIdx] = closePrice
+				vals[(0*nMetrics+2)*nDays+dayIdx] = 0.0
+				if !math.IsNaN(closePrice) {
+					vals[(0*nMetrics+3)*nDays+dayIdx] = closePrice + 2.0
+					vals[(0*nMetrics+4)*nDays+dayIdx] = closePrice - 2.0
+				} else {
+					vals[(0*nMetrics+3)*nDays+dayIdx] = math.NaN()
+					vals[(0*nMetrics+4)*nDays+dayIdx] = math.NaN()
+				}
+				vals[(0*nMetrics+5)*nDays+dayIdx] = 1.0
+				vals[(0*nMetrics+6)*nDays+dayIdx] = 1_000_000.0
+			}
+
+			staleDF, dfErr := data.NewDataFrame(times, staleAssets, staleMetrics, data.Daily,
+				data.SlabToColumns(vals, len(staleAssets)*nMetrics, nDays))
+			Expect(dfErr).NotTo(HaveOccurred())
+			staleDataProvider := data.NewTestProvider(staleMetrics, staleDF)
+
+			acct := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+			strategy := &BuyOnceExportedStrategy{Target: testStock, Qty: 50}
+			eng := engine.New(strategy,
+				engine.WithDataProvider(staleDataProvider),
+				engine.WithAssetProvider(staleProvider),
+				engine.WithAccount(acct),
+			)
+
+			btStart := dataStart
+			btEnd := times[nDays-1]
+
+			fund, err := eng.Backtest(context.Background(), btStart, btEnd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fund).NotTo(BeNil())
+
+			txns := fund.Transactions()
+
+			hasDelisted := false
+			for _, tx := range txns {
+				if tx.Type == asset.SellTransaction && tx.Asset == testStock {
+					if tx.Justification != "" {
+						hasDelisted = true
+					}
+				}
+			}
+			Expect(hasDelisted).To(BeTrue(),
+				"a 5-day trailing gap must still produce a delisting transaction")
+			Expect(fund.Position(testStock)).To(BeNumerically("==", 0),
+				"position should be liquidated after a 5-day trailing gap")
 		})
 	})
 })

--- a/engine/stale_data.go
+++ b/engine/stale_data.go
@@ -1,0 +1,150 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"math"
+	"time"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/tradecron"
+	"github.com/rs/zerolog"
+)
+
+// staleDataTolerance is the maximum number of trailing trading days that can
+// be missing before a per-asset NaN is interpreted as a delisting rather
+// than a transient data lag. A backtest run shortly after the close (or on
+// a holiday) will commonly trail by 1-2 trading days while the data feed
+// catches up; truncating end keeps those runs from spuriously liquidating
+// every held position.
+const staleDataTolerance = 2
+
+// adjustEndForStaleData detects when the requested end is 1-2 trading days
+// past the latest available close data and returns a truncated end aligned
+// with the last fully-priced trading day. Larger gaps fall through to the
+// existing per-asset delisting logic so genuinely abandoned data sources
+// still surface as delistings.
+//
+// The probe uses the strategy's statically-known assets (asset fields plus
+// the benchmark and explicit static universes). Strategies that rely solely
+// on dynamic universes have nothing to probe and skip the check.
+func (e *Engine) adjustEndForStaleData(ctx context.Context, end time.Time) time.Time {
+	probeAssets := collectStrategyAssets(e.strategy, e.benchmark)
+	for _, child := range e.children {
+		for _, childAsset := range collectStrategyAssets(child.strategy, asset.Asset{}) {
+			probeAssets = appendUniqueAsset(probeAssets, childAsset)
+		}
+	}
+
+	if len(probeAssets) == 0 {
+		return end
+	}
+
+	lookbackStart, walkErr := walkBackTradingDays(end, staleDataTolerance+3)
+	if walkErr != nil {
+		return end
+	}
+
+	df, fetchErr := e.fetchRange(ctx, probeAssets, []data.Metric{data.MetricClose}, lookbackStart, end)
+	if fetchErr != nil || df.Len() == 0 {
+		return end
+	}
+
+	times := df.Times()
+	latest := time.Time{}
+
+	for tIdx := len(times) - 1; tIdx >= 0; tIdx-- {
+		if times[tIdx].After(end) {
+			continue
+		}
+
+		for _, ast := range probeAssets {
+			col := df.Column(ast, data.MetricClose)
+			if tIdx >= len(col) {
+				continue
+			}
+
+			if !math.IsNaN(col[tIdx]) {
+				latest = times[tIdx]
+				break
+			}
+		}
+
+		if !latest.IsZero() {
+			break
+		}
+	}
+
+	if latest.IsZero() || !latest.Before(end) {
+		return end
+	}
+
+	gap, gapErr := tradingDayGap(latest, end)
+	if gapErr != nil || gap == 0 {
+		return end
+	}
+
+	if gap > staleDataTolerance {
+		return end
+	}
+
+	zerolog.Ctx(ctx).Warn().
+		Time("requested_end", end).
+		Time("adjusted_end", latest).
+		Int("missing_trading_days", gap).
+		Msg("trailing close data is stale; ending backtest at the last fully-priced trading day")
+
+	return latest
+}
+
+// tradingDayGap counts trading days strictly after `from` up to and
+// including `to`. Returns 0 if `to` is on or before `from`.
+func tradingDayGap(from, to time.Time) (int, error) {
+	if !to.After(from) {
+		return 0, nil
+	}
+
+	daily, err := tradecron.New("@close * * *", tradecron.RegularHours)
+	if err != nil {
+		return 0, err
+	}
+
+	gap := 0
+
+	cur := daily.Next(from.Add(time.Nanosecond))
+	for !cur.After(to) {
+		gap++
+		cur = daily.Next(cur.Add(time.Nanosecond))
+	}
+
+	return gap, nil
+}
+
+func appendUniqueAsset(assets []asset.Asset, candidate asset.Asset) []asset.Asset {
+	if candidate == (asset.Asset{}) || candidate.CompositeFigi == "" {
+		return assets
+	}
+
+	for _, existing := range assets {
+		if existing.CompositeFigi == candidate.CompositeFigi {
+			return assets
+		}
+	}
+
+	return append(assets, candidate)
+}


### PR DESCRIPTION
## Summary
- When a backtest end date ran slightly ahead of the data feed, every held position was liquidated as delisted on the first NaN-priced day.
- Probe the strategy's known assets over the last few trading days; if the latest valid date is within 2 trading days of `end`, truncate `end` to that date.
- Larger gaps fall through to the existing per-asset delisting logic.