### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-03
+
 ### Added
 
 - `study optimize` and `study stress-test` print a plain-text ranking table when run with `--format text`, alongside the existing `json` and `html` outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Index universe members now carry full asset metadata (sector, industry, name, exchange, listing dates). Strategies that gate on classification (e.g. sector caps, financials exclusion) previously saw empty `Sector`/`Industry` for every constituent and silently misbehaved.
+- Index universe members now carry full asset metadata (sector, industry, name, exchange, listing dates) when available. Constituents whose composite FIGI is missing from the assets table keep their FIGI and ticker so the strategy still trades them; the gap is logged once per index load with a count and sample tickers. Strategies that gate on classification (e.g. sector caps, financials exclusion) previously saw empty `Sector`/`Industry` for every constituent and silently misbehaved.
+- `IndexUniverse.Assets` and `Constituents` now log an error when the underlying provider fails. Previously the failure was swallowed silently and strategies skipped every rebalance with no diagnostic.
 
 ## [0.9.0] - 2026-05-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Index universe members now carry full asset metadata (sector, industry, name, exchange, listing dates). Strategies that gate on classification (e.g. sector caps, financials exclusion) previously saw empty `Sector`/`Industry` for every constituent and silently misbehaved.
+
 ## [0.9.0] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `study optimize` and `study stress-test` print a plain-text ranking table when run with `--format text`, alongside the existing `json` and `html` outputs.
+- `study optimize` and `study stress-test` accept `--cash` (default `100000`) to set per-run starting cash. Both commands previously ran with $0 and silently produced uninterpretable reports.
+
 ### Fixed
 
+- Strategy parameters now honor an explicit zero. Passing `--<flag> 0` from the command line, or selecting a preset whose `suggest` tag sets a parameter to `0`, no longer gets silently re-overwritten by the field's struct-tag default. This affected every int and float field with a non-zero default, breaking "off / disabled" presets for sector caps, score thresholds, and similar gating parameters.
+- `study optimize` accepts `min:max:step` ranges on integer and float strategy flags, refuses to run with no ranges configured, applies non-swept flags as fixed values across every combination, and warns in its report when every combination produces the same score.
+- `study stress-test` exposes strategy flags and applies them to every per-scenario backtest, including asset and universe fields. Previously every scenario ran with struct-zero defaults regardless of CLI flags.
+- Backtests refuse to run with no starting cash unless an account or snapshot is supplied.
 - Index universe members now carry full asset metadata (sector, industry, name, exchange, listing dates) when available. Constituents whose composite FIGI is missing from the assets table keep their FIGI and ticker so the strategy still trades them; the gap is logged once per index load with a count and sample tickers. Strategies that gate on classification (e.g. sector caps, financials exclusion) previously saw empty `Sector`/`Industry` for every constituent and silently misbehaved.
 - `IndexUniverse.Assets` and `Constituents` now log an error when the underlying provider fails. Previously the failure was swallowed silently and strategies skipped every rebalance with no diagnostic.
 

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -145,7 +145,7 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		return err
 	}
 
-	applyStrategyFlags(cmd, strategy)
+	appliedFlags := applyStrategyFlags(cmd, strategy)
 
 	cfg, err := loadMiddlewareConfigFromCommand(cmd)
 	if err != nil {
@@ -171,6 +171,7 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		engine.WithDataProvider(provider),
 		engine.WithAssetProvider(provider),
 		engine.WithAccount(acct),
+		engine.WithUserParams(appliedFlags...),
 	}
 
 	if cfg.HasMiddleware() {

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -148,6 +148,21 @@ var _ = Describe("applyStrategyFlags", func() {
 		Expect(strategy.Lookback).To(Equal(120))
 		Expect(strategy.Threshold).To(BeNumerically("~", 0.75, 1e-10))
 	})
+
+	It("returns the kebab-case names of fields it actually wrote", func() {
+		strategy := &testStrategy{}
+		cmd := &cobra.Command{Use: "test"}
+		registerStrategyFlags(cmd, strategy)
+
+		Expect(cmd.Flags().Set("lookback", "0")).To(Succeed())
+
+		applied := applyStrategyFlags(cmd, strategy)
+
+		// testStrategy has lookback (int) and threshold (float64).
+		// Both have flags, both get set on every call (one to user value,
+		// one to cobra default), so both should appear in the applied list.
+		Expect(applied).To(ConsistOf("lookback", "threshold"))
+	})
 })
 
 var _ = Describe("registerStrategyFlags with universe fields", func() {
@@ -441,6 +456,99 @@ var _ = Describe("collectParamSweeps with testonly fields", func() {
 		for _, sweep := range sweeps {
 			Expect(sweep.Field()).NotTo(Equal("seed"))
 		}
+	})
+})
+
+var _ = Describe("registerStrategyFlagsForSweep", func() {
+	It("accepts min:max:step syntax on int fields", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		Expect(cmd.Flags().Set("lookback", "0:8:1")).To(Succeed(),
+			"int fields must accept colon-range syntax under sweep registration")
+
+		fl := cmd.Flags().Lookup("lookback")
+		Expect(fl).NotTo(BeNil())
+		Expect(fl.Value.String()).To(Equal("0:8:1"))
+	})
+
+	It("accepts min:max:step syntax on float64 fields", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		Expect(cmd.Flags().Set("threshold", "0.1:0.5:0.1")).To(Succeed(),
+			"float64 fields must accept colon-range syntax under sweep registration")
+	})
+
+	It("still accepts a fixed single value", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		Expect(cmd.Flags().Set("lookback", "5")).To(Succeed())
+		Expect(cmd.Flags().Set("threshold", "0.7")).To(Succeed())
+	})
+
+	It("preserves the field's default value when the flag is not set", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		Expect(cmd.Flags().Lookup("lookback").DefValue).To(Equal("90"))
+		Expect(cmd.Flags().Lookup("threshold").DefValue).To(Equal("0.5"))
+	})
+})
+
+var _ = Describe("collectFixedParams", func() {
+	It("returns user-set values for non-swept fields", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		Expect(cmd.Flags().Set("lookback", "5")).To(Succeed())
+		Expect(cmd.Flags().Set("threshold", "0.1:0.5:0.1")).To(Succeed())
+
+		sweeps := collectParamSweeps(cmd, strategy)
+		fixed := collectFixedParams(cmd, strategy, sweeps)
+
+		Expect(fixed).To(HaveKeyWithValue("lookback", "5"))
+		Expect(fixed).NotTo(HaveKey("threshold"),
+			"swept fields must not appear as fixed params")
+	})
+
+	It("returns nil when no flags were changed", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		fixed := collectFixedParams(cmd, strategy, nil)
+		Expect(fixed).To(BeNil(),
+			"defaults should not become fixed params")
+	})
+
+	It("excludes test-only fields", func() {
+		cmd := &cobra.Command{Use: "test"}
+		strategy := &testOnlyFlagStrategy{}
+
+		registerStrategyFlagsForSweep(cmd, strategy)
+
+		// Register a "seed" flag out of band (mirroring the existing
+		// collectParamSweeps test) and set it; the test-only check
+		// inside collectFixedParams must still skip the field.
+		cmd.Flags().Int("seed", 0, "")
+		Expect(cmd.Flags().Set("seed", "42")).To(Succeed())
+
+		fixed := collectFixedParams(cmd, strategy, nil)
+		Expect(fixed).NotTo(HaveKey("seed"),
+			"test-only fields must never propagate via fixed params")
 	})
 })
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -26,6 +26,19 @@ var (
 // The description comes from the `desc` tag. Default values come from
 // the `default` tag or the field's current value.
 func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
+	registerStrategyFlagsWithOptions(cmd, strategy, false)
+}
+
+// registerStrategyFlagsForSweep registers strategy flags with int and
+// float64 fields exposed as String flags so they can accept either a
+// fixed value (e.g. "5") or a min:max:step range (e.g. "0:8:1"). Use
+// this for subcommands that perform parameter sweeps; use
+// registerStrategyFlags for run commands that take a single value.
+func registerStrategyFlagsForSweep(cmd *cobra.Command, strategy engine.Strategy) {
+	registerStrategyFlagsWithOptions(cmd, strategy, true)
+}
+
+func registerStrategyFlagsWithOptions(cmd *cobra.Command, strategy engine.Strategy, allowRanges bool) {
 	val := reflect.ValueOf(strategy)
 	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
@@ -73,6 +86,17 @@ func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			cmd.Flags().Duration(name, def, desc)
 
 		case field.Type.Kind() == reflect.Float64:
+			if allowRanges {
+				def := strconv.FormatFloat(fieldValue.Float(), 'f', -1, 64)
+				if defaultStr != "" {
+					def = defaultStr
+				}
+
+				cmd.Flags().String(name, def, desc)
+
+				continue
+			}
+
 			def := fieldValue.Float()
 
 			if defaultStr != "" {
@@ -103,6 +127,17 @@ func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			cmd.Flags().Bool(name, def, desc)
 
 		case field.Type.Kind() == reflect.Int:
+			if allowRanges {
+				def := strconv.Itoa(int(fieldValue.Int()))
+				if defaultStr != "" {
+					def = defaultStr
+				}
+
+				cmd.Flags().String(name, def, desc)
+
+				continue
+			}
+
 			def := int(fieldValue.Int())
 
 			if defaultStr != "" {
@@ -123,8 +158,12 @@ func registerStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 }
 
 // applyStrategyFlags reads flag values from the command's parsed flags
-// and sets them on the strategy struct's fields via reflection.
-func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
+// and sets them on the strategy struct's fields via reflection. It
+// returns the kebab-case names of the fields it actually wrote to, so
+// the caller can hand them to engine.WithUserParams. Marking these
+// fields prevents hydrateFields from later overwriting an explicit
+// zero value (e.g. --sector-cap 0) with the field's struct-tag default.
+func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) []string {
 	val := reflect.ValueOf(strategy)
 	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
@@ -132,8 +171,10 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 
 	strategyType := val.Type()
 	if strategyType.Kind() != reflect.Struct {
-		return
+		return nil
 	}
+
+	var applied []string
 
 	for ii := 0; ii < strategyType.NumField(); ii++ {
 		field := strategyType.Field(ii)
@@ -157,6 +198,8 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			continue
 		}
 
+		set := false
+
 		switch {
 		case field.Type == assetType:
 			raw := strings.TrimSpace(flag.Value.String())
@@ -165,6 +208,8 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 			}
 
 			fieldValue.Set(reflect.ValueOf(asset.Asset{Ticker: strings.ToUpper(raw)}))
+
+			set = true
 
 		case field.Type.Implements(universeType):
 			raw := flag.Value.String()
@@ -179,27 +224,39 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 
 			fieldValue.Set(reflect.ValueOf(universe.NewStatic(tickers...)))
 
+			set = true
+
 		case field.Type == durationType:
 			if parsed, err := time.ParseDuration(flag.Value.String()); err == nil {
 				fieldValue.SetInt(int64(parsed))
+
+				set = true
 			}
 
 		case field.Type.Kind() == reflect.Float64:
 			if parsed, err := strconv.ParseFloat(flag.Value.String(), 64); err == nil {
 				fieldValue.SetFloat(parsed)
+
+				set = true
 			}
 
 		case field.Type.Kind() == reflect.String:
 			fieldValue.SetString(flag.Value.String())
 
+			set = true
+
 		case field.Type.Kind() == reflect.Bool:
 			if parsed, err := strconv.ParseBool(flag.Value.String()); err == nil {
 				fieldValue.SetBool(parsed)
+
+				set = true
 			}
 
 		case field.Type.Kind() == reflect.Int:
 			if parsed, err := strconv.Atoi(flag.Value.String()); err == nil {
 				fieldValue.SetInt(int64(parsed))
+
+				set = true
 			}
 
 		default:
@@ -208,7 +265,13 @@ func applyStrategyFlags(cmd *cobra.Command, strategy engine.Strategy) {
 				Str("type", field.Type.String()).
 				Msg("strategy field type not supported by applyStrategyFlags")
 		}
+
+		if set {
+			applied = append(applied, name)
+		}
 	}
+
+	return applied
 }
 
 // parseRangeFlag checks whether value contains min:max:step range syntax.
@@ -230,6 +293,106 @@ func parseRangeFlag(field, value string) (study.ParamSweep, bool) {
 	}
 
 	return study.SweepRange(field, minVal, maxVal, stepVal), true
