### PR TITLE
feat: splice universe and asset.Asset CLI override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Strategies can override single-ticker parameters from the command line.
+- Backtests of recently-listed instruments can extend further into history by splicing a historical proxy ticker for pre-listing dates. Substitution uses raw prices with no leverage adjustment.
+
 ## [0.8.2] - 2026-05-02
 
 ### Fixed

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 
+	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/engine"
 	"github.com/penny-vault/pvbt/portfolio"
 	"github.com/penny-vault/pvbt/universe"
@@ -282,6 +283,59 @@ var _ = Describe("applyStrategyFlags with universe fields", func() {
 		Expect(strategy.RiskOff).NotTo(BeNil())
 		offMembers := strategy.RiskOff.Assets(time.Time{})
 		Expect(offMembers[0].Ticker).To(Equal("AGG"))
+	})
+})
+
+type assetStrategy struct {
+	Bench asset.Asset `pvbt:"bench" desc:"benchmark ticker" default:"SPY"`
+	Lev   asset.Asset `pvbt:"lev"   desc:"leveraged ticker"`
+}
+
+func (s *assetStrategy) Name() string           { return "assetTest" }
+func (s *assetStrategy) Setup(_ *engine.Engine) {}
+func (s *assetStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	return nil
+}
+
+var _ = Describe("registerStrategyFlags with asset.Asset fields", func() {
+	It("registers a string flag carrying the default ticker", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &assetStrategy{}
+
+		registerStrategyFlags(cmd, strategy)
+
+		benchFlag := cmd.Flags().Lookup("bench")
+		Expect(benchFlag).NotTo(BeNil())
+		Expect(benchFlag.DefValue).To(Equal("SPY"))
+		Expect(benchFlag.Usage).To(Equal("benchmark ticker"))
+
+		levFlag := cmd.Flags().Lookup("lev")
+		Expect(levFlag).NotTo(BeNil())
+		Expect(levFlag.DefValue).To(BeEmpty())
+	})
+})
+
+var _ = Describe("applyStrategyFlags with asset.Asset fields", func() {
+	It("sets the field's Ticker from a user-provided flag", func() {
+		strategy := &assetStrategy{}
+		rootCmd, _ := buildTestCmd(strategy, nil)
+
+		rootCmd.SetArgs([]string{"backtest", "--bench", "qqq", "--lev", " tqqq "})
+		Expect(rootCmd.Execute()).To(Succeed())
+
+		Expect(strategy.Bench.Ticker).To(Equal("QQQ"))
+		Expect(strategy.Lev.Ticker).To(Equal("TQQQ"))
+	})
+
+	It("falls back to the default tag value when no flag is given", func() {
+		strategy := &assetStrategy{}
+		rootCmd, _ := buildTestCmd(strategy, nil)
+
+		rootCmd.SetArgs([]string{"backtest"})
+		Expect(rootCmd.Execute()).To(Succeed())
+
+		Expect(strategy.Bench.Ticker).To(Equal("SPY"))
+		Expect(strategy.Lev.Ticker).To(BeEmpty())
 	})
 })
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/engine"
 	"github.com/penny-vault/pvbt/study"
 	"github.com/penny-vault/pvbt/universe"
@@ -14,6 +15,7 @@ import (
 )
 
 var (
+	assetType    = reflect.TypeOf(asset.Asset{})
 	universeType = reflect.TypeOf((*universe.Universe)(nil)).Elem()
 	durationType = reflect.TypeOf(time.Duration(0))
 )
