### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-03
+
 ### Added
 
 - Strategies can override single-ticker parameters from the command line.


### PR DESCRIPTION
Release v0.9.0.

Highlights:
- Strategies can override single-ticker parameters from the command line.
- A new splice universe lets backtests of recently-listed instruments substitute a historical proxy ticker for pre-listing dates.