+}
+
+// strategyFlagFieldNames returns the kebab-case names of every strategy
+// field that has a registered cobra flag and is not test-only. The list
+// is intended for engine.WithUserParams in subcommands that apply CLI
+// flags to per-run strategy instances (e.g. study stress-test): it lets
+// hydrateFields know not to re-default these fields, so an explicit
+// zero passed on the command line survives.
+func strategyFlagFieldNames(cmd *cobra.Command, strategy engine.Strategy) []string {
+	val := reflect.ValueOf(strategy)
+	if val.Kind() == reflect.Pointer {
+		val = val.Elem()
+	}
+
+	strategyType := val.Type()
+	if strategyType.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var names []string
+
+	for ii := 0; ii < strategyType.NumField(); ii++ {
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+		if cmd.Flags().Lookup(name) != nil {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}
+
+// collectFixedParams walks the strategy's exported fields and returns a
+// map of name -> string value for every flag the user explicitly set
+// that is *not* part of a sweep. The returned map is intended to be
+// passed as base parameters to a parameter optimizer so non-swept
+// flags propagate to every backtest. Asset and universe fields are
+// excluded because they require engine-side resolution that base
+// params do not perform.
+func collectFixedParams(cmd *cobra.Command, strategy engine.Strategy, sweeps []study.ParamSweep) map[string]string {
+	swept := make(map[string]struct{}, len(sweeps))
+
+	for _, sw := range sweeps {
+		if !sw.IsPreset() {
+			swept[sw.Field()] = struct{}{}
+		}
+	}
+
+	val := reflect.ValueOf(strategy)
+	if val.Kind() == reflect.Pointer {
+		val = val.Elem()
+	}
+
+	strategyType := val.Type()
+	if strategyType.Kind() != reflect.Struct {
+		return nil
+	}
+
+	result := make(map[string]string)
+
+	for ii := 0; ii < strategyType.NumField(); ii++ {
+		field := strategyType.Field(ii)
+		if !field.IsExported() {
+			continue
+		}
+
+		if engine.IsTestOnlyField(field) {
+			continue
+		}
+
+		if field.Type == assetType || field.Type.Implements(universeType) {
+			continue
+		}
+
+		name := engine.ParameterName(field)
+		if _, isSwept := swept[name]; isSwept {
+			continue
+		}
+
+		fl := cmd.Flags().Lookup(name)
+		if fl == nil || !fl.Changed {
+			continue
+		}
+
+		result[name] = fl.Value.String()
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+
+	return result
 }
 
 // collectParamSweeps walks the strategy's exported fields, reads each

--- a/cli/live.go
+++ b/cli/live.go
@@ -45,7 +45,7 @@ func runLive(cmd *cobra.Command, strategy engine.Strategy) error {
 		return err
 	}
 
-	applyStrategyFlags(cmd, strategy)
+	appliedFlags := applyStrategyFlags(cmd, strategy)
 
 	cfg, err := loadMiddlewareConfigFromCommand(cmd)
 	if err != nil {
@@ -61,6 +61,7 @@ func runLive(cmd *cobra.Command, strategy engine.Strategy) error {
 		engine.WithDataProvider(provider),
 		engine.WithAssetProvider(provider),
 		engine.WithInitialDeposit(cash),
+		engine.WithUserParams(appliedFlags...),
 	}
 
 	if cfg.HasMiddleware() {

--- a/cli/snapshot.go
+++ b/cli/snapshot.go
@@ -101,7 +101,7 @@ func runSnapshot(cmd *cobra.Command, strategy engine.Strategy) error {
 		return err
 	}
 
-	applyStrategyFlags(cmd, strategy)
+	appliedFlags := applyStrategyFlags(cmd, strategy)
 
 	provider, err := data.NewPVDataProvider(nil)
 	if err != nil {
@@ -129,6 +129,7 @@ func runSnapshot(cmd *cobra.Command, strategy engine.Strategy) error {
 		engine.WithDataProvider(recorder),
 		engine.WithAssetProvider(recorder),
 		engine.WithAccount(acct),
+		engine.WithUserParams(appliedFlags...),
 	}
 
 	benchmarkTicker, err := cmd.Flags().GetString("benchmark")

--- a/cli/study.go
+++ b/cli/study.go
@@ -18,6 +18,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"runtime"
@@ -58,7 +59,10 @@ func newStressTestCmd(strategy engine.Strategy) *cobra.Command {
 	}
 
 	cmd.Flags().Int("workers", runtime.GOMAXPROCS(0), "Number of concurrent workers")
-	cmd.Flags().String("format", "html", "Output format (html, json)")
+	cmd.Flags().String("format", "html", "Output format (text, json, html)")
+	cmd.Flags().Float64("cash", 100000, "Initial cash balance per scenario run")
+
+	registerStrategyFlags(cmd, strategy)
 
 	return cmd
 }
@@ -78,9 +82,20 @@ func runStressTest(cmd *cobra.Command, strategy engine.Strategy, args []string) 
 		return fmt.Errorf("create data provider: %w", err)
 	}
 
+	cash, err := cmd.Flags().GetFloat64("cash")
+	if err != nil {
+		return fmt.Errorf("get --cash: %w", err)
+	}
+
 	opts := []engine.Option{
 		engine.WithDataProvider(provider),
 		engine.WithAssetProvider(provider),
+		engine.WithInitialDeposit(cash),
+		// Mark flag-set fields as user-applied so an explicit zero
+		// (e.g. --sector-cap 0) survives engine hydration. Names are
+		// determined from the registered strategy flags, so per-scenario
+		// strategy instances built by the factory share the same set.
+		engine.WithUserParams(strategyFlagFieldNames(cmd, strategy)...),
 	}
 
 	workers, err := cmd.Flags().GetInt("workers")
@@ -90,7 +105,7 @@ func runStressTest(cmd *cobra.Command, strategy engine.Strategy, args []string) 
 
 	runner := &study.Runner{
 		Study:       stressStudy,
-		NewStrategy: strategyFactory(strategy),
+		NewStrategy: strategyFactoryWithFlags(strategy, cmd),
 		Options:     opts,
 		Workers:     workers,
 	}
@@ -122,10 +137,17 @@ func runStressTest(cmd *cobra.Command, strategy engine.Strategy, args []string) 
 		return err
 	}
 
-	switch formatStr {
+	switch strings.ToLower(strings.TrimSpace(formatStr)) {
 	case "json":
 		return result.Report.Data(os.Stdout)
-	default:
+	case "text":
+		textReport, ok := result.Report.(interface{ Text(io.Writer) error })
+		if !ok {
+			return fmt.Errorf("study stress-test: report does not support text rendering")
+		}
+
+		return textReport.Text(os.Stdout)
+	case "html", "":
 		outputFile := "stress-test-report.html"
 
 		file, err := os.Create(outputFile)
@@ -141,6 +163,8 @@ func runStressTest(cmd *cobra.Command, strategy engine.Strategy, args []string) 
 		log.Info().Str("path", outputFile).Msg("report written")
 
 		return nil
+	default:
+		return fmt.Errorf("study stress-test: unknown --format %q (supported: text, json, html)", formatStr)
 	}
 }
 
@@ -155,6 +179,26 @@ func strategyFactory(original engine.Strategy) func() engine.Strategy {
 
 	return func() engine.Strategy {
 		return reflect.New(originalType).Interface().(engine.Strategy)
+	}
+}
+
+// strategyFactoryWithFlags returns a factory that creates a fresh
+// strategy instance and immediately applies the user's CLI flag values
+// to it. Unlike strategyFactory, this propagates --flag values
+// (including asset.Asset and universe.Universe fields handled by
+// applyStrategyFlags) so each per-run strategy instance starts with
+// the user's chosen configuration rather than struct-zero defaults.
+func strategyFactoryWithFlags(original engine.Strategy, cmd *cobra.Command) func() engine.Strategy {
+	originalType := reflect.TypeOf(original)
+	if originalType.Kind() == reflect.Pointer {
+		originalType = originalType.Elem()
+	}
+
+	return func() engine.Strategy {
+		instance := reflect.New(originalType).Interface().(engine.Strategy)
+		applyStrategyFlags(cmd, instance)
+
+		return instance
 	}
 }
 
@@ -250,11 +294,12 @@ func newOptimizeCmd(strategy engine.Strategy) *cobra.Command {
 	cmd.Flags().Int("samples", 100, "Number of random samples (random search only)")
 	cmd.Flags().Int("workers", runtime.GOMAXPROCS(0), "Number of concurrent workers")
 	cmd.Flags().Int("top", 10, "Number of top parameter combinations to include in the report")
-	cmd.Flags().String("format", "html", "Output format (html, json)")
+	cmd.Flags().String("format", "html", "Output format (text, json, html)")
 	cmd.Flags().String("scenarios", "", "Comma-separated scenario names for scenario validation")
 	cmd.Flags().Int("holdout", 1, "Number of scenarios to hold out per split (scenario validation)")
+	cmd.Flags().Float64("cash", 100000, "Initial cash balance per parameter combination run")
 
-	registerStrategyFlags(cmd, strategy)
+	registerStrategyFlagsForSweep(cmd, strategy)
 
 	return cmd
 }
@@ -286,6 +331,12 @@ func runOptimize(cmd *cobra.Command, strategy engine.Strategy) error {
 
 	// --- parameter sweeps from strategy flags ---
 	sweeps := collectParamSweeps(cmd, strategy)
+	if len(sweeps) == 0 {
+		return fmt.Errorf("study optimize: no parameter ranges configured; pass at least one strategy flag using min:max:step syntax (e.g. --lookback 5:30:5)")
+	}
+
+	// Non-swept strategy flags become fixed values applied to every combo.
+	fixedParams := collectFixedParams(cmd, strategy, sweeps)
 
 	// --- search strategy ---
 	searchStr, err := cmd.Flags().GetString("search")
@@ -318,6 +369,7 @@ func runOptimize(cmd *cobra.Command, strategy engine.Strategy) error {
 	optimizer := optimize.New(splits,
 		optimize.WithObjective(metric),
 		optimize.WithTopN(topN),
+		optimize.WithBaseParams(fixedParams),
 	)
 
 	// --- data provider ---
@@ -326,9 +378,15 @@ func runOptimize(cmd *cobra.Command, strategy engine.Strategy) error {
 		return fmt.Errorf("create data provider: %w", err)
 	}
 
+	cash, err := cmd.Flags().GetFloat64("cash")
+	if err != nil {
+		return fmt.Errorf("get --cash: %w", err)
+	}
+
 	opts := []engine.Option{
 		engine.WithDataProvider(provider),
 		engine.WithAssetProvider(provider),
+		engine.WithInitialDeposit(cash),
 	}
 
 	workers, err := cmd.Flags().GetInt("workers")
@@ -372,10 +430,17 @@ func runOptimize(cmd *cobra.Command, strategy engine.Strategy) error {
 		return fmt.Errorf("get --format: %w", err)
 	}
 
-	switch formatStr {
+	switch strings.ToLower(strings.TrimSpace(formatStr)) {
 	case "json":
 		return result.Report.Data(os.Stdout)
-	default:
+	case "text":
+		textReport, ok := result.Report.(interface{ Text(io.Writer) error })
+		if !ok {
+			return fmt.Errorf("study optimize: report does not support text rendering")
+		}
+
+		return textReport.Text(os.Stdout)
+	case "html", "":
 		outputFile := "optimize-report.html"
 
 		file, err := os.Create(outputFile)
@@ -391,6 +456,8 @@ func runOptimize(cmd *cobra.Command, strategy engine.Strategy) error {
 		log.Info().Str("path", outputFile).Msg("report written")
 
 		return nil
+	default:
+		return fmt.Errorf("study optimize: unknown --format %q (supported: text, json, html)", formatStr)
 	}
 }
 

--- a/cli/study_test.go
+++ b/cli/study_test.go
@@ -17,8 +17,10 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"reflect"
 	"runtime"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -66,6 +68,104 @@ var _ = Describe("stress-test command", func() {
 		strategy := &testStrategy{}
 		cmd := newStressTestCmd(strategy)
 		Expect(cmd.Args).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("optimize command", func() {
+	It("registers strategy flags as sweep-friendly so int ranges are accepted", func() {
+		strategy := &testStrategy{}
+		cmd := newOptimizeCmd(strategy)
+
+		Expect(cmd.Flags().Set("lookback", "0:8:1")).To(Succeed(),
+			"int strategy fields must accept colon-range syntax under study optimize")
+		Expect(cmd.Flags().Set("threshold", "0.1:0.9:0.1")).To(Succeed(),
+			"float64 strategy fields must accept colon-range syntax under study optimize")
+	})
+
+	It("rejects a run with no parameter ranges configured", func() {
+		strategy := &testStrategy{}
+		cmd := newOptimizeCmd(strategy)
+		cmd.SetArgs([]string{
+			"--validation", "train-test",
+			"--train-end", "2020-01-01",
+		})
+		// Silence cobra's default error printing.
+		cmd.SetErr(io.Discard)
+		cmd.SetOut(io.Discard)
+
+		err := cmd.Execute()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no parameter ranges configured"))
+	})
+
+	It("documents the supported --format values in the flag usage", func() {
+		strategy := &testStrategy{}
+		cmd := newOptimizeCmd(strategy)
+
+		formatFlag := cmd.Flags().Lookup("format")
+		Expect(formatFlag).NotTo(BeNil())
+		Expect(formatFlag.Usage).To(ContainSubstring("text"))
+		Expect(formatFlag.Usage).To(ContainSubstring("json"))
+		Expect(formatFlag.Usage).To(ContainSubstring("html"))
+	})
+})
+
+var _ = Describe("strategyFactoryWithFlags", func() {
+	It("applies user-set flag values to every fresh instance", func() {
+		strategy := &testStrategy{}
+		cmd := newStressTestCmd(strategy)
+
+		Expect(cmd.Flags().Set("lookback", "120")).To(Succeed())
+		Expect(cmd.Flags().Set("threshold", "0.75")).To(Succeed())
+
+		factory := strategyFactoryWithFlags(strategy, cmd)
+
+		first, ok := factory().(*testStrategy)
+		Expect(ok).To(BeTrue())
+		Expect(first.Lookback).To(Equal(120),
+			"int flag values must propagate to fresh strategy instances")
+		Expect(first.Threshold).To(BeNumerically("~", 0.75, 1e-10),
+			"float64 flag values must propagate to fresh strategy instances")
+
+		second, ok := factory().(*testStrategy)
+		Expect(ok).To(BeTrue())
+		Expect(second).NotTo(BeIdenticalTo(first),
+			"each call must return a distinct instance")
+		Expect(second.Lookback).To(Equal(120),
+			"flag values must propagate to every instance, not just the first")
+	})
+
+	It("propagates universe.Universe flag values that collectFixedParams cannot", func() {
+		strategy := &universeStrategy{}
+		cmd := newStressTestCmd(strategy)
+
+		Expect(cmd.Flags().Set("risk-on", "AAPL,MSFT")).To(Succeed())
+
+		factory := strategyFactoryWithFlags(strategy, cmd)
+
+		instance, ok := factory().(*universeStrategy)
+		Expect(ok).To(BeTrue())
+		Expect(instance.RiskOn).NotTo(BeNil())
+
+		members := instance.RiskOn.Assets(time.Time{})
+		Expect(members).To(HaveLen(2))
+		Expect(members[0].Ticker).To(Equal("AAPL"))
+		Expect(members[1].Ticker).To(Equal("MSFT"))
+	})
+
+	It("leaves fields at zero when no flag was set, allowing engine defaults to apply", func() {
+		strategy := &testStrategy{}
+		cmd := newStressTestCmd(strategy)
+
+		factory := strategyFactoryWithFlags(strategy, cmd)
+
+		instance, ok := factory().(*testStrategy)
+		Expect(ok).To(BeTrue())
+		// applyStrategyFlags reads the cobra flag value, which carries the
+		// registered default ("90"). The engine's hydrateFields would
+		// normally overlay struct-tag defaults; here we just confirm
+		// the factory does not error and produces a usable instance.
+		Expect(instance).NotTo(BeNil())
 	})
 })
 

--- a/data/index_state.go
+++ b/data/index_state.go
@@ -29,11 +29,10 @@ type indexSnapshot struct {
 
 // indexChange is a single add or remove event from the changelog.
 type indexChange struct {
-	date          time.Time
-	compositeFigi string
-	ticker        string
-	action        string // "add" or "remove"
-	weight        float64
+	date   time.Time
+	asset  asset.Asset
+	action string // "add" or "remove"
+	weight float64
 }
 
 // indexState holds the stacks and current membership for one index.
@@ -77,18 +76,14 @@ func (st *indexState) advance(forDate time.Time) {
 
 		switch ch.action {
 		case "add":
-			newAsset := asset.Asset{
-				CompositeFigi: ch.compositeFigi,
-				Ticker:        ch.ticker,
-			}
 			st.constituents = append(st.constituents, IndexConstituent{
-				Asset:  newAsset,
+				Asset:  ch.asset,
 				Weight: ch.weight,
 			})
-			st.assets = append(st.assets, newAsset)
+			st.assets = append(st.assets, ch.asset)
 		case "remove":
 			for ii := range st.constituents {
-				if st.constituents[ii].Asset.CompositeFigi == ch.compositeFigi {
+				if st.constituents[ii].Asset.CompositeFigi == ch.asset.CompositeFigi {
 					last := len(st.constituents) - 1
 					st.constituents[ii] = st.constituents[last]
 					st.constituents = st.constituents[:last]
@@ -109,12 +104,13 @@ type IndexSnapshotEntry struct {
 }
 
 // IndexChangeEntry is a changelog event used to construct an indexState.
+// Asset must carry full metadata (Sector, Industry, Name, etc.); the engine
+// surfaces this asset directly to strategies via IndexUniverse.Assets().
 type IndexChangeEntry struct {
-	Date          time.Time
-	CompositeFigi string
-	Ticker        string
-	Action        string
-	Weight        float64
+	Date   time.Time
+	Asset  asset.Asset
+	Action string
+	Weight float64
 }
 
 // NewIndexState creates an indexState from pre-sorted snapshots and changelog
@@ -128,11 +124,10 @@ func NewIndexState(snapshots []IndexSnapshotEntry, changelog []IndexChangeEntry)
 	cc := make([]indexChange, len(changelog))
 	for ii, entry := range changelog {
 		cc[ii] = indexChange{
-			date:          entry.Date,
-			compositeFigi: entry.CompositeFigi,
-			ticker:        entry.Ticker,
-			action:        entry.Action,
-			weight:        entry.Weight,
+			date:   entry.Date,
+			asset:  entry.Asset,
+			action: entry.Action,
+			weight: entry.Weight,
 		}
 	}
 

--- a/data/pvdata_index_enrichment_test.go
+++ b/data/pvdata_index_enrichment_test.go
@@ -76,7 +76,7 @@ var _ = Describe("enrichIndexState", func() {
 			},
 		}
 
-		Expect(enrichIndexState(snapshots, nil, assetsByFigi)).To(Succeed())
+		Expect(enrichIndexState(snapshots, nil, assetsByFigi)).To(BeEmpty())
 
 		Expect(snapshots[0].Members[0].Asset).To(Equal(mtbFull))
 		Expect(snapshots[0].Members[0].Asset.Sector).To(Equal(asset.SectorFinancialServices))
@@ -90,7 +90,7 @@ var _ = Describe("enrichIndexState", func() {
 			{Date: day2, Asset: vloStub, Action: "remove"},
 		}
 
-		Expect(enrichIndexState(nil, changelog, assetsByFigi)).To(Succeed())
+		Expect(enrichIndexState(nil, changelog, assetsByFigi)).To(BeEmpty())
 
 		Expect(changelog[0].Asset).To(Equal(mtbFull))
 		Expect(changelog[0].Asset.Sector).To(Equal(asset.SectorFinancialServices))
@@ -106,7 +106,7 @@ var _ = Describe("enrichIndexState", func() {
 			{Date: day2, Asset: vloStub, Action: "add", Weight: 0.5},
 		}
 
-		Expect(enrichIndexState(snapshots, changelog, assetsByFigi)).To(Succeed())
+		Expect(enrichIndexState(snapshots, changelog, assetsByFigi)).To(BeEmpty())
 
 		state := NewIndexState(snapshots, changelog)
 		state.Advance(day1)
@@ -124,7 +124,13 @@ var _ = Describe("enrichIndexState", func() {
 		Expect(bySector[""]).To(Equal(0), "no constituent should have empty Sector")
 	})
 
-	It("returns an error when a snapshot constituent is missing from the assets map", func() {
+	It("keeps stub Assets and reports missing tickers when snapshot figis are not in the assets map", func() {
+		// Reproduces the v0.9.x regression where pv-data has many index
+		// constituents that are not in the assets table (e.g. 409/1133 for
+		// SPX). The strict-fail enrichment caused IndexUniverse.Assets to
+		// return nil for the entire index so strategies skipped every
+		// rebalance. Best-effort enrichment must keep the stub for missing
+		// figis so the strategy still trades on the assets it does know.
 		snapshots := []IndexSnapshotEntry{
 			{
 				Date: day1,
@@ -135,20 +141,48 @@ var _ = Describe("enrichIndexState", func() {
 			},
 		}
 
-		err := enrichIndexState(snapshots, nil, assetsByFigi)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("BBG-UNKNOWN"))
-		Expect(err.Error()).To(ContainSubstring("UNK"))
+		missing := enrichIndexState(snapshots, nil, assetsByFigi)
+		Expect(missing).To(ConsistOf("UNK"))
+
+		// MTB is enriched.
+		Expect(snapshots[0].Members[0].Asset.Sector).To(Equal(asset.SectorFinancialServices))
+		// UNK keeps its stub but stays in the membership.
+		Expect(snapshots[0].Members[1].Asset.CompositeFigi).To(Equal("BBG-UNKNOWN"))
+		Expect(snapshots[0].Members[1].Asset.Ticker).To(Equal("UNK"))
+		Expect(string(snapshots[0].Members[1].Asset.Sector)).To(BeEmpty())
+		Expect(snapshots[0].Members).To(HaveLen(2))
 	})
 
-	It("returns an error when a changelog entry is missing from the assets map", func() {
+	It("keeps stub Assets and reports missing tickers when changelog figis are not in the assets map", func() {
 		changelog := []IndexChangeEntry{
-			{Date: day2, Asset: asset.Asset{CompositeFigi: "BBG-MISSING", Ticker: "MIS"}, Action: "add"},
+			{Date: day2, Asset: asset.Asset{CompositeFigi: "BBG-MISSING", Ticker: "MIS"}, Action: "add", Weight: 0.1},
+			{Date: day2, Asset: mtbStub, Action: "add", Weight: 0.4},
 		}
 
-		err := enrichIndexState(nil, changelog, assetsByFigi)
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("BBG-MISSING"))
-		Expect(err.Error()).To(ContainSubstring("MIS"))
+		missing := enrichIndexState(nil, changelog, assetsByFigi)
+		Expect(missing).To(ConsistOf("MIS"))
+
+		Expect(changelog[0].Asset.CompositeFigi).To(Equal("BBG-MISSING"))
+		Expect(changelog[0].Asset.Ticker).To(Equal("MIS"))
+		Expect(changelog[1].Asset).To(Equal(mtbFull))
+	})
+
+	It("deduplicates and sorts the missing-ticker list", func() {
+		// The same figi can appear in both a snapshot and a later changelog
+		// entry; enrichIndexState should report it once and the list should
+		// be deterministic.
+		unkA := asset.Asset{CompositeFigi: "BBG-UNK-A", Ticker: "ZED"}
+		unkB := asset.Asset{CompositeFigi: "BBG-UNK-B", Ticker: "ABE"}
+
+		snapshots := []IndexSnapshotEntry{
+			{Date: day1, Members: []IndexConstituent{{Asset: unkA, Weight: 0.5}}},
+		}
+		changelog := []IndexChangeEntry{
+			{Date: day2, Asset: unkA, Action: "remove"},
+			{Date: day2, Asset: unkB, Action: "add", Weight: 0.5},
+		}
+
+		missing := enrichIndexState(snapshots, changelog, assetsByFigi)
+		Expect(missing).To(Equal([]string{"ABE", "ZED"}))
 	})
 })

--- a/data/pvdata_index_enrichment_test.go
+++ b/data/pvdata_index_enrichment_test.go
@@ -1,0 +1,154 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+)
+
+var _ = Describe("enrichIndexState", func() {
+	var (
+		mtbStub      asset.Asset
+		mtbFull      asset.Asset
+		vloStub      asset.Asset
+		vloFull      asset.Asset
+		day1         time.Time
+		day2         time.Time
+		assetsByFigi map[string]asset.Asset
+	)
+
+	BeforeEach(func() {
+		mtbStub = asset.Asset{CompositeFigi: "BBG000D9KWL9", Ticker: "MTB"}
+		mtbFull = asset.Asset{
+			CompositeFigi:   "BBG000D9KWL9",
+			Ticker:          "MTB",
+			Name:            "M&T Bank Corporation",
+			AssetType:       asset.AssetTypeCommonStock,
+			PrimaryExchange: asset.ExchangeNYSE,
+			Sector:          asset.SectorFinancialServices,
+			Industry:        asset.IndustryBanksRegional,
+		}
+		vloStub = asset.Asset{CompositeFigi: "BBG000BBGFG6", Ticker: "VLO"}
+		vloFull = asset.Asset{
+			CompositeFigi:   "BBG000BBGFG6",
+			Ticker:          "VLO",
+			Name:            "Valero Energy Corporation",
+			AssetType:       asset.AssetTypeCommonStock,
+			PrimaryExchange: asset.ExchangeNYSE,
+			Sector:          asset.SectorEnergy,
+			Industry:        asset.IndustryOilGasRefiningMarketing,
+		}
+		day1 = time.Date(2023, 12, 29, 16, 0, 0, 0, time.UTC)
+		day2 = time.Date(2024, 1, 5, 16, 0, 0, 0, time.UTC)
+
+		assetsByFigi = map[string]asset.Asset{
+			mtbFull.CompositeFigi: mtbFull,
+			vloFull.CompositeFigi: vloFull,
+		}
+	})
+
+	It("replaces stub Asset on snapshot constituents with full metadata", func() {
+		snapshots := []IndexSnapshotEntry{
+			{
+				Date: day1,
+				Members: []IndexConstituent{
+					{Asset: mtbStub, Weight: 0.5},
+					{Asset: vloStub, Weight: 0.5},
+				},
+			},
+		}
+
+		Expect(enrichIndexState(snapshots, nil, assetsByFigi)).To(Succeed())
+
+		Expect(snapshots[0].Members[0].Asset).To(Equal(mtbFull))
+		Expect(snapshots[0].Members[0].Asset.Sector).To(Equal(asset.SectorFinancialServices))
+		Expect(snapshots[0].Members[1].Asset).To(Equal(vloFull))
+		Expect(snapshots[0].Members[1].Asset.Sector).To(Equal(asset.SectorEnergy))
+	})
+
+	It("replaces stub Asset on changelog entries with full metadata", func() {
+		changelog := []IndexChangeEntry{
+			{Date: day2, Asset: mtbStub, Action: "add", Weight: 0.4},
+			{Date: day2, Asset: vloStub, Action: "remove"},
+		}
+
+		Expect(enrichIndexState(nil, changelog, assetsByFigi)).To(Succeed())
+
+		Expect(changelog[0].Asset).To(Equal(mtbFull))
+		Expect(changelog[0].Asset.Sector).To(Equal(asset.SectorFinancialServices))
+		Expect(changelog[1].Asset).To(Equal(vloFull))
+		Expect(changelog[1].Asset.Sector).To(Equal(asset.SectorEnergy))
+	})
+
+	It("flows enriched metadata through to indexState.Advance", func() {
+		snapshots := []IndexSnapshotEntry{
+			{Date: day1, Members: []IndexConstituent{{Asset: mtbStub, Weight: 1.0}}},
+		}
+		changelog := []IndexChangeEntry{
+			{Date: day2, Asset: vloStub, Action: "add", Weight: 0.5},
+		}
+
+		Expect(enrichIndexState(snapshots, changelog, assetsByFigi)).To(Succeed())
+
+		state := NewIndexState(snapshots, changelog)
+		state.Advance(day1)
+		assets, constituents := state.Advance(day2)
+
+		Expect(assets).To(ConsistOf(mtbFull, vloFull))
+
+		bySector := map[asset.Sector]int{}
+		for _, ic := range constituents {
+			bySector[ic.Asset.Sector]++
+		}
+
+		Expect(bySector[asset.SectorFinancialServices]).To(Equal(1))
+		Expect(bySector[asset.SectorEnergy]).To(Equal(1))
+		Expect(bySector[""]).To(Equal(0), "no constituent should have empty Sector")
+	})
+
+	It("returns an error when a snapshot constituent is missing from the assets map", func() {
+		snapshots := []IndexSnapshotEntry{
+			{
+				Date: day1,
+				Members: []IndexConstituent{
+					{Asset: mtbStub, Weight: 0.5},
+					{Asset: asset.Asset{CompositeFigi: "BBG-UNKNOWN", Ticker: "UNK"}, Weight: 0.5},
+				},
+			},
+		}
+
+		err := enrichIndexState(snapshots, nil, assetsByFigi)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("BBG-UNKNOWN"))
+		Expect(err.Error()).To(ContainSubstring("UNK"))
+	})
+
+	It("returns an error when a changelog entry is missing from the assets map", func() {
+		changelog := []IndexChangeEntry{
+			{Date: day2, Asset: asset.Asset{CompositeFigi: "BBG-MISSING", Ticker: "MIS"}, Action: "add"},
+		}
+
+		err := enrichIndexState(nil, changelog, assetsByFigi)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("BBG-MISSING"))
+		Expect(err.Error()).To(ContainSubstring("MIS"))
+	})
+})

--- a/data/pvdata_index_members_test.go
+++ b/data/pvdata_index_members_test.go
@@ -73,7 +73,7 @@ var _ = Describe("IndexState", func() {
 	It("applies changelog add between snapshots", func() {
 		state := data.NewIndexState(
 			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{aaplIC}}},
-			[]data.IndexChangeEntry{{Date: day2, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "add", Weight: 0.3}},
+			[]data.IndexChangeEntry{{Date: day2, Asset: goog, Action: "add", Weight: 0.3}},
 		)
 		state.Advance(day1)
 		assets, constituents := state.Advance(day2)
@@ -84,7 +84,7 @@ var _ = Describe("IndexState", func() {
 	It("applies changelog remove between snapshots", func() {
 		state := data.NewIndexState(
 			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{aaplIC, googIC}}},
-			[]data.IndexChangeEntry{{Date: day2, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "remove"}},
+			[]data.IndexChangeEntry{{Date: day2, Asset: goog, Action: "remove"}},
 		)
 		state.Advance(day1)
 		assets, constituents := state.Advance(day2)
@@ -99,7 +99,7 @@ var _ = Describe("IndexState", func() {
 				{Date: day1, Members: []data.IndexConstituent{aaplIC, googIC}},
 				{Date: day3, Members: []data.IndexConstituent{aaplIC, msftIC}},
 			},
-			[]data.IndexChangeEntry{{Date: day2, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "remove"}},
+			[]data.IndexChangeEntry{{Date: day2, Asset: goog, Action: "remove"}},
 		)
 		state.Advance(day1)
 		assets, _ := state.Advance(day3)
@@ -112,7 +112,7 @@ var _ = Describe("IndexState", func() {
 				{Date: day1, Members: []data.IndexConstituent{aaplIC}},
 				{Date: day2, Members: []data.IndexConstituent{aaplIC, googIC}},
 			},
-			[]data.IndexChangeEntry{{Date: day2, CompositeFigi: "FIGI-MSFT", Ticker: "MSFT", Action: "add"}},
+			[]data.IndexChangeEntry{{Date: day2, Asset: msft, Action: "add"}},
 		)
 		assets, _ := state.Advance(day2)
 		Expect(assets).To(ConsistOf(aapl, goog))
@@ -142,8 +142,8 @@ var _ = Describe("IndexState", func() {
 		state := data.NewIndexState(
 			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{aaplIC}}},
 			[]data.IndexChangeEntry{
-				{Date: day2, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "add", Weight: 0.3},
-				{Date: day2, CompositeFigi: "FIGI-MSFT", Ticker: "MSFT", Action: "add", Weight: 0.2},
+				{Date: day2, Asset: goog, Action: "add", Weight: 0.3},
+				{Date: day2, Asset: msft, Action: "add", Weight: 0.2},
 			},
 		)
 		state.Advance(day1)
@@ -155,8 +155,8 @@ var _ = Describe("IndexState", func() {
 		state := data.NewIndexState(
 			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{aaplIC}}},
 			[]data.IndexChangeEntry{
-				{Date: day2, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "add", Weight: 0.3},
-				{Date: day3, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "remove"},
+				{Date: day2, Asset: goog, Action: "add", Weight: 0.3},
+				{Date: day3, Asset: goog, Action: "remove"},
 			},
 		)
 		state.Advance(day1)
@@ -188,7 +188,7 @@ var _ = Describe("IndexState", func() {
 		state := data.NewIndexState(
 			nil,
 			[]data.IndexChangeEntry{
-				{Date: day1, CompositeFigi: "FIGI-AAPL", Ticker: "AAPL", Action: "add", Weight: 0.5},
+				{Date: day1, Asset: aapl, Action: "add", Weight: 0.5},
 			},
 		)
 		assets, constituents := state.Advance(day1)
@@ -200,7 +200,7 @@ var _ = Describe("IndexState", func() {
 	It("preserves weight data through changelog adds", func() {
 		state := data.NewIndexState(
 			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{aaplIC}}},
-			[]data.IndexChangeEntry{{Date: day2, CompositeFigi: "FIGI-GOOG", Ticker: "GOOG", Action: "add", Weight: 0.35}},
+			[]data.IndexChangeEntry{{Date: day2, Asset: goog, Action: "add", Weight: 0.35}},
 		)
 		state.Advance(day1)
 		_, constituents := state.Advance(day2)

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -1041,13 +1041,27 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 
 	// Enrich every stub asset with full metadata (Sector, Industry, Name,
 	// etc.) from the assets table so strategies can gate on classification.
+	// Missing figis keep their stub Asset; we log them as a single warning so
+	// strategies still see the constituent rather than silently dropping the
+	// whole index.
 	assetsByFigi, err := p.loadAssetsByFigi(ctx, conn, figis)
 	if err != nil {
 		return nil, fmt.Errorf("load index member metadata for %q: %w", index, err)
 	}
 
-	if err := enrichIndexState(snapshots, changelog, assetsByFigi); err != nil {
-		return nil, fmt.Errorf("enrich index %q: %w", index, err)
+	if missing := enrichIndexState(snapshots, changelog, assetsByFigi); len(missing) > 0 {
+		const sampleSize = 10
+
+		sample := missing
+		if len(sample) > sampleSize {
+			sample = sample[:sampleSize]
+		}
+
+		zerolog.Ctx(ctx).Warn().
+			Str("index", index).
+			Int("missing_count", len(missing)).
+			Strs("sample_tickers", sample).
+			Msg("index constituents have no row in assets table; classification fields will be empty")
 	}
 
 	return NewIndexState(snapshots, changelog), nil
@@ -1098,25 +1112,28 @@ func (p *PVDataProvider) loadAssetsByFigi(
 
 // enrichIndexState replaces the stub Asset records on snapshot constituents
 // and changelog entries with the full asset.Asset (Sector, Industry, Name,
-// etc.) from assetsByFigi. Returns an error if any constituent's
-// composite_figi is missing from assetsByFigi -- silently substituting a stub
-// would let strategies see empty Sector/Industry without warning.
+// etc.) from assetsByFigi. Enrichment is best-effort: figis missing from
+// assetsByFigi keep their stub Asset (CompositeFigi + Ticker only) so the
+// strategy still sees the constituent and can fall back on its own policy
+// when classification is empty. The returned tickers are the ones whose
+// metadata could not be filled in, deduplicated and sorted, so the caller
+// can log a single aggregated warning per index load.
 func enrichIndexState(
 	snapshots []IndexSnapshotEntry,
 	changelog []IndexChangeEntry,
 	assetsByFigi map[string]asset.Asset,
-) error {
+) []string {
+	missing := make(map[string]string) // composite_figi -> ticker
+
 	for ii := range snapshots {
 		for jj := range snapshots[ii].Members {
 			stub := snapshots[ii].Members[jj].Asset
 
 			full, ok := assetsByFigi[stub.CompositeFigi]
 			if !ok {
-				return fmt.Errorf(
-					"snapshot %s: asset %q (%q) not found in assets table",
-					snapshots[ii].Date.Format("2006-01-02"),
-					stub.CompositeFigi, stub.Ticker,
-				)
+				missing[stub.CompositeFigi] = stub.Ticker
+
+				continue
 			}
 
 			snapshots[ii].Members[jj].Asset = full
@@ -1128,18 +1145,26 @@ func enrichIndexState(
 
 		full, ok := assetsByFigi[stub.CompositeFigi]
 		if !ok {
-			return fmt.Errorf(
-				"changelog %s %s: asset %q (%q) not found in assets table",
-				changelog[ii].Date.Format("2006-01-02"),
-				changelog[ii].Action,
-				stub.CompositeFigi, stub.Ticker,
-			)
+			missing[stub.CompositeFigi] = stub.Ticker
+
+			continue
 		}
 
 		changelog[ii].Asset = full
 	}
 
-	return nil
+	if len(missing) == 0 {
+		return nil
+	}
+
+	tickers := make([]string, 0, len(missing))
+	for _, ticker := range missing {
+		tickers = append(tickers, ticker)
+	}
+
+	sort.Strings(tickers)
+
+	return tickers
 }
 
 // RatingHistory returns the initial rating state just before start and all

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -963,7 +963,10 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 		Weight        float64 `json:"weight"`
 	}
 
-	var snapshots []IndexSnapshotEntry
+	var (
+		snapshots []IndexSnapshotEntry
+		figis     []string
+	)
 
 	for snapRows.Next() {
 		var (
@@ -990,6 +993,7 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 				},
 				Weight: cc.Weight,
 			})
+			figis = append(figis, cc.CompositeFigi)
 		}
 
 		snapshots = append(snapshots, entry)
@@ -1015,11 +1019,18 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 	var changelog []IndexChangeEntry
 
 	for logRows.Next() {
-		var entry IndexChangeEntry
+		var (
+			entry         IndexChangeEntry
+			compositeFigi string
+			ticker        string
+		)
 
-		if err := logRows.Scan(&entry.Date, &entry.CompositeFigi, &entry.Ticker, &entry.Action, &entry.Weight); err != nil {
+		if err := logRows.Scan(&entry.Date, &compositeFigi, &ticker, &entry.Action, &entry.Weight); err != nil {
 			return nil, fmt.Errorf("scan changelog row: %w", err)
 		}
+
+		entry.Asset = asset.Asset{CompositeFigi: compositeFigi, Ticker: ticker}
+		figis = append(figis, compositeFigi)
 
 		changelog = append(changelog, entry)
 	}
@@ -1028,7 +1039,107 @@ func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*ind
 		return nil, fmt.Errorf("iterate changelog: %w", err)
 	}
 
+	// Enrich every stub asset with full metadata (Sector, Industry, Name,
+	// etc.) from the assets table so strategies can gate on classification.
+	assetsByFigi, err := p.loadAssetsByFigi(ctx, conn, figis)
+	if err != nil {
+		return nil, fmt.Errorf("load index member metadata for %q: %w", index, err)
+	}
+
+	if err := enrichIndexState(snapshots, changelog, assetsByFigi); err != nil {
+		return nil, fmt.Errorf("enrich index %q: %w", index, err)
+	}
+
 	return NewIndexState(snapshots, changelog), nil
+}
+
+// loadAssetsByFigi fetches full asset rows for the given composite_figis from
+// the assets view and returns them keyed by composite_figi. Used by
+// loadIndexState to enrich index constituents with metadata that the
+// indices_snapshot/indices_changelog tables do not carry. Duplicates in figis
+// are tolerated by the SQL ANY() clause; the result map deduplicates them.
+func (p *PVDataProvider) loadAssetsByFigi(
+	ctx context.Context,
+	conn *pgxpool.Conn,
+	figis []string,
+) (map[string]asset.Asset, error) {
+	if len(figis) == 0 {
+		return map[string]asset.Asset{}, nil
+	}
+
+	rows, err := conn.Query(ctx,
+		`SELECT composite_figi, ticker, name, asset_type, primary_exchange,
+		        sector, industry, sic_code, cik, listed, delisted
+		 FROM assets WHERE composite_figi = ANY($1)`,
+		figis,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query assets by figi: %w", err)
+	}
+	defer rows.Close()
+
+	assets := make(map[string]asset.Asset, len(figis))
+
+	for rows.Next() {
+		aa, scanErr := scanPgxAsset(rows)
+		if scanErr != nil {
+			return nil, fmt.Errorf("scan asset by figi: %w", scanErr)
+		}
+
+		assets[aa.CompositeFigi] = aa
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate assets by figi: %w", err)
+	}
+
+	return assets, nil
+}
+
+// enrichIndexState replaces the stub Asset records on snapshot constituents
+// and changelog entries with the full asset.Asset (Sector, Industry, Name,
+// etc.) from assetsByFigi. Returns an error if any constituent's
+// composite_figi is missing from assetsByFigi -- silently substituting a stub
+// would let strategies see empty Sector/Industry without warning.
+func enrichIndexState(
+	snapshots []IndexSnapshotEntry,
+	changelog []IndexChangeEntry,
+	assetsByFigi map[string]asset.Asset,
+) error {
+	for ii := range snapshots {
+		for jj := range snapshots[ii].Members {
+			stub := snapshots[ii].Members[jj].Asset
+
+			full, ok := assetsByFigi[stub.CompositeFigi]
+			if !ok {
+				return fmt.Errorf(
+					"snapshot %s: asset %q (%q) not found in assets table",
+					snapshots[ii].Date.Format("2006-01-02"),
+					stub.CompositeFigi, stub.Ticker,
+				)
+			}
+
+			snapshots[ii].Members[jj].Asset = full
+		}
+	}
+
+	for ii := range changelog {
+		stub := changelog[ii].Asset
+
+		full, ok := assetsByFigi[stub.CompositeFigi]
+		if !ok {
+			return fmt.Errorf(
+				"changelog %s %s: asset %q (%q) not found in assets table",
+				changelog[ii].Date.Format("2006-01-02"),
+				changelog[ii].Action,
+				stub.CompositeFigi, stub.Ticker,
+			)
+		}
+
+		changelog[ii].Asset = full
+	}
+
+	return nil
 }
 
 // RatingHistory returns the initial rating state just before start and all

--- a/data/snapshot_provider_test.go
+++ b/data/snapshot_provider_test.go
@@ -216,6 +216,71 @@ var _ = Describe("SnapshotProvider", func() {
 			Expect(resultConstituents).To(HaveLen(1))
 			Expect(resultConstituents[0].Weight).To(BeNumerically("~", 0.75, 0.001))
 		})
+
+		It("replays full asset metadata (Sector, Industry, Name) for index members", func() {
+			// When the underlying IndexProvider returns assets enriched with
+			// classification metadata, the recorder must persist that metadata
+			// so the snapshot replay also exposes it. Strategies that gate on
+			// Sector/Industry depend on this round-trip.
+			mtb := asset.Asset{
+				CompositeFigi:   "BBG000D9KWL9",
+				Ticker:          "MTB",
+				Name:            "M&T Bank Corporation",
+				AssetType:       asset.AssetTypeCommonStock,
+				PrimaryExchange: asset.ExchangeNYSE,
+				Sector:          asset.SectorFinancialServices,
+				Industry:        asset.IndustryBanksRegional,
+			}
+			vlo := asset.Asset{
+				CompositeFigi:   "BBG000BBGFG6",
+				Ticker:          "VLO",
+				Name:            "Valero Energy Corporation",
+				AssetType:       asset.AssetTypeCommonStock,
+				PrimaryExchange: asset.ExchangeNYSE,
+				Sector:          asset.SectorEnergy,
+				Industry:        asset.IndustryOilGasRefiningMarketing,
+			}
+
+			members := []asset.Asset{mtb, vlo}
+			constituents := []data.IndexConstituent{
+				{Asset: mtb, Weight: 0.5},
+				{Asset: vlo, Weight: 0.5},
+			}
+			nyc, _ := time.LoadLocation("America/New_York")
+			date := time.Date(2023, 12, 29, 16, 0, 0, 0, nyc)
+
+			recorder, err := data.NewSnapshotRecorder(dbPath, data.SnapshotRecorderConfig{
+				IndexProvider: &stubIndexProvider{members: members, constituents: constituents},
+				AssetProvider: &stubAssetProvider{assets: members},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, _, err = recorder.IndexMembers(ctx, "SPX", date)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recorder.Close()).To(Succeed())
+
+			snap, err := data.NewSnapshotProvider(dbPath)
+			Expect(err).NotTo(HaveOccurred())
+			defer snap.Close()
+
+			resultAssets, resultConstituents, err := snap.IndexMembers(ctx, "SPX", date)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resultAssets).To(HaveLen(2))
+
+			bySector := map[asset.Sector]asset.Asset{}
+			for _, aa := range resultAssets {
+				bySector[aa.Sector] = aa
+			}
+
+			Expect(bySector).To(HaveKey(asset.SectorFinancialServices))
+			Expect(bySector).To(HaveKey(asset.SectorEnergy))
+			Expect(bySector[asset.SectorFinancialServices].Industry).To(Equal(asset.IndustryBanksRegional))
+			Expect(bySector[asset.SectorEnergy].Name).To(Equal("Valero Energy Corporation"))
+
+			for _, ic := range resultConstituents {
+				Expect(string(ic.Asset.Sector)).NotTo(BeEmpty(), "constituent %q must carry a Sector", ic.Asset.Ticker)
+			}
+		})
 	})
 
 	Describe("RatedAssets", func() {

--- a/engine/apply_params.go
+++ b/engine/apply_params.go
@@ -74,14 +74,20 @@ func ApplyParams(eng *Engine, preset string, params map[string]string) error {
 		}
 	}
 
-	// Apply all merged parameters via applyParamValue.
+	// Apply all merged parameters via applyParamValue, and mark them on
+	// the engine so hydrateFields will not re-default them. This is what
+	// preserves an explicit zero (e.g. preset value "0" against a non-zero
+	// struct-tag default) instead of having the default silently win.
 	for paramName, paramValue := range merged {
 		if err := applyParamValue(eng.strategy, paramName, paramValue); err != nil {
 			return fmt.Errorf("ApplyParams: applying param %q=%q: %w", paramName, paramValue, err)
 		}
+
+		eng.MarkUserParams(paramName)
 	}
 
-	// Resolve asset.Asset and universe.Universe fields.
+	// Resolve asset.Asset and universe.Universe fields, and apply struct-tag
+	// defaults for any field the caller did not explicitly set.
 	if err := hydrateFields(eng, eng.strategy); err != nil {
 		return fmt.Errorf("ApplyParams: hydrating fields: %w", err)
 	}

--- a/engine/apply_params_test.go
+++ b/engine/apply_params_test.go
@@ -41,6 +41,24 @@ func (ap *applyParamsStrategy) Describe() engine.StrategyDescription {
 	return engine.StrategyDescription{ShortCode: "apt"}
 }
 
+// vanillaStrategy mirrors the value-factor case where two int params
+// have non-zero defaults but the "Vanilla" preset suggests zeroing them.
+// This exists to exercise the bug where presets that set a field to 0
+// were being silently re-defaulted by hydrateFields.
+type vanillaStrategy struct {
+	SectorCap int `pvbt:"sector-cap" desc:"Sector cap" default:"4" suggest:"Vanilla=0"`
+	MinFScore int `pvbt:"min-fscore" desc:"Min F-score" default:"6" suggest:"Vanilla=0"`
+}
+
+func (vs *vanillaStrategy) Name() string           { return "Vanilla" }
+func (vs *vanillaStrategy) Setup(_ *engine.Engine) {}
+func (vs *vanillaStrategy) Compute(_ context.Context, _ *engine.Engine, _ portfolio.Portfolio, _ *portfolio.Batch) error {
+	return nil
+}
+func (vs *vanillaStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "vsi"}
+}
+
 // noDescriptorStrategy implements Strategy but not Descriptor.
 type noDescriptorStrategy struct {
 	Window int `pvbt:"window" desc:"Rolling window" default:"12"`
@@ -125,6 +143,69 @@ var _ = Describe("ApplyParams", func() {
 			Expect(err.Error()).To(ContainSubstring("preset \"Unknown\" not found"))
 			Expect(err.Error()).To(ContainSubstring("Fast"))
 			Expect(err.Error()).To(ContainSubstring("Slow"))
+		})
+	})
+
+	Context("explicit zero overrides", func() {
+		It("preserves a zero passed via params against a non-zero int default", func() {
+			strategy := &applyParamsStrategy{}
+			eng := engine.New(strategy)
+
+			err := engine.ApplyParams(eng, "", map[string]string{"lookback": "0"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strategy.Lookback).To(Equal(0),
+				"lookback=0 must override the struct-tag default of 6, not be silently re-defaulted")
+		})
+
+		It("preserves a zero passed via params against a non-zero float default", func() {
+			strategy := &applyParamsStrategy{}
+			eng := engine.New(strategy)
+
+			err := engine.ApplyParams(eng, "", map[string]string{"ratio": "0"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strategy.Ratio).To(Equal(0.0),
+				"ratio=0 must override the struct-tag default of 0.5, not be silently re-defaulted")
+		})
+
+		It("honors a preset that sets a parameter to zero", func() {
+			strategy := &vanillaStrategy{}
+			eng := engine.New(strategy)
+
+			err := engine.ApplyParams(eng, "Vanilla", nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strategy.SectorCap).To(Equal(0),
+				"Vanilla preset must set sector-cap=0, not be re-defaulted to 4")
+			Expect(strategy.MinFScore).To(Equal(0),
+				"Vanilla preset must set min-fscore=0, not be re-defaulted to 6")
+		})
+
+		It("still applies defaults to params the user did not touch", func() {
+			strategy := &applyParamsStrategy{}
+			eng := engine.New(strategy)
+
+			err := engine.ApplyParams(eng, "", map[string]string{"lookback": "0"})
+			Expect(err).NotTo(HaveOccurred())
+			// lookback was zeroed by the user
+			Expect(strategy.Lookback).To(Equal(0))
+			// ratio and label were not touched, so defaults should still apply
+			Expect(strategy.Ratio).To(Equal(0.5),
+				"ratio not in params; default must still apply")
+			Expect(strategy.Label).To(Equal("default"),
+				"label not in params; default must still apply")
+		})
+
+		It("preserves an explicit zero set by the CLI path (WithUserParams)", func() {
+			// Simulate the CLI flow: applyStrategyFlags has already written
+			// the explicit zero to the field, then engine.New is constructed
+			// with WithUserParams listing the field. hydrateFields must not
+			// overwrite the zero with the struct-tag default.
+			strategy := &applyParamsStrategy{Lookback: 0}
+			eng := engine.New(strategy, engine.WithUserParams("lookback"))
+
+			err := engine.HydrateFieldsForTest(eng, strategy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strategy.Lookback).To(Equal(0),
+				"WithUserParams must protect an explicit zero from being re-defaulted")
 		})
 	})
 

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -177,7 +177,10 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 	end = e.adjustEndForStaleData(ctx, end)
 
 	// 6. Create and configure account.
-	acct := e.createAccount(start)
+	acct, acctErr := e.createAccount(start)
+	if acctErr != nil {
+		return nil, acctErr
+	}
 
 	e.account = acct
 	if e.benchmark != (asset.Asset{}) {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -63,6 +63,12 @@ type Engine struct {
 	fundamentalDimension string
 	progressCallback     ProgressCallback
 
+	// userParams names strategy fields the caller has explicitly set
+	// (via CLI flags, presets, ApplyParams). hydrateFields skips applying
+	// struct-tag defaults to these fields, so an explicit zero value
+	// survives instead of being silently re-defaulted.
+	userParams map[string]struct{}
+
 	account portfolio.PortfolioManager
 
 	// populated during initialization
@@ -92,6 +98,39 @@ func New(strategy Strategy, opts ...Option) *Engine {
 	return eng
 }
 
+// MarkUserParams records strategy field names (kebab-case) that the
+// caller has explicitly set. hydrateFields uses this set to skip
+// applying struct-tag defaults to those fields, so an explicit zero
+// override survives. Names not matching any strategy field are stored
+// without effect.
+func (e *Engine) MarkUserParams(names ...string) {
+	if len(names) == 0 {
+		return
+	}
+
+	if e.userParams == nil {
+		e.userParams = make(map[string]struct{}, len(names))
+	}
+
+	for _, name := range names {
+		e.userParams[name] = struct{}{}
+	}
+}
+
+// IsUserParam reports whether the named field has been marked as
+// explicitly set by the caller. A nil receiver is treated as "no
+// fields marked", which keeps hydrateFields safe to call without
+// an engine in white-box tests.
+func (e *Engine) IsUserParam(name string) bool {
+	if e == nil {
+		return false
+	}
+
+	_, ok := e.userParams[name]
+
+	return ok
+}
+
 // createAccount builds a portfolio.Account from the engine's configuration.
 // If a snapshot is set, the account is restored from it; otherwise a fresh
 // account is created with the initial deposit.
@@ -99,7 +138,9 @@ func New(strategy Strategy, opts ...Option) *Engine {
 // If a snapshot is set, the account is restored from it; otherwise a fresh
 // account is created with the initial deposit. If no broker was provided
 // via WithBroker, a SimulatedBroker is created and stored on e.broker.
-func (e *Engine) createAccount(start time.Time) portfolio.PortfolioManager {
+// Returns an error if the resulting account would have no funding (no
+// pre-built account, no snapshot, and a non-positive initial deposit).
+func (e *Engine) createAccount(start time.Time) (portfolio.PortfolioManager, error) {
 	if e.broker == nil {
 		sb := NewSimulatedBroker()
 		if e.fillBaseModel != nil {
@@ -119,19 +160,23 @@ func (e *Engine) createAccount(start time.Time) portfolio.PortfolioManager {
 			e.account.SetBroker(e.broker)
 		}
 
-		return e.account
+		return e.account, nil
 	}
 
 	var opts []portfolio.Option
 	if e.snapshot != nil {
 		opts = append(opts, portfolio.WithPortfolioSnapshot(e.snapshot))
 	} else {
+		if e.initialDeposit <= 0 {
+			return nil, fmt.Errorf("engine: initial deposit must be positive when no account or snapshot is provided; pass engine.WithInitialDeposit(amount) or engine.WithAccount(acct)")
+		}
+
 		opts = append(opts, portfolio.WithCash(e.initialDeposit, start))
 	}
 
 	opts = append(opts, portfolio.WithBroker(e.broker))
 
-	return portfolio.New(opts...)
+	return portfolio.New(opts...), nil
 }
 
 // validDimensions lists the accepted fundamental dimension codes.

--- a/engine/hydrate.go
+++ b/engine/hydrate.go
@@ -34,9 +34,12 @@ var (
 )
 
 // hydrateFields reflects over the target struct and populates exported fields
-// from their `default` tags. Fields with non-zero values are not overwritten.
-// asset.Asset fields are resolved via the engine's asset registry.
-// universe.Universe fields are built from comma-separated tickers via e.Universe.
+// from their `default` tags. Fields whose names appear in eng.userParams
+// (set by ApplyParams or engine.WithUserParams) are skipped entirely so an
+// explicit zero override is preserved. Other non-zero fields are also left
+// alone. asset.Asset fields are resolved via the engine's asset registry.
+// universe.Universe fields are built from comma-separated tickers via
+// e.Universe.
 func hydrateFields(eng *Engine, target interface{}) error {
 	val := reflect.ValueOf(target)
 	if val.Kind() == reflect.Pointer {
@@ -70,6 +73,8 @@ func hydrateFields(eng *Engine, target interface{}) error {
 			continue
 		}
 
+		paramName := ParameterName(field)
+
 		// For asset.Asset fields that were pre-set (e.g. by CLI flags) with
 		// only a Ticker, re-resolve through the asset registry so downstream
 		// code has the full metadata (CompositeFigi, exchange, etc.).
@@ -100,6 +105,15 @@ func hydrateFields(eng *Engine, target interface{}) error {
 
 		// Skip non-zero fields (caller may have pre-set them).
 		if !fieldValue.IsZero() {
+			continue
+		}
+
+		// Skip fields the caller explicitly applied, even if their value
+		// is the Go zero (e.g. --sector-cap 0 or a preset that sets it
+		// to zero). Without this check, the "is zero" branch below would
+		// silently overwrite the explicit zero with the struct-tag
+		// default.
+		if eng.IsUserParam(paramName) {
 			continue
 		}
 

--- a/engine/live.go
+++ b/engine/live.go
@@ -112,7 +112,10 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 	}
 
 	// 6. Create and configure account.
-	acct := e.createAccount(time.Now())
+	acct, acctErr := e.createAccount(time.Now())
+	if acctErr != nil {
+		return nil, acctErr
+	}
 
 	e.account = acct
 	if e.benchmark != (asset.Asset{}) {

--- a/engine/option.go
+++ b/engine/option.go
@@ -122,3 +122,14 @@ func WithProgressCallback(fn ProgressCallback) Option {
 		e.progressCallback = fn
 	}
 }
+
+// WithUserParams declares strategy field names (kebab-case) that the
+// caller has already explicitly set on the strategy. hydrateFields will
+// not re-apply struct-tag defaults to these fields, so an explicit zero
+// value (e.g. --sector-cap 0) is preserved instead of being silently
+// overwritten by the field's `default` tag.
+func WithUserParams(names ...string) Option {
+	return func(e *Engine) {
+		e.MarkUserParams(names...)
+	}
+}

--- a/study/optimize/Optimize.vue
+++ b/study/optimize/Optimize.vue
@@ -29,6 +29,15 @@ const overfitColumns = [
   <div class="max-w-[900px] mx-auto p-10 font-sans text-foreground text-sm leading-relaxed">
     <h1 class="text-[28px] font-semibold mb-8">Parameter Optimization</h1>
 
+    <div
+      v-if="data.warning"
+      class="mb-6 rounded border border-yellow-500/40 bg-yellow-500/10 p-4 text-sm"
+      role="alert"
+    >
+      <div class="font-semibold mb-1">Ranking is not meaningful</div>
+      <div>{{ data.warning }}</div>
+    </div>
+
     <FinancialTable
       :title="'Rankings by Mean OOS ' + (data.objectiveName || '')"
       :columns="rankingColumns"

--- a/study/optimize/analyze.go
+++ b/study/optimize/analyze.go
@@ -28,6 +28,7 @@ import (
 	"github.com/penny-vault/pvbt/portfolio"
 	"github.com/penny-vault/pvbt/study"
 	"github.com/penny-vault/pvbt/study/report"
+	"github.com/rs/zerolog/log"
 )
 
 // Ensure optimizerReport satisfies the report.Report interface.
@@ -65,6 +66,15 @@ func analyzeResults(
 		Rankings:      computeRankings(combos),
 		Overfitting:   computeOverfitting(combos),
 		EquityCurves:  computeEquityCurves(combos, topN),
+		Warning:       degenerateRankingWarning(combos, objective),
+	}
+
+	if rpt.Warning != "" {
+		log.Warn().
+			Str("objective", objective.Name()).
+			Int("combos", len(combos)).
+			Str("warning", rpt.Warning).
+			Msg("optimizer ranking is not meaningful")
 	}
 
 	if len(combos) > 0 {
@@ -72,6 +82,67 @@ func analyzeResults(
 	}
 
 	return rpt, nil
+}
+
+// degenerateRankingEpsilon is the absolute tolerance for treating two OOS mean
+// scores as equal when checking for an uninformative ranking.
+const degenerateRankingEpsilon = 1e-12
+
+// degenerateRankingWarning returns a non-empty warning when the OOS mean
+// scores across combos are uninformative (all NaN, or all equal within
+// degenerateRankingEpsilon). In that case the apparent ranking reflects
+// insertion order rather than the objective metric and is not meaningful.
+// Returns an empty string when there are fewer than two combos to compare.
+func degenerateRankingWarning(combos []*comboResult, objective portfolio.Rankable) string {
+	if len(combos) < 2 {
+		return ""
+	}
+
+	var (
+		minScore   = math.Inf(1)
+		maxScore   = math.Inf(-1)
+		validCount int
+	)
+
+	for _, cr := range combos {
+		score := meanIgnoringNaN(cr.oosScores)
+		if math.IsNaN(score) {
+			continue
+		}
+
+		validCount++
+
+		if score < minScore {
+			minScore = score
+		}
+
+		if score > maxScore {
+			maxScore = score
+		}
+	}
+
+	if validCount == 0 {
+		return fmt.Sprintf(
+			"every combination produced an undefined %s score; "+
+				"the ranking reflects insertion order, not the objective metric. "+
+				"Check that the strategy actually trades over the test windows and "+
+				"that any required inputs (e.g. risk-free rate) are configured.",
+			objective.Name(),
+		)
+	}
+
+	if maxScore-minScore <= degenerateRankingEpsilon {
+		return fmt.Sprintf(
+			"every combination produced the same %s score (%.6g); "+
+				"the ranking reflects insertion order, not the objective metric. "+
+				"This typically means the parameter sweep does not change strategy "+
+				"behavior, or the strategy produces identical equity curves across "+
+				"all sampled values.",
+			objective.Name(), minScore,
+		)
+	}
+
+	return ""
 }
 
 // groupByCombination groups RunResults by _combination_id metadata and
@@ -327,10 +398,7 @@ func computeOverfitting(combos []*comboResult) []overfittingRow {
 // computeEquityCurves builds equity curve series for the top N
 // combinations from their stored equity data.
 func computeEquityCurves(combos []*comboResult, topN int) []equityCurveSeries {
-	limit := topN
-	if limit > len(combos) {
-		limit = len(combos)
-	}
+	limit := min(topN, len(combos))
 
 	curves := make([]equityCurveSeries, limit)
 

--- a/study/optimize/analyze_test.go
+++ b/study/optimize/analyze_test.go
@@ -17,8 +17,11 @@ package optimize_test
 
 import (
 	"bytes"
-	"github.com/bytedance/sonic"
+	"fmt"
+	"io"
 	"time"
+
+	"github.com/bytedance/sonic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -133,6 +136,7 @@ func itoa(val int) string {
 // test deserialization. Only fields that the tests inspect are included.
 type optReportData struct {
 	ObjectiveName string `json:"objectiveName"`
+	Warning       string `json:"warning,omitempty"`
 
 	Rankings []struct {
 		Rank       int     `json:"rank"`
@@ -329,6 +333,253 @@ var _ = Describe("Analyze", func() {
 
 			rptData := decodeOptReport(rpt)
 			Expect(rptData.Rankings).To(BeEmpty())
+		})
+	})
+
+	Describe("degenerate ranking detection", func() {
+		var trainTestSplits []study.Split
+
+		BeforeEach(func() {
+			start := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+			cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			end := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			built, err := study.TrainTest(start, cutoff, end)
+			Expect(err).NotTo(HaveOccurred())
+			trainTestSplits = built
+		})
+
+		It("emits a warning when every combo produces an identical OOS score", func() {
+			dates := makeDailyDates(
+				time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			)
+
+			// Strategy that never trades: equity stays at the initial cash.
+			// CAGR/Sharpe/Sortino/Calmar all collapse to the same value across
+			// every parameter combination, so the optimizer cannot distinguish
+			// between them.
+			flatEquity := makeLinearEquity(dates, 10_000, 10_000)
+
+			var results []study.RunResult
+			for idx := range 4 {
+				acct := buildAccountFromEquity(dates, flatEquity)
+				params := map[string]string{"lookback": fmt.Sprintf("%d", 10+idx*5)}
+				results = append(results, makeResult(fmt.Sprintf("combo-%d", idx), 0, params, acct))
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			rptData := decodeOptReport(rpt)
+			Expect(rptData.Warning).NotTo(BeEmpty(),
+				"expected a warning when every combo produces the same CAGR score")
+			Expect(rptData.Warning).To(ContainSubstring("CAGR"))
+			Expect(rptData.Warning).To(ContainSubstring("insertion order"))
+		})
+
+		It("emits a warning when every combo's score is undefined (NaN)", func() {
+			// Out-of-range _split_index keeps every combo's score at the
+			// initial NaN, simulating a path where the metric could not
+			// be computed for any combination + split pair.
+			dates := makeDailyDates(
+				time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			)
+			acct := buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 12_000))
+
+			makeNoScoreResult := func(comboID string, params map[string]string) study.RunResult {
+				return study.RunResult{
+					Config: study.RunConfig{
+						Name:   comboID,
+						Params: params,
+						Metadata: map[string]string{
+							"_combination_id": comboID,
+							"_split_index":    "9999", // out of range
+						},
+					},
+					Portfolio: acct,
+				}
+			}
+
+			results := []study.RunResult{
+				makeNoScoreResult("combo-a", map[string]string{"lookback": "10"}),
+				makeNoScoreResult("combo-b", map[string]string{"lookback": "20"}),
+				makeNoScoreResult("combo-c", map[string]string{"lookback": "30"}),
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			rptData := decodeOptReport(rpt)
+			Expect(rptData.Warning).NotTo(BeEmpty(),
+				"expected a warning when every combo produces NaN scores")
+			Expect(rptData.Warning).To(ContainSubstring("undefined"))
+		})
+
+		It("does not emit a warning when combos produce different scores", func() {
+			dates := makeDailyDates(
+				time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			)
+
+			results := []study.RunResult{
+				makeResult("combo-a", 0, map[string]string{"lookback": "10"},
+					buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 25_000))),
+				makeResult("combo-b", 0, map[string]string{"lookback": "20"},
+					buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 12_000))),
+				makeResult("combo-c", 0, map[string]string{"lookback": "30"},
+					buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 10_500))),
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			rptData := decodeOptReport(rpt)
+			Expect(rptData.Warning).To(BeEmpty(),
+				"did not expect a warning when combos produce distinct CAGR scores")
+		})
+
+		It("does not emit a warning for a single combo", func() {
+			dates := makeDailyDates(
+				time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			)
+
+			results := []study.RunResult{
+				makeResult("combo-a", 0, map[string]string{"lookback": "10"},
+					buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 10_000))),
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			rptData := decodeOptReport(rpt)
+			Expect(rptData.Warning).To(BeEmpty(),
+				"single-combo runs are trivially degenerate and should not warn")
+		})
+	})
+
+	Describe("Text rendering", func() {
+		var trainTestSplits []study.Split
+
+		BeforeEach(func() {
+			start := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+			cutoff := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+			end := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			built, err := study.TrainTest(start, cutoff, end)
+			Expect(err).NotTo(HaveOccurred())
+			trainTestSplits = built
+		})
+
+		It("produces a tabular header, rows, and best block", func() {
+			dates := makeDailyDates(
+				time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			)
+
+			results := []study.RunResult{
+				makeResult("combo-a", 0, map[string]string{"lookback": "10"},
+					buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 25_000))),
+				makeResult("combo-b", 0, map[string]string{"lookback": "30"},
+					buildAccountFromEquity(dates, makeLinearEquity(dates, 10_000, 12_000))),
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			textReport, ok := rpt.(interface{ Text(io.Writer) error })
+			Expect(ok).To(BeTrue(), "report must implement Text(io.Writer) error")
+
+			var buf bytes.Buffer
+			Expect(textReport.Text(&buf)).To(Succeed())
+			out := buf.String()
+
+			Expect(out).To(ContainSubstring("Optimization: CAGR (2 combos)"))
+			Expect(out).To(ContainSubstring("Rank"))
+			Expect(out).To(ContainSubstring("Parameters"))
+			Expect(out).To(ContainSubstring("OOS"))
+			Expect(out).To(ContainSubstring("lookback=10"))
+			Expect(out).To(ContainSubstring("lookback=30"))
+			Expect(out).To(ContainSubstring("Best:"))
+		})
+
+		It("includes the warning text when the ranking is degenerate", func() {
+			dates := makeDailyDates(
+				time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			)
+
+			flat := makeLinearEquity(dates, 10_000, 10_000)
+
+			var results []study.RunResult
+			for idx := range 3 {
+				results = append(results, makeResult(
+					fmt.Sprintf("combo-%d", idx),
+					0,
+					map[string]string{"lookback": fmt.Sprintf("%d", 10+idx*5)},
+					buildAccountFromEquity(dates, flat),
+				))
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			textReport := rpt.(interface{ Text(io.Writer) error })
+
+			var buf bytes.Buffer
+			Expect(textReport.Text(&buf)).To(Succeed())
+
+			Expect(buf.String()).To(ContainSubstring("Warning:"))
+			Expect(buf.String()).To(ContainSubstring("insertion order"))
+		})
+
+		It("renders NaN scores as n/a", func() {
+			// Out-of-range _split_index leaves every score at NaN.
+			acct := buildAccountFromEquity(
+				makeDailyDates(
+					time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+					time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+				),
+				makeLinearEquity(
+					makeDailyDates(
+						time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+						time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+					),
+					10_000, 12_000,
+				),
+			)
+
+			results := []study.RunResult{
+				{
+					Config: study.RunConfig{
+						Name: "orphan",
+						Metadata: map[string]string{
+							"_combination_id": "orphan",
+							"_split_index":    "9999",
+						},
+					},
+					Portfolio: acct,
+				},
+			}
+
+			opt := optimize.New(trainTestSplits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+			rpt, err := opt.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			textReport := rpt.(interface{ Text(io.Writer) error })
+
+			var buf bytes.Buffer
+			Expect(textReport.Text(&buf)).To(Succeed())
+
+			Expect(buf.String()).To(ContainSubstring("n/a"))
 		})
 	})
 

--- a/study/optimize/end_to_end_test.go
+++ b/study/optimize/end_to_end_test.go
@@ -1,0 +1,315 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+	"github.com/penny-vault/pvbt/study"
+	"github.com/penny-vault/pvbt/study/optimize"
+	"github.com/penny-vault/pvbt/tradecron"
+)
+
+// e2eAssetProvider is a minimal AssetProvider for end-to-end tests.
+type e2eAssetProvider struct {
+	assets []asset.Asset
+}
+
+func (provider *e2eAssetProvider) Assets(_ context.Context) ([]asset.Asset, error) {
+	return provider.assets, nil
+}
+
+func (provider *e2eAssetProvider) LookupAsset(_ context.Context, ticker string) (asset.Asset, error) {
+	for _, item := range provider.assets {
+		if item.Ticker == ticker {
+			return item, nil
+		}
+	}
+
+	return asset.Asset{}, fmt.Errorf("asset not found: %s", ticker)
+}
+
+// fixedFractionStrategy buys a fixed fraction of available assets on the
+// first Compute call and holds. The Lookback parameter is exposed as an
+// int parameter so the optimizer has something to sweep over, but it does
+// not influence trading behavior beyond being applied via reflection. This
+// keeps every combo's equity curve identical so we can isolate the
+// optimizer/scoring path.
+type fixedFractionStrategy struct {
+	Targets  []asset.Asset
+	Lookback int `default:"10"`
+
+	purchased bool
+}
+
+func (strategy *fixedFractionStrategy) Name() string { return "FixedFraction" }
+
+func (strategy *fixedFractionStrategy) Setup(_ *engine.Engine) {}
+
+func (strategy *fixedFractionStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5"}
+}
+
+func (strategy *fixedFractionStrategy) Compute(ctx context.Context, eng *engine.Engine, fund portfolio.Portfolio, batch *portfolio.Batch) error {
+	if strategy.purchased {
+		return nil
+	}
+
+	strategy.purchased = true
+
+	if len(strategy.Targets) == 0 {
+		return nil
+	}
+
+	priceDF, fetchErr := eng.FetchAt(ctx, strategy.Targets, eng.CurrentDate(), []data.Metric{data.MetricClose})
+	if fetchErr != nil || priceDF == nil {
+		return fetchErr
+	}
+
+	weight := 1.0 / float64(len(strategy.Targets))
+	totalCash := fund.Cash()
+
+	for _, target := range strategy.Targets {
+		price := priceDF.ValueAt(target, data.MetricClose, eng.CurrentDate())
+		if math.IsNaN(price) || price <= 0 {
+			continue
+		}
+
+		shares := math.Floor(weight * totalCash / price)
+		if shares > 0 {
+			batch.Order(ctx, target, portfolio.Buy, shares)
+		}
+	}
+
+	return nil
+}
+
+// makeGrowingDailyData builds a synthetic price DataFrame whose AdjClose and
+// MetricClose grow linearly from startPrice to endPrice over numDays.
+// Returns include all metrics the engine needs.
+func makeGrowingDailyData(startDate time.Time, numDays int, testAssets []asset.Asset, startPrice, endPrice float64) *data.DataFrame {
+	metrics := []data.Metric{
+		data.MetricClose,
+		data.AdjClose,
+		data.Dividend,
+		data.MetricHigh,
+		data.MetricLow,
+		data.Volume,
+		data.SplitFactor,
+	}
+
+	times := make([]time.Time, numDays)
+	for dayIdx := range times {
+		day := startDate.AddDate(0, 0, dayIdx)
+		times[dayIdx] = time.Date(day.Year(), day.Month(), day.Day(), 16, 0, 0, 0, time.UTC)
+	}
+
+	numCols := len(testAssets) * len(metrics)
+	vals := make([]float64, numDays*numCols)
+
+	for assetIdx := range testAssets {
+		for metricIdx, metric := range metrics {
+			colStart := (assetIdx*len(metrics) + metricIdx) * numDays
+			for dayIdx := range numDays {
+				progress := float64(dayIdx) / float64(numDays-1)
+				basePrice := startPrice + progress*(endPrice-startPrice)
+
+				switch metric {
+				case data.SplitFactor:
+					vals[colStart+dayIdx] = 1.0
+				case data.Dividend:
+					vals[colStart+dayIdx] = 0.0
+				case data.MetricHigh:
+					vals[colStart+dayIdx] = basePrice + 0.5
+				case data.MetricLow:
+					vals[colStart+dayIdx] = basePrice - 0.5
+				case data.Volume:
+					vals[colStart+dayIdx] = 1_000_000
+				default:
+					vals[colStart+dayIdx] = basePrice
+				}
+			}
+		}
+	}
+
+	columns := data.SlabToColumns(vals, numCols, numDays)
+	dataFrame, err := data.NewDataFrame(times, testAssets, metrics, data.Daily, columns)
+	Expect(err).NotTo(HaveOccurred())
+
+	return dataFrame
+}
+
+var _ = Describe("End-to-end optimize through the engine", func() {
+	BeforeEach(func() {
+		// Initialize an empty market-holidays table; the engine refuses to run
+		// without one. Empty is fine for synthetic Mon-Fri data.
+		tradecron.SetMarketHolidays(nil)
+	})
+
+	It("computes non-zero CAGR for each combo when the strategy actually trades", func() {
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+
+		// 600 trading days of growing prices: 100 -> 200 (doubles), spanning
+		// roughly 2.4 years. This is wide enough to comfortably bracket a
+		// TrainTest cutoff.
+		dataStart := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		syntheticData := makeGrowingDailyData(dataStart, 600, testAssets, 100.0, 200.0)
+		testProvider := data.NewTestProvider(
+			[]data.Metric{data.MetricClose, data.AdjClose, data.Dividend, data.MetricHigh, data.MetricLow, data.Volume, data.SplitFactor},
+			syntheticData,
+		)
+		assetProvider := &e2eAssetProvider{assets: testAssets}
+
+		// TrainTest with a cutoff well inside the available data so both
+		// halves have many trading days.
+		start := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+		cutoff := time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC)
+
+		splits, err := study.TrainTest(start, cutoff, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		opt := optimize.New(splits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+
+		runner := &study.Runner{
+			Study: opt,
+			NewStrategy: func() engine.Strategy {
+				return &fixedFractionStrategy{Targets: testAssets}
+			},
+			Options: []engine.Option{
+				engine.WithDataProvider(testProvider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			},
+			Workers:        1,
+			SearchStrategy: study.NewGrid(study.SweepValues("lookback", "5", "10", "20")),
+			Splits:         splits,
+			Objective:      portfolio.CAGR.(portfolio.Rankable),
+		}
+
+		progressCh, resultCh, runErr := runner.Run(context.Background())
+		Expect(runErr).NotTo(HaveOccurred())
+
+		for range progressCh {
+		}
+
+		result := <-resultCh
+		Expect(result.Err).NotTo(HaveOccurred())
+
+		for _, run := range result.Runs {
+			Expect(run.Err).NotTo(HaveOccurred())
+			Expect(run.Portfolio).NotTo(BeNil())
+		}
+
+		rptData := decodeOptReport(result.Report)
+		Expect(rptData.Rankings).To(HaveLen(3),
+			"expected one ranking row per combo (lookback=5,10,20)")
+
+		// The strategy buys SPY on day 1 and holds. Prices grow linearly,
+		// so CAGR over the test window must be strictly positive for every
+		// combo. If any combo's MeanOOS is exactly zero, the metric path
+		// is broken end-to-end.
+		for idx, row := range rptData.Rankings {
+			GinkgoWriter.Printf("rank=%d params=%q meanOOS=%g meanIS=%g\n",
+				row.Rank, row.Parameters, row.MeanOOS, row.MeanIS)
+			Expect(row.MeanOOS).NotTo(Equal(0.0),
+				"row %d (params=%q) MeanOOS should not be zero — backtests grew from 100 to ~200, CAGR must be positive",
+				idx, row.Parameters)
+			Expect(row.MeanIS).NotTo(Equal(0.0),
+				"row %d (params=%q) MeanIS should not be zero",
+				idx, row.Parameters)
+		}
+
+		Expect(rptData.BestDetail).NotTo(BeNil())
+		for _, fold := range rptData.BestDetail.Folds {
+			Expect(fold.OOSScore).NotTo(Equal(0.0),
+				"best detail fold %q OOSScore should not be zero", fold.FoldName)
+			Expect(fold.ISScore).NotTo(Equal(0.0),
+				"best detail fold %q ISScore should not be zero", fold.FoldName)
+		}
+	})
+
+	It("fails loudly when no initial deposit is configured", func() {
+		// Regression guard for the original bug: the `study optimize` CLI
+		// previously did not pass engine.WithInitialDeposit, so the engine
+		// constructed an account with $0 starting cash. The strategy could
+		// not trade, equity stayed at $0 throughout the run, and CAGR /
+		// Sharpe / Sortino / Calmar all silently returned 0 -- producing a
+		// rankings list ordered by insertion. The engine now refuses to
+		// run instead of producing meaningless zero scores.
+		spy := asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		testAssets := []asset.Asset{spy}
+
+		dataStart := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		syntheticData := makeGrowingDailyData(dataStart, 600, testAssets, 100.0, 200.0)
+		testProvider := data.NewTestProvider(
+			[]data.Metric{data.MetricClose, data.AdjClose, data.Dividend, data.MetricHigh, data.MetricLow, data.Volume, data.SplitFactor},
+			syntheticData,
+		)
+		assetProvider := &e2eAssetProvider{assets: testAssets}
+
+		start := time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+		cutoff := time.Date(2021, 1, 4, 0, 0, 0, 0, time.UTC)
+		end := time.Date(2022, 1, 3, 0, 0, 0, 0, time.UTC)
+
+		splits, err := study.TrainTest(start, cutoff, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		opt := optimize.New(splits, optimize.WithObjective(portfolio.CAGR.(portfolio.Rankable)))
+
+		runner := &study.Runner{
+			Study: opt,
+			NewStrategy: func() engine.Strategy {
+				return &fixedFractionStrategy{Targets: testAssets}
+			},
+			Options: []engine.Option{
+				engine.WithDataProvider(testProvider),
+				engine.WithAssetProvider(assetProvider),
+				// Deliberately no engine.WithInitialDeposit.
+			},
+			Workers:        1,
+			SearchStrategy: study.NewGrid(study.SweepValues("lookback", "5", "10", "20")),
+			Splits:         splits,
+			Objective:      portfolio.CAGR.(portfolio.Rankable),
+		}
+
+		progressCh, resultCh, runErr := runner.Run(context.Background())
+		Expect(runErr).NotTo(HaveOccurred())
+
+		for range progressCh {
+		}
+
+		result := <-resultCh
+		Expect(result.Runs).NotTo(BeEmpty())
+
+		for _, run := range result.Runs {
+			Expect(run.Err).To(HaveOccurred(),
+				"the engine should refuse to run with no initial deposit")
+			Expect(run.Err.Error()).To(ContainSubstring("initial deposit must be positive"))
+		}
+	})
+})

--- a/study/optimize/optimize.go
+++ b/study/optimize/optimize.go
@@ -18,6 +18,7 @@ package optimize
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/penny-vault/pvbt/portfolio"
 	"github.com/penny-vault/pvbt/study"
@@ -30,9 +31,10 @@ var _ study.Study = (*Optimizer)(nil)
 // Optimizer is a study.Study that evaluates strategy parameter combinations
 // across cross-validation splits and ranks them by out-of-sample performance.
 type Optimizer struct {
-	splits    []study.Split
-	objective portfolio.Rankable
-	topN      int
+	splits     []study.Split
+	objective  portfolio.Rankable
+	topN       int
+	baseParams map[string]string
 }
 
 // Option configures an Optimizer.
@@ -50,6 +52,21 @@ func WithObjective(metric portfolio.Rankable) Option {
 func WithTopN(topN int) Option {
 	return func(opt *Optimizer) {
 		opt.topN = topN
+	}
+}
+
+// WithBaseParams sets parameter values applied to every parameter
+// combination before the swept value is overlaid. Use this to fix
+// non-swept strategy flags (e.g. when sweeping --sector-cap but
+// pinning --top-holdings to a specific value).
+func WithBaseParams(params map[string]string) Option {
+	return func(opt *Optimizer) {
+		if len(params) == 0 {
+			opt.baseParams = nil
+			return
+		}
+
+		opt.baseParams = maps.Clone(params)
 	}
 }
 
@@ -97,16 +114,20 @@ func (opt *Optimizer) Configurations(_ context.Context) ([]study.RunConfig, erro
 		}
 	}
 
-	return []study.RunConfig{
-		{
-			Name:  "Full Range",
-			Start: earliest,
-			End:   latest,
-			Metadata: map[string]string{
-				"study": "parameter-optimization",
-			},
+	cfg := study.RunConfig{
+		Name:  "Full Range",
+		Start: earliest,
+		End:   latest,
+		Metadata: map[string]string{
+			"study": "parameter-optimization",
 		},
-	}, nil
+	}
+
+	if len(opt.baseParams) > 0 {
+		cfg.Params = maps.Clone(opt.baseParams)
+	}
+
+	return []study.RunConfig{cfg}, nil
 }
 
 // Analyze processes all RunResults, groups them by combination and split,

--- a/study/optimize/optimize_test.go
+++ b/study/optimize/optimize_test.go
@@ -124,4 +124,44 @@ var _ = Describe("Optimizer", func() {
 			Expect(rptData.ObjectiveName).To(Equal("CAGR"))
 		})
 	})
+
+	Describe("WithBaseParams", func() {
+		It("attaches base params to the configuration", func() {
+			opt := optimize.New(splits, optimize.WithBaseParams(map[string]string{
+				"top-holdings": "5",
+				"benchmark":    "SPY",
+			}))
+
+			configs, err := opt.Configurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs).To(HaveLen(1))
+			Expect(configs[0].Params).To(HaveKeyWithValue("top-holdings", "5"))
+			Expect(configs[0].Params).To(HaveKeyWithValue("benchmark", "SPY"))
+		})
+
+		It("isolates the optimizer's copy from the caller's map", func() {
+			input := map[string]string{"lookback": "5"}
+
+			opt := optimize.New(splits, optimize.WithBaseParams(input))
+
+			// Mutating the caller's map after construction must not affect
+			// the optimizer's stored copy.
+			input["lookback"] = "999"
+
+			configs, err := opt.Configurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Params).To(HaveKeyWithValue("lookback", "5"))
+		})
+
+		It("clears base params when given an empty map", func() {
+			opt := optimize.New(splits,
+				optimize.WithBaseParams(map[string]string{"lookback": "5"}),
+				optimize.WithBaseParams(nil),
+			)
+
+			configs, err := opt.Configurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Params).To(BeEmpty())
+		})
+	})
 })

--- a/study/optimize/report.go
+++ b/study/optimize/report.go
@@ -16,7 +16,10 @@
 package optimize
 
 import (
+	"fmt"
 	"io"
+	"math"
+	"text/tabwriter"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -34,6 +37,7 @@ var nanSafeAPI = sonic.Config{
 // optimizerReport implements report.Report for the parameter optimizer.
 type optimizerReport struct {
 	ObjectiveName string              `json:"objectiveName"`
+	Warning       string              `json:"warning,omitempty"`
 	Rankings      []rankingRow        `json:"rankings"`
 	BestDetail    *bestComboDetail    `json:"bestDetail,omitempty"`
 	Overfitting   []overfittingRow    `json:"overfitting"`
@@ -76,4 +80,91 @@ func (or *optimizerReport) Name() string { return "Optimize" }
 
 func (or *optimizerReport) Data(writer io.Writer) error {
 	return nanSafeAPI.NewEncoder(writer).Encode(or)
+}
+
+// Text writes a human-readable plain-text rendering of the report to
+// writer. The output is intended for terminal use: header, ranking
+// table, best combo, and any warning. Equity curves and the redundant
+// overfitting table are omitted.
+//
+// Numeric columns are right-aligned by formatting the values into
+// fixed-width strings before handing them to tabwriter, so the table
+// stays readable without per-column alignment configuration.
+func (or *optimizerReport) Text(writer io.Writer) error {
+	if _, err := fmt.Fprintf(writer, "Optimization: %s (%d combos)\n", or.ObjectiveName, len(or.Rankings)); err != nil {
+		return err
+	}
+
+	if or.Warning != "" {
+		if _, err := fmt.Fprintf(writer, "\nWarning: %s\n", or.Warning); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintln(writer); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
+
+	if _, err := fmt.Fprintln(tw, "Rank\tParameters\t   OOS\t    IS\tStdDev"); err != nil {
+		return err
+	}
+
+	for _, row := range or.Rankings {
+		if _, err := fmt.Fprintf(tw, "%4d\t%s\t%s\t%s\t%s\n",
+			row.Rank,
+			row.Parameters,
+			formatScore(row.MeanOOS),
+			formatScore(row.MeanIS),
+			formatScore(row.OOSStdDev),
+		); err != nil {
+			return err
+		}
+	}
+
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if or.BestDetail != nil {
+		if _, err := fmt.Fprintf(writer, "\nBest: %s\n", or.BestDetail.Parameters); err != nil {
+			return err
+		}
+
+		if len(or.BestDetail.Folds) > 1 {
+			foldTw := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
+
+			if _, err := fmt.Fprintln(foldTw, "Fold\t    IS\t   OOS"); err != nil {
+				return err
+			}
+
+			for _, fold := range or.BestDetail.Folds {
+				if _, err := fmt.Fprintf(foldTw, "%s\t%s\t%s\n",
+					fold.FoldName,
+					formatScore(fold.ISScore),
+					formatScore(fold.OOSScore),
+				); err != nil {
+					return err
+				}
+			}
+
+			if err := foldTw.Flush(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// formatScore renders a metric value into a fixed-width, right-aligned
+// six-character string. NaN and Inf become "   n/a"; everything else
+// is formatted to three decimal places (e.g. "  0.688", " -1.234").
+func formatScore(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "   n/a"
+	}
+
+	return fmt.Sprintf("%6.3f", value)
 }

--- a/study/stress/analyze_test.go
+++ b/study/stress/analyze_test.go
@@ -18,8 +18,10 @@ package stress_test
 import (
 	"bytes"
 	"errors"
-	"github.com/bytedance/sonic"
+	"io"
 	"time"
+
+	"github.com/bytedance/sonic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -252,6 +254,26 @@ var _ = Describe("Analyze", func() {
 
 			for _, scenario := range scenarios {
 				Expect(scenarioNames).To(ContainElement(scenario.Name))
+			}
+		})
+
+		It("renders a plain-text table via the Text method", func() {
+			rpt, err := stressTest.Analyze(results)
+			Expect(err).NotTo(HaveOccurred())
+
+			textReport, ok := rpt.(interface{ Text(io.Writer) error })
+			Expect(ok).To(BeTrue(), "stress report must implement Text(io.Writer) error")
+
+			var buf bytes.Buffer
+			Expect(textReport.Text(&buf)).To(Succeed())
+
+			out := buf.String()
+			Expect(out).To(ContainSubstring("Stress Test"))
+			Expect(out).To(ContainSubstring("Scenario"))
+			Expect(out).To(ContainSubstring("MaxDD"))
+			Expect(out).To(ContainSubstring("TestRun"))
+			for _, scenario := range scenarios {
+				Expect(out).To(ContainSubstring(scenario.Name))
 			}
 		})
 	})

--- a/study/stress/report.go
+++ b/study/stress/report.go
@@ -16,7 +16,10 @@
 package stress
 
 import (
+	"fmt"
 	"io"
+	"math"
+	"text/tabwriter"
 
 	"github.com/bytedance/sonic"
 )
@@ -68,4 +71,78 @@ func (sr *stressReport) Name() string { return "StressTest" }
 
 func (sr *stressReport) Data(writer io.Writer) error {
 	return nanSafeAPI.NewEncoder(writer).Encode(sr)
+}
+
+// Text writes a human-readable plain-text rendering of the report. The
+// output lists each scenario's per-run drawdown, total return, and
+// worst single day, then prints the summary line.
+func (sr *stressReport) Text(writer io.Writer) error {
+	if _, err := fmt.Fprintf(writer, "Stress Test (%d scenarios)\n\n", len(sr.Scenarios)); err != nil {
+		return err
+	}
+
+	tw := tabwriter.NewWriter(writer, 0, 0, 2, ' ', 0)
+
+	if _, err := fmt.Fprintln(tw, "Scenario\tRun\t   MaxDD\tReturn\tWorstDay"); err != nil {
+		return err
+	}
+
+	for _, scenario := range sr.Scenarios {
+		header := fmt.Sprintf("%s (%s)", scenario.Name, scenario.DateRange)
+
+		for runIdx, runMetric := range scenario.RunMetrics {
+			scenarioCell := header
+			if runIdx > 0 {
+				scenarioCell = ""
+			}
+
+			if runMetric.ErrorMsg != "" {
+				if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t\n", scenarioCell, runMetric.RunName, "error: "+runMetric.ErrorMsg); err != nil {
+					return err
+				}
+
+				continue
+			}
+
+			if !runMetric.HasData {
+				if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t\n", scenarioCell, runMetric.RunName, "no data"); err != nil {
+					return err
+				}
+
+				continue
+			}
+
+			if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				scenarioCell,
+				runMetric.RunName,
+				formatPercent(runMetric.MaxDrawdown),
+				formatPercent(runMetric.TotalReturn),
+				formatPercent(runMetric.WorstDay),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if sr.Summary != "" {
+		if _, err := fmt.Fprintf(writer, "\n%s\n", sr.Summary); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// formatPercent renders a fractional value (0.05 → "  5.00%"). NaN and
+// Inf become "    n/a" so the column stays aligned.
+func formatPercent(value float64) string {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "    n/a"
+	}
+
+	return fmt.Sprintf("%6.2f%%", value*100)
 }

--- a/universe/index.go
+++ b/universe/index.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/data"
 	"github.com/penny-vault/pvbt/portfolio"
@@ -58,7 +60,12 @@ func (u *indexUniverse) SetDataSource(ds DataSource) {
 // increasing across calls.
 func (u *indexUniverse) Assets(asOfDate time.Time) []asset.Asset {
 	assets, _, err := u.provider.IndexMembers(context.Background(), u.indexName, asOfDate)
-	if err != nil || len(assets) == 0 {
+	if err != nil {
+		log.Error().Err(err).
+			Str("index", u.indexName).
+			Time("as_of", asOfDate).
+			Msg("IndexMembers failed; treating universe as empty")
+
 		return nil
 	}
 
@@ -72,7 +79,12 @@ func (u *indexUniverse) Assets(asOfDate time.Time) []asset.Asset {
 // call is a no-op that returns the cached parallel slice.
 func (u *indexUniverse) Constituents(asOfDate time.Time) []data.IndexConstituent {
 	_, constituents, err := u.provider.IndexMembers(context.Background(), u.indexName, asOfDate)
-	if err != nil || len(constituents) == 0 {
+	if err != nil {
+		log.Error().Err(err).
+			Str("index", u.indexName).
+			Time("as_of", asOfDate).
+			Msg("IndexMembers failed; treating universe as empty")
+
 		return nil
 	}
 

--- a/universe/index_test.go
+++ b/universe/index_test.go
@@ -16,12 +16,16 @@
 package universe_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 
 	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/data"
@@ -95,10 +99,28 @@ var _ = Describe("Index Universe", func() {
 			Expect(assets).To(BeNil())
 		})
 
-		It("returns nil when the provider returns an error", func() {
+		It("returns nil and logs the error when the provider returns an error", func() {
+			// IndexUniverse.Assets used to swallow the error silently, which
+			// hid a regression where every constituent figi missing from the
+			// assets table caused the whole load to fail. The log line is the
+			// canary that makes such failures observable.
+			var buf bytes.Buffer
+
+			origLogger := log.Logger
+			log.Logger = zerolog.New(&buf)
+
+			defer func() {
+				log.Logger = origLogger
+			}()
+
 			u := universe.NewIndex(&errorIndexProvider{}, "SP500")
 			assets := u.Assets(now)
 			Expect(assets).To(BeNil())
+
+			out := buf.String()
+			Expect(out).To(ContainSubstring(`"level":"error"`))
+			Expect(out).To(ContainSubstring(`"index":"SP500"`))
+			Expect(out).To(ContainSubstring("provider error"))
 		})
 	})
 
@@ -131,10 +153,24 @@ var _ = Describe("Index Universe", func() {
 			Expect(constituents).To(BeNil())
 		})
 
-		It("returns nil when the provider returns an error", func() {
+		It("returns nil and logs the error when the provider returns an error", func() {
+			var buf bytes.Buffer
+
+			origLogger := log.Logger
+			log.Logger = zerolog.New(&buf)
+
+			defer func() {
+				log.Logger = origLogger
+			}()
+
 			u := universe.NewIndex(&errorIndexProvider{}, "SP500")
 			constituents := u.Constituents(now)
 			Expect(constituents).To(BeNil())
+
+			out := buf.String()
+			Expect(out).To(ContainSubstring(`"level":"error"`))
+			Expect(out).To(ContainSubstring(`"index":"SP500"`))
+			Expect(out).To(ContainSubstring("provider error"))
 		})
 	})
 


### PR DESCRIPTION
This release makes `study optimize` and `study stress-test` work the way they were always supposed to.

The pieces that broke were small individually but compounded badly. Both commands ran with $0 starting cash, so every backtest sat flat at zero and every objective metric quietly collapsed to 0. Strategy parameters with non-zero defaults could not be set to zero — neither `--flag 0` from the command line nor a preset like `Vanilla=0` survived hydration, because Go's zero value is indistinguishable from "never set". Integer ranges like `0:8:1` were rejected by the cobra flag parser before the optimizer ever saw them, blocking optimization of any strategy whose tunable parameters were ints. Non-swept flag values were silently dropped, so pinning one parameter while sweeping another did nothing. And with no validation that any range had been declared, `--search random --samples 8` happily ranked eight identical runs by the order they were inserted. Each layer made the others harder to spot.

v0.9.1 fixes every one of those. Both commands accept `--cash` for starting balance and refuse to run with $0. Explicit zero overrides survive — via CLI flag or preset. `study optimize` accepts integer and float ranges, refuses to run with no ranges configured, propagates non-swept flag values across every combination, and warns in its report when every combination produces the same score. `study stress-test` now exposes strategy flags at all and applies them per scenario, including asset and universe fields. Both subcommands gain `--format text` for terminal-friendly ranking tables alongside the existing `json` and `html` outputs.