### PR TITLE
chore: release v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-04
+
 ### Fixed
 
 - Tax-related metrics (`TaxDrag`, `TaxCostRatio`, `LTCG`, `STCG`, `QualifiedDividends`, `NonQualifiedIncome`) now honor the requested window. Previously every per-window value reported in snapshots and the metrics table was the all-history figure, making per-window after-tax returns impossible to assemble.


### PR DESCRIPTION
## Summary

Stamps v0.9.2. The release fixes per-window tax metrics: `TaxDrag`, `TaxCostRatio`, `LTCG`, `STCG`, `QualifiedDividends`, and `NonQualifiedIncome` previously fell back to the all-history value for every window label, so a 1-year `TaxDrag` and a 5-year `TaxDrag` reported the same number. With this release, per-window after-tax returns can be assembled directly from the metrics table.