@@ -53,6 +55,9 @@ func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 		fieldValue := val.Field(ii)
 
 		switch {
+		case field.Type == assetType:
+			cmd.Flags().String(name, defaultStr, desc)
+
 		case field.Type.Implements(universeType):
 			cmd.Flags().String(name, defaultStr, desc)
 
@@ -153,6 +158,14 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 		}
 
 		switch {
+		case field.Type == assetType:
+			raw := strings.TrimSpace(flag.Value.String())
+			if raw == "" {
+				continue
+			}
+
+			fieldValue.Set(reflect.ValueOf(asset.Asset{Ticker: strings.ToUpper(raw)}))
+
 		case field.Type.Implements(universeType):
 			raw := flag.Value.String()
 			if raw == "" {

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -403,6 +403,21 @@ func (s *MyStrategy) Setup(eng *engine.Engine) {
 }
 ```
 
+### Splice universe
+
+Substitutes a historical proxy ticker for dates before the primary's listing. Useful when a strategy names a recently-listed instrument (TQQQ, BITO, etc.) but you want to backtest further into history. Substitution is raw -- no leverage or composition adjustment -- so pick proxies whose risk profile is close to the primary.
+
+```go
+func (s *MyStrategy) Setup(eng *engine.Engine) {
+    s.lev = eng.SpliceUniverse("TQQQ", universe.SplicePeriod{
+        Ticker: "QLD",
+        Before: time.Date(2010, 2, 11, 0, 0, 0, 0, time.UTC),
+    })
+}
+```
+
+`s.lev.Assets(t)` returns `QLD` before the cutoff and `TQQQ` after. When the simulation crosses the cutoff, the position migrates from `QLD` to `TQQQ` on the next rebalance. See [Universes](universes.md) for more.
+
 ### Fetching data from a universe
 
 Both methods are available in `Compute`:

--- a/docs/universes.md
+++ b/docs/universes.md
@@ -25,7 +25,7 @@ type Universe interface {
 
 ## Creating universes
 
-There are three ways to create a universe, depending on where the assets come from.
+There are four ways to create a universe, depending on where the assets come from.
 
 ### From struct tags
 
@@ -93,6 +93,31 @@ The `us-tradable` universe is recomputed daily by pv-data and includes only US c
 ADRs, limited partnerships, ETFs, closed-end funds, OTC stocks, and recent IPOs are excluded. For companies with multiple share classes, only the most liquid common share is kept. Membership typically lands in the 1,500-2,500 range. This is the same set of constraints Quantopian's QTradableStocksUS used to define its tradable universe, with a percentile-based market cap floor that adapts across time rather than a fixed dollar threshold.
 
 Use `us-tradable` as the default for any broad US equity strategy. Use `SPX` or `NDX` only when you specifically want to track those indexes. Use `NewStatic` for fixed asset lists like ETF rotations.
+
+### From a primary ticker with historical fallbacks
+
+Some instruments are too young to backtest as far as you'd like. TQQQ launched in February 2010; if you want to study a TQQQ-based strategy back to 2005, the first five years have no TQQQ price series at all. A splice universe lets you nominate a historical proxy -- typically a less-leveraged or otherwise similar ETF that did exist -- to fill in pre-listing dates:
+
+```go
+func (s *LeveragedMomentum) Setup(eng *engine.Engine) {
+    if s.Lev == nil { // respect any --lev CLI override
+        s.Lev = eng.SpliceUniverse("TQQQ", universe.SplicePeriod{
+            Ticker: "QLD",
+            Before: time.Date(2010, 2, 11, 0, 0, 0, 0, time.UTC),
+        })
+    }
+}
+```
+
+The strategy uses `s.Lev` like any other universe -- `Window`, `At`, and order routing all work normally. Behind the scenes:
+
+- `s.Lev.Assets(t)` returns a single asset: `QLD` for dates strictly before the cutoff, `TQQQ` from the cutoff onward.
+- `s.Lev.Window(...)` returns a single column whose identity is whichever ticker is live on the *current* simulation date. Pre-cutoff bars in that column hold `QLD` prices, post-cutoff bars hold `TQQQ` prices.
+- When a backtest crosses the cutoff date, the next rebalance naturally sells `QLD` and buys `TQQQ`. No special handling.
+
+You can declare more than one fallback by passing additional `SplicePeriod` entries; they're sorted chronologically and each covers dates from the previous cutoff up to its own.
+
+**Substitution is raw.** No leverage scaling, no return adjustment. A QLD-to-TQQQ splice will understate pre-2010 returns because QLD is 2x daily and TQQQ is 3x daily. Pick proxies whose risk and exposure profile is close to the primary, and be explicit in your strategy's documentation about what's being substituted.
 
 ## Getting data for a universe
 

--- a/engine/doc.go
+++ b/engine/doc.go
@@ -223,7 +223,11 @@
 //
 // The CLI uses the pvbt and desc tags to register cobra flags automatically.
 // When a user passes --riskOn "SPY,QQQ", the field is populated before
-// hydration runs, so the default tag is skipped.
+// hydration runs, so the default tag is skipped. CLI overrides are supported
+// for [asset.Asset] fields (single ticker, e.g. --bench QQQ) and for
+// [universe.Universe] fields (comma-separated tickers, e.g. --riskOn
+// "SPY,QQQ"). Overrides set only the Ticker; the engine re-resolves through
+// the asset registry during hydration so downstream code has full metadata.
 //
 // # Metadata
 //

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -226,6 +226,22 @@ func (e *Engine) IndexUniverse(indexName string) universe.Universe {
 	panic(fmt.Sprintf("engine: no provider implements IndexProvider (needed for index %q)", indexName))
 }
 
+// SpliceUniverse creates a single-asset universe that substitutes proxy
+// tickers for dates before the primary's listing. This lets backtests of
+// strategies that name a recent ticker (e.g. TQQQ, listed in 2010) extend
+// further into history by transparently using a proxy (e.g. QLD) for
+// pre-listing bars. Each fallback covers dates strictly before its Before
+// cutoff. Order routing and reporting use whichever ticker is live on the
+// order date, so positions migrate naturally when the simulation crosses
+// a cutoff.
+func (e *Engine) SpliceUniverse(primary string, fallbacks ...universe.SplicePeriod) universe.Universe {
+	u := universe.NewSplice(primary, fallbacks...)
+	u.Resolve(e.Asset)
+	u.SetDataSource(e)
+
+	return u
+}
+
 // CurrentDate returns the current simulation date.
 func (e *Engine) CurrentDate() time.Time {
 	return e.currentDate

--- a/engine/hydrate.go
+++ b/engine/hydrate.go
@@ -70,6 +70,18 @@ func hydrateFields(eng *Engine, target interface{}) error {
 			continue
 		}
 
+		// For asset.Asset fields that were pre-set (e.g. by CLI flags) with
+		// only a Ticker, re-resolve through the asset registry so downstream
+		// code has the full metadata (CompositeFigi, exchange, etc.).
+		if field.Type == assetType && !fieldValue.IsZero() {
+			existing := fieldValue.Interface().(asset.Asset)
+			if existing.CompositeFigi == "" && existing.Ticker != "" {
+				fieldValue.Set(reflect.ValueOf(eng.Asset(existing.Ticker)))
+			}
+
+			continue
+		}
+
 		// For universe fields that were pre-set (e.g. by CLI flags), re-wire
 		// with the engine's data source so data fetching works.
 		if field.Type.Implements(universeType) && !fieldValue.IsZero() {

--- a/engine/hydrate_test.go
+++ b/engine/hydrate_test.go
@@ -136,4 +136,33 @@ var _ = Describe("Hydration", func() {
 		// PreSet should NOT be overwritten since it was non-zero.
 		Expect(strategy.PreSet).To(Equal(1.0))
 	})
+
+	It("re-resolves a pre-set asset.Asset that carries only a Ticker", func() {
+		metrics := []data.Metric{data.MetricClose, data.AdjClose, data.Dividend}
+		dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		df := makeDailyTestData(dataStart, 90, []asset.Asset{aapl, goog}, metrics)
+		provider := data.NewTestProvider(metrics, df)
+
+		// Simulate what CLI applyStrategyFlags does for asset.Asset fields:
+		// set the Ticker only, leaving CompositeFigi and other metadata empty.
+		// The default tag says "AAPL"; the CLI override should win and the
+		// engine should resolve the bare ticker through the asset registry.
+		strategy := &hydrateStrategy{
+			AssetVal: asset.Asset{Ticker: "GOOG"},
+		}
+		eng := engine.New(strategy,
+			engine.WithDataProvider(provider),
+			engine.WithAssetProvider(assetProvider),
+			engine.WithInitialDeposit(100_000.0),
+		)
+
+		start := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2024, 2, 5, 23, 0, 0, 0, time.UTC)
+
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(strategy.AssetVal.Ticker).To(Equal("GOOG"))
+		Expect(strategy.AssetVal.CompositeFigi).To(Equal("FIGI-GOOG"))
+	})
 })

--- a/universe/doc.go
+++ b/universe/doc.go
@@ -69,6 +69,26 @@
 // completeness). Use SP500 or Nasdaq100 only when you specifically want to
 // track those indexes.
 //
+// From a primary ticker with historical fallbacks: use eng.SpliceUniverse
+// from Setup to substitute proxy tickers for dates before the primary's
+// listing. This is useful for backtesting strategies on instruments that did
+// not exist for the full study period -- for example, TQQQ (listed in early
+// 2010) can be backtested further into history using QLD as a proxy.
+//
+//	func (s *Strategy) Setup(eng *engine.Engine) {
+//	    s.Lev = eng.SpliceUniverse("TQQQ", universe.SplicePeriod{
+//	        Ticker: "QLD",
+//	        Before: time.Date(2010, 2, 11, 0, 0, 0, 0, time.UTC),
+//	    })
+//	}
+//
+// Substitution is raw: the proxy's price series is used directly, with no
+// adjustment for differences in leverage or composition. A strategy that
+// substitutes QLD (2x daily) for TQQQ (3x daily) will understate pre-2010
+// returns. Order routing and reporting always use whichever ticker is live
+// on the order date, so positions migrate via a normal rebalance when the
+// simulation crosses a cutoff.
+//
 // # Getting Data
 //
 // Strategies retrieve market data through the universe rather than querying a

--- a/universe/splice.go
+++ b/universe/splice.go
@@ -1,0 +1,241 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package universe
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+// SplicePeriod declares a fallback ticker for dates strictly before a cutoff.
+// Used by NewSplice to substitute historical proxies when the primary ticker
+// did not yet exist (e.g. QLD before TQQQ was listed in early 2010).
+type SplicePeriod struct {
+	Ticker string
+	Before time.Time
+}
+
+// compile-time check
+var _ Universe = (*SpliceUniverse)(nil)
+
+// SpliceUniverse is a single-asset universe that substitutes different
+// tickers across history. The primary ticker is "active" by default; each
+// fallback covers dates strictly before its Before cutoff. Pre-cutoff bars in
+// data fetches come from the fallback's price series, which is useful for
+// extending backtests of leveraged or thematic ETFs that did not exist for
+// the full study period.
+//
+// SpliceUniverse always reports a single active asset for any given date, so
+// it composes naturally with weighting functions like portfolio.EqualWeight
+// and with order routing -- the engine places orders against whichever ticker
+// is live on the order date.
+type SpliceUniverse struct {
+	segments []spliceSegment // chronological; the last segment is the primary
+	ds       DataSource
+}
+
+// spliceSegment defines [start, end) coverage of a particular ticker.
+// Zero start means -infinity; zero end means +infinity. The primary segment
+// is the last entry and has zero end.
+type spliceSegment struct {
+	asset asset.Asset
+	start time.Time
+	end   time.Time
+}
+
+// SetDataSource wires the universe to a data source.
+func (u *SpliceUniverse) SetDataSource(ds DataSource) { u.ds = ds }
+
+// Resolve replaces each segment's bare ticker with a fully-resolved asset.
+// Strategies typically do not call this directly; the engine helper
+// SpliceUniverse() handles resolution before returning.
+func (u *SpliceUniverse) Resolve(lookup func(ticker string) asset.Asset) {
+	for ii := range u.segments {
+		u.segments[ii].asset = lookup(u.segments[ii].asset.Ticker)
+	}
+}
+
+// Assets returns the active ticker as of asOf. Always a single-element slice.
+func (u *SpliceUniverse) Assets(asOf time.Time) []asset.Asset {
+	return []asset.Asset{u.segmentFor(asOf).asset}
+}
+
+// segmentFor finds the segment whose [start, end) covers asOf, defaulting to
+// the primary segment if asOf lies before the earliest cutoff (which can
+// happen only if Assets is queried at the zero time).
+func (u *SpliceUniverse) segmentFor(asOf time.Time) spliceSegment {
+	for _, seg := range u.segments {
+		if !seg.start.IsZero() && asOf.Before(seg.start) {
+			continue
+		}
+
+		if !seg.end.IsZero() && !asOf.Before(seg.end) {
+			continue
+		}
+
+		return seg
+	}
+
+	return u.segments[len(u.segments)-1]
+}
+
+// Window fetches data for each segment intersecting the lookback range,
+// relabels each piece's column to the currently-active ticker, and stitches
+// them together chronologically. The returned DataFrame has a single asset
+// column whose identity matches whichever ticker is live as of the current
+// simulation date, so signals computed from it route orders to that ticker.
+func (u *SpliceUniverse) Window(ctx context.Context, lookback portfolio.Period, metrics ...data.Metric) (*data.DataFrame, error) {
+	if u.ds == nil {
+		return nil, fmt.Errorf("universe has no data source; was it created via engine.SpliceUniverse()?")
+	}
+
+	now := u.ds.CurrentDate()
+	windowStart := lookback.Before(now)
+	active := u.segmentFor(now).asset
+
+	pieces := make([]*data.DataFrame, 0, len(u.segments))
+
+	for _, seg := range u.segments {
+		segStart := seg.start
+		if segStart.IsZero() || segStart.Before(windowStart) {
+			segStart = windowStart
+		}
+
+		segEnd := seg.end
+		if segEnd.IsZero() || now.Before(segEnd) {
+			segEnd = now
+		}
+
+		if !segStart.Before(segEnd) {
+			continue
+		}
+
+		raw, err := u.ds.Fetch(ctx, []asset.Asset{seg.asset}, lookback, metrics)
+		if err != nil {
+			return nil, fmt.Errorf("splice fetch %s: %w", seg.asset.Ticker, err)
+		}
+
+		// Between is inclusive on both ends; segEnd is exclusive in our model,
+		// so step back by one nanosecond to avoid double-counting the boundary.
+		sliced := raw.Between(segStart, segEnd.Add(-time.Nanosecond))
+		if sliced.Len() == 0 {
+			continue
+		}
+
+		relabeled, err := relabelSingle(sliced, seg.asset, active)
+		if err != nil {
+			return nil, fmt.Errorf("splice relabel %s -> %s: %w", seg.asset.Ticker, active.Ticker, err)
+		}
+
+		pieces = append(pieces, relabeled)
+	}
+
+	if len(pieces) == 0 {
+		return data.WithErr(fmt.Errorf("splice %s: no data in window [%s, %s]",
+			active.Ticker, windowStart.Format(time.DateOnly), now.Format(time.DateOnly))), nil
+	}
+
+	return data.MergeTimes(pieces...)
+}
+
+// At returns a single-row DataFrame at the current simulation date for
+// whichever ticker is active on that date.
+func (u *SpliceUniverse) At(ctx context.Context, metrics ...data.Metric) (*data.DataFrame, error) {
+	if u.ds == nil {
+		return nil, fmt.Errorf("universe has no data source; was it created via engine.SpliceUniverse()?")
+	}
+
+	now := u.ds.CurrentDate()
+
+	return u.ds.FetchAt(ctx, []asset.Asset{u.segmentFor(now).asset}, now, metrics)
+}
+
+// CurrentDate returns the current simulation date from the data source, or
+// the zero time if no data source is set.
+func (u *SpliceUniverse) CurrentDate() time.Time {
+	if u.ds == nil {
+		return time.Time{}
+	}
+
+	return u.ds.CurrentDate()
+}
+
+// NewSplice creates a single-asset universe that substitutes proxy tickers
+// for dates before the primary's listing. Fallbacks may be passed in any
+// order; they are sorted by Before ascending. Each fallback covers dates
+// strictly before its Before cutoff (and at-or-after the previous cutoff).
+// The primary covers all remaining dates from the latest cutoff onward.
+//
+// The universe has no data source until it is wired via
+// engine.SpliceUniverse(), which also resolves each ticker through the
+// engine's asset registry so downstream fetches have full asset metadata.
+func NewSplice(primary string, fallbacks ...SplicePeriod) *SpliceUniverse {
+	sorted := make([]SplicePeriod, len(fallbacks))
+	copy(sorted, fallbacks)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Before.Before(sorted[j].Before) })
+
+	segments := make([]spliceSegment, 0, len(sorted)+1)
+
+	var prevCutoff time.Time
+
+	for _, fb := range sorted {
+		segments = append(segments, spliceSegment{
+			asset: asset.Asset{Ticker: fb.Ticker},
+			start: prevCutoff,
+			end:   fb.Before,
+		})
+		prevCutoff = fb.Before
+	}
+
+	segments = append(segments, spliceSegment{
+		asset: asset.Asset{Ticker: primary},
+		start: prevCutoff,
+	})
+
+	return &SpliceUniverse{segments: segments}
+}
+
+// relabelSingle returns a new DataFrame whose single asset is target instead
+// of source, preserving the time axis, metrics, and column data. Used to
+// give every spliced segment a common column identity so MergeTimes can
+// concatenate them.
+func relabelSingle(df *data.DataFrame, source, target asset.Asset) (*data.DataFrame, error) {
+	assets := df.AssetList()
+	if len(assets) != 1 || assets[0].CompositeFigi != source.CompositeFigi {
+		return nil, fmt.Errorf("expected single-asset frame for %s", source.Ticker)
+	}
+
+	metrics := df.MetricList()
+	cols := make([][]float64, len(metrics))
+
+	for mi, metric := range metrics {
+		col := df.Column(source, metric)
+
+		out := make([]float64, len(col))
+		copy(out, col)
+		cols[mi] = out
+	}
+
+	times := df.Times()
+
+	return data.NewDataFrame(times, []asset.Asset{target}, metrics, df.Frequency(), cols)
+}

--- a/universe/splice_test.go
+++ b/universe/splice_test.go
@@ -1,0 +1,313 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package universe_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/portfolio"
+	"github.com/penny-vault/pvbt/universe"
+)
+
+// spliceMockDataSource serves a per-asset DataFrame on every Fetch/FetchAt
+// call, recording which assets were requested. Unlike mockDataSource above,
+// it supports multiple Fetch calls with different asset lists -- splice needs
+// one Fetch per segment.
+type spliceMockDataSource struct {
+	currentDate time.Time
+	frames      map[string]*data.DataFrame // keyed by Ticker
+	fetchCalls  []string                   // tickers requested, in order
+}
+
+func (m *spliceMockDataSource) Fetch(_ context.Context, assets []asset.Asset, _ portfolio.Period, _ []data.Metric) (*data.DataFrame, error) {
+	m.fetchCalls = append(m.fetchCalls, assets[0].Ticker)
+	return m.frames[assets[0].Ticker], nil
+}
+
+func (m *spliceMockDataSource) FetchAt(_ context.Context, assets []asset.Asset, _ time.Time, _ []data.Metric) (*data.DataFrame, error) {
+	m.fetchCalls = append(m.fetchCalls, assets[0].Ticker)
+	return m.frames[assets[0].Ticker], nil
+}
+
+func (m *spliceMockDataSource) CurrentDate() time.Time { return m.currentDate }
+
+// makeDailyFrame builds a single-asset, single-metric DataFrame with one
+// daily row per day in [start, start+nDays). Each row's value equals the
+// (1-indexed) row number for easy assertions.
+func makeDailyFrame(a asset.Asset, metric data.Metric, start time.Time, nDays int) *data.DataFrame {
+	times := make([]time.Time, nDays)
+	col := make([]float64, nDays)
+	for ii := range nDays {
+		times[ii] = start.AddDate(0, 0, ii)
+		col[ii] = float64(ii + 1)
+	}
+
+	df, err := data.NewDataFrame(times, []asset.Asset{a}, []data.Metric{metric}, data.Daily, [][]float64{col})
+	if err != nil {
+		panic(err)
+	}
+
+	return df
+}
+
+var _ = Describe("Splice Universe", func() {
+	var (
+		tqqq   asset.Asset
+		qld    asset.Asset
+		cutoff time.Time
+	)
+
+	BeforeEach(func() {
+		tqqq = asset.Asset{CompositeFigi: "FIGI-TQQQ", Ticker: "TQQQ"}
+		qld = asset.Asset{CompositeFigi: "FIGI-QLD", Ticker: "QLD"}
+		cutoff = time.Date(2010, 2, 11, 0, 0, 0, 0, time.UTC)
+	})
+
+	resolveAssets := func(u *universe.SpliceUniverse) {
+		u.Resolve(func(ticker string) asset.Asset {
+			switch ticker {
+			case "TQQQ":
+				return tqqq
+			case "QLD":
+				return qld
+			}
+			return asset.Asset{Ticker: ticker}
+		})
+	}
+
+	Describe("Assets", func() {
+		It("returns the fallback before the cutoff and the primary on or after", func() {
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+
+			before := time.Date(2008, 6, 1, 0, 0, 0, 0, time.UTC)
+			Expect(u.Assets(before)).To(ConsistOf(qld))
+
+			at := cutoff
+			Expect(u.Assets(at)).To(ConsistOf(tqqq))
+
+			after := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			Expect(u.Assets(after)).To(ConsistOf(tqqq))
+		})
+
+		It("walks multiple chronological fallbacks regardless of input order", func() {
+			early := asset.Asset{CompositeFigi: "FIGI-EARLY", Ticker: "EARLY"}
+			mid := asset.Asset{CompositeFigi: "FIGI-MID", Ticker: "MID"}
+			cutoffEarly := time.Date(2005, 1, 1, 0, 0, 0, 0, time.UTC)
+			cutoffMid := cutoff
+
+			// Pass fallbacks out of chronological order to confirm sorting.
+			u := universe.NewSplice("TQQQ",
+				universe.SplicePeriod{Ticker: "MID", Before: cutoffMid},
+				universe.SplicePeriod{Ticker: "EARLY", Before: cutoffEarly},
+			)
+			u.Resolve(func(ticker string) asset.Asset {
+				switch ticker {
+				case "TQQQ":
+					return tqqq
+				case "MID":
+					return mid
+				case "EARLY":
+					return early
+				}
+				return asset.Asset{Ticker: ticker}
+			})
+
+			Expect(u.Assets(time.Date(2003, 6, 1, 0, 0, 0, 0, time.UTC))).To(ConsistOf(early))
+			Expect(u.Assets(time.Date(2007, 6, 1, 0, 0, 0, 0, time.UTC))).To(ConsistOf(mid))
+			Expect(u.Assets(time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC))).To(ConsistOf(tqqq))
+		})
+	})
+
+	Describe("At", func() {
+		It("fetches the active ticker for the current simulation date", func() {
+			before := time.Date(2008, 6, 1, 0, 0, 0, 0, time.UTC)
+			ds := &spliceMockDataSource{
+				currentDate: before,
+				frames: map[string]*data.DataFrame{
+					"QLD": makeDailyFrame(qld, data.MetricClose, before, 1),
+				},
+			}
+
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+			u.SetDataSource(ds)
+
+			df, err := u.At(context.Background(), data.MetricClose)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(df.AssetList()).To(ConsistOf(qld))
+			Expect(ds.fetchCalls).To(Equal([]string{"QLD"}))
+		})
+
+		It("fetches the primary on the cutoff day and after", func() {
+			at := cutoff
+			ds := &spliceMockDataSource{
+				currentDate: at,
+				frames: map[string]*data.DataFrame{
+					"TQQQ": makeDailyFrame(tqqq, data.MetricClose, at, 1),
+				},
+			}
+
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+			u.SetDataSource(ds)
+
+			_, err := u.At(context.Background(), data.MetricClose)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ds.fetchCalls).To(Equal([]string{"TQQQ"}))
+		})
+
+		It("returns an error when no data source is set", func() {
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+
+			_, err := u.At(context.Background(), data.MetricClose)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Window", func() {
+		It("returns only primary data when the lookback is fully after the cutoff", func() {
+			now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+			fetchStart := portfolio.Months(3).Before(now)
+
+			ds := &spliceMockDataSource{
+				currentDate: now,
+				frames: map[string]*data.DataFrame{
+					"TQQQ": makeDailyFrame(tqqq, data.MetricClose, fetchStart, 100),
+					"QLD":  makeDailyFrame(qld, data.MetricClose, fetchStart, 100),
+				},
+			}
+
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+			u.SetDataSource(ds)
+
+			df, err := u.Window(context.Background(), portfolio.Months(3), data.MetricClose)
+			Expect(err).NotTo(HaveOccurred())
+
+			// QLD was never fetched because its segment doesn't intersect the window.
+			Expect(ds.fetchCalls).To(Equal([]string{"TQQQ"}))
+			Expect(df.AssetList()).To(ConsistOf(tqqq))
+			Expect(df.Len()).To(BeNumerically(">", 0))
+		})
+
+		It("returns only fallback data when the lookback is fully before the cutoff", func() {
+			now := time.Date(2008, 6, 1, 0, 0, 0, 0, time.UTC)
+			fetchStart := portfolio.Months(3).Before(now)
+
+			ds := &spliceMockDataSource{
+				currentDate: now,
+				frames: map[string]*data.DataFrame{
+					"QLD": makeDailyFrame(qld, data.MetricClose, fetchStart, 100),
+				},
+			}
+
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+			u.SetDataSource(ds)
+
+			df, err := u.Window(context.Background(), portfolio.Months(3), data.MetricClose)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ds.fetchCalls).To(Equal([]string{"QLD"}))
+			// All rows come from QLD, but the column identity is QLD itself
+			// because that is the active ticker on the current sim date.
+			Expect(df.AssetList()).To(ConsistOf(qld))
+			Expect(df.Len()).To(BeNumerically(">", 0))
+		})
+
+		It("splices QLD and TQQQ rows when the window crosses the cutoff", func() {
+			now := time.Date(2010, 4, 1, 0, 0, 0, 0, time.UTC)
+			fetchStart := portfolio.Months(3).Before(now)
+
+			ds := &spliceMockDataSource{
+				currentDate: now,
+				frames: map[string]*data.DataFrame{
+					"QLD":  makeDailyFrame(qld, data.MetricClose, fetchStart, 120),
+					"TQQQ": makeDailyFrame(tqqq, data.MetricClose, fetchStart, 120),
+				},
+			}
+
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+			u.SetDataSource(ds)
+
+			df, err := u.Window(context.Background(), portfolio.Months(3), data.MetricClose)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Both segments intersect the window, so both got fetched.
+			Expect(ds.fetchCalls).To(ConsistOf("QLD", "TQQQ"))
+
+			// Result is a single column under the active-today asset (TQQQ),
+			// even though pre-cutoff bars are sourced from QLD.
+			Expect(df.AssetList()).To(ConsistOf(tqqq))
+
+			// Times are strictly increasing across the splice with no
+			// duplicates at the cutoff boundary.
+			times := df.Times()
+			Expect(len(times)).To(BeNumerically(">", 1))
+			for ii := 1; ii < len(times); ii++ {
+				Expect(times[ii].After(times[ii-1])).To(BeTrue(),
+					"timestamps must strictly increase across the splice; got %s then %s",
+					times[ii-1], times[ii])
+			}
+
+			// The cutoff itself should be the first post-cutoff row.
+			cutoffIdx := -1
+			for ii, t := range times {
+				if !t.Before(cutoff) {
+					cutoffIdx = ii
+					break
+				}
+			}
+			Expect(cutoffIdx).To(BeNumerically(">", 0),
+				"window must contain at least one pre-cutoff and one post-cutoff row")
+		})
+
+		It("returns an error when no data source is set", func() {
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+
+			_, err := u.Window(context.Background(), portfolio.Months(3), data.MetricClose)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("CurrentDate", func() {
+		It("delegates to the data source", func() {
+			now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			ds := &spliceMockDataSource{currentDate: now}
+
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			resolveAssets(u)
+			u.SetDataSource(ds)
+
+			Expect(u.CurrentDate()).To(Equal(now))
+		})
+
+		It("returns zero time when no data source is set", func() {
+			u := universe.NewSplice("TQQQ", universe.SplicePeriod{Ticker: "QLD", Before: cutoff})
+			Expect(u.CurrentDate()).To(Equal(time.Time{}))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Strategies can now declare single-ticker `asset.Asset` parameters that are overridable from the command line (e.g. `--bench QQQ`).

A new splice universe lets backtests of recently-listed instruments extend further into history by substituting a historical proxy ticker for pre-listing dates. For example, a TQQQ-based strategy can register QLD as a fallback for dates before TQQQ's February 2010 listing. Substitution uses raw prices with no leverage adjustment; order routing and reporting follow whichever ticker is live on the order date, so positions migrate via a normal rebalance when the simulation crosses a cutoff.