### PR TITLE
fix(portfolio): make tax metrics honor the requested window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Tax-related metrics (`TaxDrag`, `TaxCostRatio`, `LTCG`, `STCG`, `QualifiedDividends`, `NonQualifiedIncome`) now honor the requested window. Previously every per-window value reported in snapshots and the metrics table was the all-history figure, making per-window after-tax returns impossible to assemble.
+
 ## [0.9.1] - 2026-05-03
 
 ### Added

--- a/portfolio/ltcg.go
+++ b/portfolio/ltcg.go
@@ -29,8 +29,10 @@ func (ltcgMetric) Description() string {
 	return "Total realized long-term capital gains from positions held longer than 365 days. Computed by replaying the transaction log with FIFO lot matching. Taxed at preferential rates (typically 15-20%)."
 }
 
-func (ltcgMetric) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (float64, error) {
-	ltcg, _, _, _ := realizedGains(stats.TransactionsView(ctx))
+func (ltcgMetric) Compute(ctx context.Context, stats PortfolioStats, window *Period) (float64, error) {
+	start, end := windowBounds(ctx, stats, window)
+	ltcg, _, _, _ := realizedGainsInRange(stats.TransactionsView(ctx), start, end)
+
 	return ltcg, nil
 }
 

--- a/portfolio/metric_helpers.go
+++ b/portfolio/metric_helpers.go
@@ -16,11 +16,52 @@
 package portfolio
 
 import (
+	"context"
 	"math"
 	"time"
 
 	"github.com/penny-vault/pvbt/asset"
 )
+
+// windowBoundsHinter is implemented by stats wrappers that already know
+// their user-supplied date range (e.g. windowedStats from AbsoluteWindow).
+// When present, the metric uses these bounds directly so that transactions
+// falling inside the window but outside the recorded equity-curve rows
+// are still attributed correctly.
+type windowBoundsHinter interface {
+	windowBounds() (start, end time.Time)
+}
+
+// windowBounds returns the inclusive [start, end] timestamp range covered
+// by window when applied to stats. For absolute windows the bounds come
+// from the wrapper; for relative *Period windows the end is the latest
+// recorded equity timestamp and the start is period.Before(end). Returning
+// zero times signals an unbounded range, which realizedGainsInRange treats
+// as full history.
+func windowBounds(ctx context.Context, stats PortfolioStats, window *Period) (start, end time.Time) {
+	if hinter, ok := stats.(windowBoundsHinter); ok {
+		return hinter.windowBounds()
+	}
+
+	if window == nil {
+		return time.Time{}, time.Time{}
+	}
+
+	df := stats.EquitySeries(ctx, nil)
+	if df == nil {
+		return time.Time{}, time.Time{}
+	}
+
+	times := df.Times()
+	if len(times) == 0 {
+		return time.Time{}, time.Time{}
+	}
+
+	end = times[len(times)-1]
+	start = window.Before(end)
+
+	return start, end
+}
 
 // removeNaN returns a copy of col with all NaN values removed.
 func removeNaN(col []float64) []float64 {
@@ -194,12 +235,35 @@ func roundTrips(details []TradeDetail, txns []Transaction) ([]roundTrip, float64
 
 // realizedGains replays the transaction log with FIFO lot matching to
 // compute realized long-term capital gains, short-term capital gains,
-// qualified dividend income, and non-qualified dividend income.
+// qualified dividend income, and non-qualified dividend income across
+// the full transaction history.
 func realizedGains(txns []Transaction) (ltcg, stcg, qualDiv, nonQualDiv float64) {
+	return realizedGainsInRange(txns, time.Time{}, time.Time{})
+}
+
+// realizedGainsInRange replays the full transaction log with FIFO lot
+// matching but only attributes realized gains and dividends whose
+// transaction date falls inside the inclusive [start, end] window.
+// Buys outside the window still build up tax lots so that in-window
+// sells consume the correct cost basis. A zero-value start/end disables
+// the bound on that side; a zero range on both sides covers all history.
+func realizedGainsInRange(txns []Transaction, start, end time.Time) (ltcg, stcg, qualDiv, nonQualDiv float64) {
 	type lot struct {
 		date  time.Time
 		qty   float64
 		price float64
+	}
+
+	inRange := func(date time.Time) bool {
+		if !start.IsZero() && date.Before(start) {
+			return false
+		}
+
+		if !end.IsZero() && date.After(end) {
+			return false
+		}
+
+		return true
 	}
 
 	lots := make(map[string][]lot) // keyed by CompositeFigi
@@ -216,6 +280,7 @@ func realizedGains(txns []Transaction) (ltcg, stcg, qualDiv, nonQualDiv float64)
 		case asset.SellTransaction:
 			remaining := txn.Qty
 			lotList := lots[key]
+			attribute := inRange(txn.Date)
 
 			lotIdx := 0
 			for lotIdx < len(lotList) && remaining > 0 {
@@ -224,13 +289,15 @@ func realizedGains(txns []Transaction) (ltcg, stcg, qualDiv, nonQualDiv float64)
 					matched = remaining
 				}
 
-				gain := (txn.Price - lotList[lotIdx].price) * matched
+				if attribute {
+					gain := (txn.Price - lotList[lotIdx].price) * matched
 
-				holdingDays := txn.Date.Sub(lotList[lotIdx].date).Hours() / 24
-				if holdingDays > 365 {
-					ltcg += gain
-				} else {
-					stcg += gain
+					holdingDays := txn.Date.Sub(lotList[lotIdx].date).Hours() / 24
+					if holdingDays > 365 {
+						ltcg += gain
+					} else {
+						stcg += gain
+					}
 				}
 
 				if lotList[lotIdx].qty <= remaining {
@@ -244,6 +311,10 @@ func realizedGains(txns []Transaction) (ltcg, stcg, qualDiv, nonQualDiv float64)
 
 			lots[key] = lotList[lotIdx:]
 		case asset.DividendTransaction:
+			if !inRange(txn.Date) {
+				continue
+			}
+
 			if txn.Qualified {
 				qualDiv += txn.Amount
 			} else {

--- a/portfolio/non_qualified_income.go
+++ b/portfolio/non_qualified_income.go
@@ -33,13 +33,25 @@ func (nonQualifiedIncome) Description() string {
 		"interest distributions."
 }
 
-func (nonQualifiedIncome) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (float64, error) {
+func (nonQualifiedIncome) Compute(ctx context.Context, stats PortfolioStats, window *Period) (float64, error) {
+	start, end := windowBounds(ctx, stats, window)
+
 	var total float64
 
 	for _, tx := range stats.TransactionsView(ctx) {
-		if tx.Type == asset.DividendTransaction && !tx.Qualified {
-			total += tx.Amount
+		if tx.Type != asset.DividendTransaction || tx.Qualified {
+			continue
 		}
+
+		if !start.IsZero() && tx.Date.Before(start) {
+			continue
+		}
+
+		if !end.IsZero() && tx.Date.After(end) {
+			continue
+		}
+
+		total += tx.Amount
 	}
 
 	return total, nil

--- a/portfolio/qualified_dividends.go
+++ b/portfolio/qualified_dividends.go
@@ -30,13 +30,25 @@ func (qualifiedDividends) Description() string {
 	return "Total qualified dividend income received. Qualified dividends are taxed at preferential capital gains rates rather than ordinary income rates."
 }
 
-func (qualifiedDividends) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (float64, error) {
+func (qualifiedDividends) Compute(ctx context.Context, stats PortfolioStats, window *Period) (float64, error) {
+	start, end := windowBounds(ctx, stats, window)
+
 	var total float64
 
 	for _, tx := range stats.TransactionsView(ctx) {
-		if tx.Type == asset.DividendTransaction && tx.Qualified {
-			total += tx.Amount
+		if tx.Type != asset.DividendTransaction || !tx.Qualified {
+			continue
 		}
+
+		if !start.IsZero() && tx.Date.Before(start) {
+			continue
+		}
+
+		if !end.IsZero() && tx.Date.After(end) {
+			continue
+		}
+
+		total += tx.Amount
 	}
 
 	return total, nil

--- a/portfolio/stcg.go
+++ b/portfolio/stcg.go
@@ -29,8 +29,10 @@ func (stcgMetric) Description() string {
 	return "Total realized short-term capital gains from positions held 365 days or fewer. Computed by replaying the transaction log with FIFO lot matching. Taxed as ordinary income."
 }
 
-func (stcgMetric) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (float64, error) {
-	_, stcg, _, _ := realizedGains(stats.TransactionsView(ctx))
+func (stcgMetric) Compute(ctx context.Context, stats PortfolioStats, window *Period) (float64, error) {
+	start, end := windowBounds(ctx, stats, window)
+	_, stcg, _, _ := realizedGainsInRange(stats.TransactionsView(ctx), start, end)
+
 	return stcg, nil
 }
 

--- a/portfolio/tax_cost_ratio.go
+++ b/portfolio/tax_cost_ratio.go
@@ -29,13 +29,13 @@ func (taxCostRatio) Description() string {
 	return "Estimated percentage of portfolio gain lost to taxes. Computed as estimated tax liability (using 25% for short-term gains, 15% for long-term gains and qualified dividends) divided by total portfolio gain. Lower values indicate more tax-efficient strategies."
 }
 
-func (taxCostRatio) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (float64, error) {
-	pd := stats.PerfDataView(ctx)
-	if pd == nil {
+func (taxCostRatio) Compute(ctx context.Context, stats PortfolioStats, window *Period) (float64, error) {
+	df := stats.EquitySeries(ctx, window)
+	if df == nil {
 		return 0, nil
 	}
 
-	ec := pd.Column(portfolioAsset, data.PortfolioEquity)
+	ec := df.Column(portfolioAsset, data.PortfolioEquity)
 	if len(ec) < 2 {
 		return 0, nil
 	}
@@ -45,7 +45,10 @@ func (taxCostRatio) Compute(ctx context.Context, stats PortfolioStats, _ *Period
 		return 0, nil
 	}
 
-	ltcg, stcg, qualDiv, nonQualDiv := realizedGains(stats.TransactionsView(ctx))
+	start, end := windowBounds(ctx, stats, window)
+	ltcg, stcg, qualDiv, nonQualDiv := realizedGainsInRange(
+		stats.TransactionsView(ctx), start, end,
+	)
 
 	estimatedTax := 0.0
 	if stcg > 0 {

--- a/portfolio/tax_drag.go
+++ b/portfolio/tax_drag.go
@@ -29,13 +29,13 @@ func (taxDrag) Description() string {
 	return "Percentage of pre-tax return consumed by taxes from trading activity, excluding dividend taxation. Uses 25% for short-term gains and 15% for long-term gains."
 }
 
-func (taxDrag) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (float64, error) {
-	perfData := stats.PerfDataView(ctx)
-	if perfData == nil {
+func (taxDrag) Compute(ctx context.Context, stats PortfolioStats, window *Period) (float64, error) {
+	df := stats.EquitySeries(ctx, window)
+	if df == nil {
 		return 0, nil
 	}
 
-	ec := perfData.Column(portfolioAsset, data.PortfolioEquity)
+	ec := df.Column(portfolioAsset, data.PortfolioEquity)
 	if len(ec) < 2 {
 		return 0, nil
 	}
@@ -45,7 +45,8 @@ func (taxDrag) Compute(ctx context.Context, stats PortfolioStats, _ *Period) (fl
 		return 0, nil
 	}
 
-	ltcg, stcg, _, _ := realizedGains(stats.TransactionsView(ctx))
+	start, end := windowBounds(ctx, stats, window)
+	ltcg, stcg, _, _ := realizedGainsInRange(stats.TransactionsView(ctx), start, end)
 
 	estimatedTax := 0.0
 	if stcg > 0 {

--- a/portfolio/tax_drag_test.go
+++ b/portfolio/tax_drag_test.go
@@ -277,4 +277,178 @@ var _ = Describe("TaxDrag", func() {
 		// preTaxReturn = 48000 - 50000 = -2000 (negative), so TaxDrag = 0
 		Expect(tm.TaxDrag).To(Equal(0.0))
 	})
+
+	Describe("window-aware tax metrics", func() {
+		// Build an account that realizes gains in two distinct calendar
+		// years so a sub-window can isolate one. Buy 100 SPY @ $100 in
+		// 2023, sell 50 @ $130 in mid-2023 (STCG = 1500), and sell the
+		// remaining 50 @ $150 in mid-2024 after > 1 year (LTCG = 2500).
+		var (
+			acct        *portfolio.Account
+			start2023   = time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+			endOf2023   = time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+			midYear2024 = time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+		)
+
+		BeforeEach(func() {
+			acct = portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+
+			acct.Record(portfolio.Transaction{
+				Date:   start2023,
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    100,
+				Price:  100.0,
+				Amount: -10_000.0,
+			})
+			acct.UpdatePrices(buildDF(
+				start2023,
+				[]asset.Asset{spy}, []float64{100.0}, []float64{100.0},
+			))
+
+			// In-2023 sell: 50 shares @ $130, held < 1 year => STCG = 1500.
+			acct.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.SellTransaction,
+				Qty:    50,
+				Price:  130.0,
+				Amount: 6_500.0,
+			})
+			acct.UpdatePrices(buildDF(
+				time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+				[]asset.Asset{spy}, []float64{130.0}, []float64{130.0},
+			))
+
+			// Stamp the equity curve at end of 2023 so a 2023-only
+			// window contains both the buy and the in-2023 sell.
+			acct.UpdatePrices(buildDF(
+				endOf2023,
+				[]asset.Asset{spy}, []float64{140.0}, []float64{140.0},
+			))
+
+			// In-2024 sell: remaining 50 shares @ $150, held > 1 year
+			// => LTCG = 50 * (150 - 100) = 2500.
+			acct.Record(portfolio.Transaction{
+				Date:   midYear2024,
+				Asset:  spy,
+				Type:   asset.SellTransaction,
+				Qty:    50,
+				Price:  150.0,
+				Amount: 7_500.0,
+			})
+			acct.UpdatePrices(buildDF(
+				midYear2024,
+				[]asset.Asset{spy}, []float64{150.0}, []float64{150.0},
+			))
+		})
+
+		It("STCG honors AbsoluteWindow and excludes out-of-window sells", func() {
+			fullSTCG, err := acct.PerformanceMetric(portfolio.STCGMetric).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fullSTCG).To(BeNumerically("~", 1_500.0, 1e-9))
+
+			win2023, err := acct.PerformanceMetric(portfolio.STCGMetric).
+				AbsoluteWindow(start2023, endOf2023).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2023).To(BeNumerically("~", 1_500.0, 1e-9))
+
+			// 2024 window has no STCG sell.
+			win2024, err := acct.PerformanceMetric(portfolio.STCGMetric).
+				AbsoluteWindow(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), midYear2024).
+				Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2024).To(Equal(0.0))
+		})
+
+		It("LTCG honors AbsoluteWindow and uses pre-window buys for cost basis", func() {
+			fullLTCG, err := acct.PerformanceMetric(portfolio.LTCGMetric).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fullLTCG).To(BeNumerically("~", 2_500.0, 1e-9))
+
+			// 2024 window: only the LTCG sell falls inside, but the
+			// 2023 buy must still seed the FIFO lot so cost basis is $100.
+			win2024, err := acct.PerformanceMetric(portfolio.LTCGMetric).
+				AbsoluteWindow(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), midYear2024).
+				Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2024).To(BeNumerically("~", 2_500.0, 1e-9))
+
+			// 2023 window has no LTCG sell.
+			win2023, err := acct.PerformanceMetric(portfolio.LTCGMetric).
+				AbsoluteWindow(start2023, endOf2023).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2023).To(Equal(0.0))
+		})
+
+		It("TaxDrag returns a different value for a sub-window than for full history", func() {
+			fullDrag, err := acct.PerformanceMetric(portfolio.TaxDragMetric).Value()
+			Expect(err).NotTo(HaveOccurred())
+
+			// 2023-only window:
+			//   equity start = 50000 (initial cash)
+			//   equity end (Dec 31 @ $140) = cash 46500 + 50*140 = 53500
+			//   preTaxReturn = 3500
+			//   STCG = 1500 (sell in 2023), LTCG = 0
+			//   estimatedTax = 0.25*1500 = 375
+			//   TaxDrag = 375 / 3500
+			win2023Drag, err := acct.PerformanceMetric(portfolio.TaxDragMetric).
+				AbsoluteWindow(start2023, endOf2023).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2023Drag).To(BeNumerically("~", 375.0/3500.0, 1e-9))
+			Expect(win2023Drag).NotTo(BeNumerically("~", fullDrag, 1e-9))
+		})
+
+		It("QualifiedDividends honors AbsoluteWindow", func() {
+			// Build a fresh account that records dividends after their
+			// underlying lots have aged > 60 days but before the lots
+			// are sold, so isDividendQualified resolves to true.
+			divAcct := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+			divAcct.Record(portfolio.Transaction{
+				Date:   start2023,
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    100,
+				Price:  100.0,
+				Amount: -10_000.0,
+			})
+			divAcct.UpdatePrices(buildDF(
+				start2023,
+				[]asset.Asset{spy}, []float64{100.0}, []float64{100.0},
+			))
+
+			divAcct.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 4, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.DividendTransaction,
+				Amount: 400.0,
+			})
+			divAcct.UpdatePrices(buildDF(
+				endOf2023,
+				[]asset.Asset{spy}, []float64{120.0}, []float64{120.0},
+			))
+
+			divAcct.Record(portfolio.Transaction{
+				Date:   time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.DividendTransaction,
+				Amount: 600.0,
+			})
+			divAcct.UpdatePrices(buildDF(
+				midYear2024,
+				[]asset.Asset{spy}, []float64{130.0}, []float64{130.0},
+			))
+
+			win2023, err := divAcct.PerformanceMetric(portfolio.QualifiedDividendsMetric).
+				AbsoluteWindow(start2023, endOf2023).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2023).To(BeNumerically("~", 400.0, 1e-9))
+
+			win2024, err := divAcct.PerformanceMetric(portfolio.QualifiedDividendsMetric).
+				AbsoluteWindow(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), midYear2024).
+				Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(win2024).To(BeNumerically("~", 600.0, 1e-9))
+		})
+	})
 })

--- a/portfolio/windowed_stats.go
+++ b/portfolio/windowed_stats.go
@@ -38,6 +38,14 @@ func newWindowedStats(inner PortfolioStats, start, end time.Time) PortfolioStats
 	return &windowedStats{inner: inner, start: start, end: end}
 }
 
+// windowBounds reports the user-supplied [start, end] range so that
+// transaction-walking metrics (LTCG, STCG, TaxDrag, dividend metrics) can
+// attribute events that fall inside the window even when no equity-curve
+// row was recorded at those dates.
+func (ws *windowedStats) windowBounds() (time.Time, time.Time) {
+	return ws.start, ws.end
+}
+
 func (ws *windowedStats) Returns(ctx context.Context, window *Period) *data.DataFrame {
 	df := ws.inner.Returns(ctx, window)
 	if df == nil {


### PR DESCRIPTION
## Summary

Tax-related metrics (`TaxDrag`, `TaxCostRatio`, `LTCG`, `STCG`, `QualifiedDividends`, `NonQualifiedIncome`) ignored the `*Period` passed to `Compute` and operated on the full transaction log and full equity curve. Since the engine writes one row per (metric x window x date), every window label received the same all-history value, making per-window after-tax returns impossible to assemble from the metrics table.

This change makes those metrics genuinely window-aware:

- `realizedGainsInRange` walks the full transaction log so FIFO lots are seeded by pre-window buys, but only attributes gains and dividends whose date falls inside the window.
- A new `windowBounds` helper returns the user-intended range. Absolute windows are read from `windowedStats` via a new `windowBoundsHinter` interface, so transactions that fall inside the user range still count when no equity-curve row was recorded on those exact dates. Relative `*Period` windows compute `[period.Before(end), end]` from the latest equity timestamp.