### PR TITLE
fix(portfolio): decouple liquidation from MaxLeverage; add WithMarginModel(RegT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Accounts enforce a configurable gross-leverage model, `(LongMarketValue + ShortMarketValue) / Equity`. `WithMaxLeverage` sets the entry-time cap that the simulated broker uses to reject orders (default `1.0`, i.e. no margin); `WithGrossMaintenanceLeverage` separately controls the liquidation threshold (default off, so only short-side maintenance margin can force liquidation). `WithMarginModel(RegT{Initial: 0.5, Maintenance: 0.25})` packages both knobs together for Reg T-style accounts. Strategies can read `Portfolio.GrossLeverage`, `MaxLeverage`, and `LeverageHeadroom` to size orders.
-- Strategies can declare a default `MaxLeverage` in their `Describe()` metadata; the engine applies it unless an explicit `WithMaxLeverage` (account or engine option) takes precedence.
-- `backtest` and `live` accept `--max-leverage` to override the strategy-supplied cap from the command line.
+- Accounts enforce a Reg T-style two-knob margin model. `WithMaxLeverage` sets the entry-time cap that the simulated broker uses to reject orders; `WithGrossMaintenanceLeverage` separately controls the liquidation threshold; `WithMarginModel(RegT{Initial: 0.5, Maintenance: 0.25})` packages both. Strategies can declare default values for both knobs in their `Describe()` metadata, and can read `Portfolio.GrossLeverage`, `MaxLeverage`, `GrossMaintenanceLeverage`, and `LeverageHeadroom` to size orders.
+- `backtest` and `live` accept `--margin-model {regt,cash}` (default `regt`) to pick a packaged margin model, plus `--max-leverage` and `--gross-maintenance-leverage` to override either knob individually.
 
 ### Changed
 
-- `MarginDeficiency` returns the dollar amount of position notional that must be unwound to restore compliance, taking the worst of the short-side maintenance breach and (when configured) the gross maintenance leverage breach. `MaxLeverage` is now an entry-time order gate only: adverse price drift above the cap no longer forces liquidation. Strategies that want a leverage-driven liquidation trigger should set `WithGrossMaintenanceLeverage` or `WithMarginModel` explicitly.
+- The default margin model is now Reg T (50% initial / 25% maintenance), matching real US brokerage accounts. Backtests that previously relied on the implicit cash-account default (`MaxLeverage 1.0`, no leverage-driven liquidation) should pass `--margin-model cash` on the command line, declare `MaxLeverage: 1.0` in `Describe()`, or call `portfolio.WithMaxLeverage(1.0)`.
+- `MarginDeficiency` takes the worst of the short-side maintenance breach and the gross maintenance leverage breach. `MaxLeverage` is an entry-time order gate only: adverse price drift above the cap no longer forces liquidation. Strategies that want a leverage-driven liquidation trigger separate from the account default should set `WithGrossMaintenanceLeverage` or `WithMarginModel` explicitly.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Accounts now enforce a configurable gross-leverage cap, `(LongMarketValue + ShortMarketValue) / Equity`. Strategies can read `Portfolio.GrossLeverage`, `MaxLeverage`, and `LeverageHeadroom` to size orders, and `WithMaxLeverage` sets the cap (default `1.0`, i.e. no margin). Orders that would push the account above the cap are rejected by the simulated broker; a continuous breach triggers the existing margin-call path, which now trims long and short positions proportionally.
+- Strategies can declare a default `MaxLeverage` in their `Describe()` metadata; the engine applies it unless an explicit `WithMaxLeverage` (account or engine option) takes precedence.
+- `backtest` and `live` accept `--max-leverage` to override the strategy-supplied cap from the command line.
+
+### Changed
+
+- `MarginDeficiency` returns the dollar amount of position notional that must be unwound to restore compliance, taking the worst of the short-side maintenance breach and the new gross-leverage breach. The previous return value was the equity gap on the short side only; auto-liquidation undercovered as a result.
+
+### Fixed
+
+- The trade-summary "Avg Loss" (and other dollar fields) no longer render as `$--9,223,372,036,854,775,808.00` when an upstream value is non-finite or out of range; the formatter now prints `$NaN`, `$Inf`, or `$-Inf` instead.
+- Transactions with non-finite `Qty`, `Price`, or `Amount` are dropped at `Account.Record` with a warning, rather than silently corrupting cash, tax-lot pricing, and trade-detail PnL. Trade aggregators (`AverageWin`, `AverageLoss`, `ProfitFactor`) also skip non-finite PnL entries when reading historical data.
+
 ## [0.9.3] - 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Accounts now enforce a configurable gross-leverage cap, `(LongMarketValue + ShortMarketValue) / Equity`. Strategies can read `Portfolio.GrossLeverage`, `MaxLeverage`, and `LeverageHeadroom` to size orders, and `WithMaxLeverage` sets the cap (default `1.0`, i.e. no margin). Orders that would push the account above the cap are rejected by the simulated broker; a continuous breach triggers the existing margin-call path, which now trims long and short positions proportionally.
+- Accounts enforce a configurable gross-leverage model, `(LongMarketValue + ShortMarketValue) / Equity`. `WithMaxLeverage` sets the entry-time cap that the simulated broker uses to reject orders (default `1.0`, i.e. no margin); `WithGrossMaintenanceLeverage` separately controls the liquidation threshold (default off, so only short-side maintenance margin can force liquidation). `WithMarginModel(RegT{Initial: 0.5, Maintenance: 0.25})` packages both knobs together for Reg T-style accounts. Strategies can read `Portfolio.GrossLeverage`, `MaxLeverage`, and `LeverageHeadroom` to size orders.
 - Strategies can declare a default `MaxLeverage` in their `Describe()` metadata; the engine applies it unless an explicit `WithMaxLeverage` (account or engine option) takes precedence.
 - `backtest` and `live` accept `--max-leverage` to override the strategy-supplied cap from the command line.
 
 ### Changed
 
-- `MarginDeficiency` returns the dollar amount of position notional that must be unwound to restore compliance, taking the worst of the short-side maintenance breach and the new gross-leverage breach. The previous return value was the equity gap on the short side only; auto-liquidation undercovered as a result.
+- `MarginDeficiency` returns the dollar amount of position notional that must be unwound to restore compliance, taking the worst of the short-side maintenance breach and (when configured) the gross maintenance leverage breach. `MaxLeverage` is now an entry-time order gate only: adverse price drift above the cap no longer forces liquidation. Strategies that want a leverage-driven liquidation trigger should set `WithGrossMaintenanceLeverage` or `WithMarginModel` explicitly.
 
 ### Fixed
 

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -45,7 +45,7 @@ func newBacktestCmd(strategy engine.Strategy) *cobra.Command {
 	cmd.Flags().String("benchmark", "", "Benchmark ticker for performance comparison")
 	cmd.Flags().String("risk-profile", "", "Risk profile (conservative, moderate, aggressive, none)")
 	cmd.Flags().Bool("tax", false, "Enable tax optimization")
-	cmd.Flags().Float64("max-leverage", 0, "Cap on gross leverage (LMV+SMV)/Equity. 0 uses the strategy's value if set, else 1.0 (cash account)")
+	registerMarginFlags(cmd)
 
 	return cmd
 }
@@ -163,7 +163,7 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		return fmt.Errorf("create data provider: %w", err)
 	}
 
-	maxLeverage, err := cmd.Flags().GetFloat64("max-leverage")
+	marginOpts, err := resolveMarginOptions(cmd)
 	if err != nil {
 		return err
 	}
@@ -180,9 +180,7 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		engine.WithUserParams(appliedFlags...),
 	}
 
-	if maxLeverage > 0 {
-		engineOpts = append(engineOpts, engine.WithMaxLeverage(maxLeverage))
-	}
+	engineOpts = append(engineOpts, marginOpts...)
 
 	if cfg.HasMiddleware() {
 		engineOpts = append(engineOpts, engine.WithMiddlewareConfig(*cfg))

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -45,6 +45,7 @@ func newBacktestCmd(strategy engine.Strategy) *cobra.Command {
 	cmd.Flags().String("benchmark", "", "Benchmark ticker for performance comparison")
 	cmd.Flags().String("risk-profile", "", "Risk profile (conservative, moderate, aggressive, none)")
 	cmd.Flags().Bool("tax", false, "Enable tax optimization")
+	cmd.Flags().Float64("max-leverage", 0, "Cap on gross leverage (LMV+SMV)/Equity. 0 uses the strategy's value if set, else 1.0 (cash account)")
 
 	return cmd
 }
@@ -162,6 +163,11 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		return fmt.Errorf("create data provider: %w", err)
 	}
 
+	maxLeverage, err := cmd.Flags().GetFloat64("max-leverage")
+	if err != nil {
+		return err
+	}
+
 	acct := portfolio.New(
 		portfolio.WithCash(cash, start),
 		portfolio.WithAllMetrics(),
@@ -172,6 +178,10 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 		engine.WithAssetProvider(provider),
 		engine.WithAccount(acct),
 		engine.WithUserParams(appliedFlags...),
+	}
+
+	if maxLeverage > 0 {
+		engineOpts = append(engineOpts, engine.WithMaxLeverage(maxLeverage))
 	}
 
 	if cfg.HasMiddleware() {

--- a/cli/live.go
+++ b/cli/live.go
@@ -29,7 +29,7 @@ func newLiveCmd(strategy engine.Strategy) *cobra.Command {
 	cmd.Flags().String("benchmark", "", "Benchmark ticker for performance comparison")
 	cmd.Flags().String("risk-profile", "", "Risk profile (conservative, moderate, aggressive, none)")
 	cmd.Flags().Bool("tax", false, "Enable tax optimization")
-	cmd.Flags().Float64("max-leverage", 0, "Cap on gross leverage (LMV+SMV)/Equity. 0 uses the strategy's value if set, else 1.0 (cash account)")
+	registerMarginFlags(cmd)
 
 	return cmd
 }
@@ -78,14 +78,12 @@ func runLive(cmd *cobra.Command, strategy engine.Strategy) error {
 		engineOpts = append(engineOpts, engine.WithBenchmarkTicker(benchmarkTicker))
 	}
 
-	maxLeverage, err := cmd.Flags().GetFloat64("max-leverage")
+	marginOpts, err := resolveMarginOptions(cmd)
 	if err != nil {
 		return err
 	}
 
-	if maxLeverage > 0 {
-		engineOpts = append(engineOpts, engine.WithMaxLeverage(maxLeverage))
-	}
+	engineOpts = append(engineOpts, marginOpts...)
 
 	eng := engine.New(strategy, engineOpts...)
 	defer eng.Close()

--- a/cli/live.go
+++ b/cli/live.go
@@ -29,6 +29,7 @@ func newLiveCmd(strategy engine.Strategy) *cobra.Command {
 	cmd.Flags().String("benchmark", "", "Benchmark ticker for performance comparison")
 	cmd.Flags().String("risk-profile", "", "Risk profile (conservative, moderate, aggressive, none)")
 	cmd.Flags().Bool("tax", false, "Enable tax optimization")
+	cmd.Flags().Float64("max-leverage", 0, "Cap on gross leverage (LMV+SMV)/Equity. 0 uses the strategy's value if set, else 1.0 (cash account)")
 
 	return cmd
 }
@@ -75,6 +76,15 @@ func runLive(cmd *cobra.Command, strategy engine.Strategy) error {
 
 	if benchmarkTicker != "" {
 		engineOpts = append(engineOpts, engine.WithBenchmarkTicker(benchmarkTicker))
+	}
+
+	maxLeverage, err := cmd.Flags().GetFloat64("max-leverage")
+	if err != nil {
+		return err
+	}
+
+	if maxLeverage > 0 {
+		engineOpts = append(engineOpts, engine.WithMaxLeverage(maxLeverage))
 	}
 
 	eng := engine.New(strategy, engineOpts...)

--- a/cli/margin.go
+++ b/cli/margin.go
@@ -1,0 +1,84 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+	"github.com/spf13/cobra"
+)
+
+// registerMarginFlags adds --margin-model, --max-leverage, and
+// --gross-maintenance-leverage to the given command. The default model
+// is Reg T (50% initial, 25% maintenance), matching real US brokerage
+// accounts.
+func registerMarginFlags(cmd *cobra.Command) {
+	cmd.Flags().String("margin-model", "regt",
+		"Margin model preset: 'regt' (50% initial / 25% maintenance) or 'cash' (no margin)")
+	cmd.Flags().Float64("max-leverage", 0,
+		"Override the entry-time gross leverage cap (LMV+SMV)/Equity. 0 uses the model preset or strategy value.")
+	cmd.Flags().Float64("gross-maintenance-leverage", 0,
+		"Override the gross leverage liquidation threshold. 0 uses the model preset or strategy value.")
+}
+
+// resolveMarginOptions reads the margin flags and returns the engine
+// options that express the requested margin configuration. Per-knob
+// flags (--max-leverage, --gross-maintenance-leverage) override the
+// model preset.
+func resolveMarginOptions(cmd *cobra.Command) ([]engine.Option, error) {
+	model, err := cmd.Flags().GetString("margin-model")
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []engine.Option
+
+	switch strings.ToLower(strings.TrimSpace(model)) {
+	case "regt", "":
+		opts = append(opts, engine.WithMarginModel(portfolio.RegT{Initial: 0.5, Maintenance: 0.25}))
+	case "cash":
+		// Cash account: 1x entry cap, no leverage-driven liquidation
+		// trigger. (Maintenance: 0 leaves the default 4.0 in place,
+		// but a cash account cannot mathematically reach 4x gross
+		// leverage so the trigger is dormant.)
+		opts = append(opts, engine.WithMarginModel(portfolio.RegT{Initial: 1.0}))
+	default:
+		return nil, fmt.Errorf("unknown --margin-model %q (expected 'regt' or 'cash')", model)
+	}
+
+	maxLev, err := cmd.Flags().GetFloat64("max-leverage")
+	if err != nil {
+		return nil, err
+	}
+
+	if maxLev > 0 {
+		opts = append(opts, engine.WithMaxLeverage(maxLev))
+	}
+
+	maintLev, err := cmd.Flags().GetFloat64("gross-maintenance-leverage")
+	if err != nil {
+		return nil, err
+	}
+
+	if maintLev > 0 {
+		opts = append(opts, engine.WithGrossMaintenanceLeverage(maintLev))
+	}
+
+	return opts, nil
+}

--- a/cli/summary/style.go
+++ b/cli/summary/style.go
@@ -217,11 +217,38 @@ func padLeft(text string, width int) string {
 	return strings.Repeat(" ", width-visible) + text
 }
 
-// formatDollar formats a float64 as "$1,234.56" with commas.
+// maxDollarWhole is the largest absolute whole-dollar amount the
+// formatter can render without int64 overflow during float-to-int
+// conversion. Beyond this, "$Inf" / "$-Inf" is rendered instead.
+const maxDollarWhole = float64(1 << 62)
+
+// formatDollar formats a float64 as "$1,234.56" with commas. Non-finite
+// or out-of-range values render as "$Inf" / "$-Inf" / "$NaN" rather
+// than producing garbage from a saturating float-to-int64 conversion.
 func formatDollar(val float64) string {
+	if math.IsNaN(val) {
+		return "$NaN"
+	}
+
+	if math.IsInf(val, 1) {
+		return "$Inf"
+	}
+
+	if math.IsInf(val, -1) {
+		return "$-Inf"
+	}
+
 	negative := val < 0
 	if negative {
 		val = -val
+	}
+
+	if val >= maxDollarWhole {
+		if negative {
+			return "$-Inf"
+		}
+
+		return "$Inf"
 	}
 
 	whole := int64(val)
@@ -232,7 +259,6 @@ func formatDollar(val float64) string {
 		cents = 0
 	}
 
-	// Format with commas.
 	wholeStr := formatWithCommas(whole)
 
 	if negative {

--- a/cli/summary/style_internal_test.go
+++ b/cli/summary/style_internal_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("formatDollar", func() {
+	It("formats positive amounts with commas and cents", func() {
+		Expect(formatDollar(1234.56)).To(Equal("$1,234.56"))
+	})
+
+	It("formats negative amounts with a leading minus", func() {
+		Expect(formatDollar(-1234.56)).To(Equal("$-1,234.56"))
+	})
+
+	It("renders NaN as $NaN instead of garbage", func() {
+		Expect(formatDollar(math.NaN())).To(Equal("$NaN"))
+	})
+
+	It("renders +Inf as $Inf instead of garbage", func() {
+		Expect(formatDollar(math.Inf(1))).To(Equal("$Inf"))
+	})
+
+	It("renders -Inf as $-Inf instead of garbage", func() {
+		Expect(formatDollar(math.Inf(-1))).To(Equal("$-Inf"))
+	})
+
+	It("renders out-of-range positive values as $Inf", func() {
+		Expect(formatDollar(1e30)).To(Equal("$Inf"))
+	})
+
+	It("renders out-of-range negative values as $-Inf", func() {
+		Expect(formatDollar(-1e30)).To(Equal("$-Inf"))
+	})
+})

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -82,7 +82,9 @@ type MarginCallHandler interface {
 
 The handler receives the engine, the current portfolio (read-only), and a dedicated batch on which to queue orders. The batch bypasses middleware (it must not be further transformed by risk/tax rules) and is executed immediately after `OnMarginCall` returns. If the handler clears the deficiency the step continues; otherwise the engine falls back to automatic liquidation.
 
-If the strategy does not implement `MarginCallHandler`, the engine auto-liquidates short positions proportionally until the deficiency is resolved. Returning an error from the handler halts the run.
+If the strategy does not implement `MarginCallHandler`, the engine auto-liquidates positions proportionally across the gross book (long *and* short) until the deficiency is resolved. Returning an error from the handler halts the run.
+
+The margin check fires on two breaches: the short-side maintenance margin (`SMV * maintenanceRate > equity`) and the gross-leverage cap configured via `portfolio.WithMaxLeverage` (`(LMV + SMV) / equity > maxLeverage`). The default cap is `1.0`, which models a cash account; set it higher to opt into Reg T-style leverage. The simulated broker also rejects new orders that would breach the cap at submission time, so the margin-call path mostly catches breaches caused by adverse price moves on existing positions.
 
 ### Stock split handling
 

--- a/docs/portfolio.md
+++ b/docs/portfolio.md
@@ -361,8 +361,11 @@ p.LongMarketValue()    // total market value of long positions
 p.ShortMarketValue()   // total absolute market value of short positions (always >= 0)
 p.Equity()             // cash + long market value − short market value
 p.BuyingPower()        // cash available for new positions given current margin
-p.MarginRatio()        // equity / (long + short market value); NaN when no positions
-p.MarginDeficiency()   // shortfall below the maintenance margin threshold; 0 if compliant
+p.MarginRatio()        // equity / short market value; NaN when no shorts
+p.MarginDeficiency()   // notional that must be unwound to restore compliance; 0 if compliant
+p.GrossLeverage()      // (LongMarketValue + ShortMarketValue) / Equity
+p.MaxLeverage()        // configured cap (default 1.0)
+p.LeverageHeadroom()   // additional notional that can be opened before the cap
 ```
 
 Margin parameters are configured when constructing the account:
@@ -372,10 +375,13 @@ acct := portfolio.New(
     portfolio.WithCash(100_000, startDate),
     portfolio.WithInitialMargin(0.50),      // Regulation T default: 50%
     portfolio.WithMaintenanceMargin(0.25),  // typical broker minimum: 25%
+    portfolio.WithMaxLeverage(2.0),         // Reg T-style 2x; default is 1.0 (cash account)
 )
 ```
 
-`WithInitialMargin` sets the fraction of a new position's value that must be covered by equity. `WithMaintenanceMargin` sets the ongoing minimum equity fraction. If `MarginDeficiency()` is positive, the account is below the maintenance threshold and new orders that increase exposure are rejected by the engine.
+`WithInitialMargin` sets the fraction of a new short position's value that must be covered by equity. `WithMaintenanceMargin` sets the ongoing minimum equity fraction for shorts. `WithMaxLeverage` caps gross leverage `(LMV + SMV) / equity` and applies to long *and* short notional alike; the simulated broker rejects orders that would push the account over the cap. The default cap is `1.0`, which models a cash account: every long buy must be backed by available cash, and shorts are still subject to the initial-margin rule above.
+
+If `MarginDeficiency()` is positive, the account is over the maintenance threshold or above the leverage cap, and the engine triggers a margin call. The strategy can implement `engine.MarginCallHandler` to liquidate on its own terms; otherwise the engine trims long and short positions proportionally to restore compliance.
 
 ## Borrow fees and dividend obligations
 

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -750,15 +750,42 @@ During `Compute`, use the portfolio to inspect margin health before placing orde
 
 ```go
 ratio      := port.MarginRatio()      // equity / short market value; NaN if no shorts
-deficiency := port.MarginDeficiency() // dollars needed to restore maintenance margin; 0 if healthy
+deficiency := port.MarginDeficiency() // notional that must be unwound to restore margin; 0 if healthy
 buyPower   := port.BuyingPower()      // cash minus margin reserved for existing shorts
+gross      := port.GrossLeverage()    // (LMV + SMV) / equity; 0 when flat
+cap        := port.MaxLeverage()      // configured cap; default 1.0 (cash account)
+headroom   := port.LeverageHeadroom() // additional notional that can be opened before the cap
 ```
 
-`MarginRatio` returns `NaN` when there are no short positions. The engine triggers a margin call when `MarginDeficiency()` is greater than zero (equity has fallen below the maintenance margin rate, which defaults to 30% of short market value).
+`MarginRatio` returns `NaN` when there are no short positions. The engine triggers a margin call when `MarginDeficiency()` is greater than zero, which happens on either of two breaches: the short-side maintenance threshold (defaults to 30% of short market value), or the configured gross-leverage cap. The cap defaults to `1.0` (cash account); set it via `portfolio.WithMaxLeverage` to opt into margin (e.g., `2.0` for Reg T-style leverage). The simulated broker rejects orders that would push the account above the cap, so size new entries against `LeverageHeadroom`.
+
+#### Declaring a strategy default
+
+Strategies that need leverage can declare it once in `Describe()` so callers don't have to remember to pass it:
+
+```go
+func (s *PairsStrategy) Describe() engine.StrategyDescription {
+    return engine.StrategyDescription{
+        Schedule:    "0 16 * * 1-5",
+        Benchmark:   "SPY",
+        MaxLeverage: 2.0,
+    }
+}
+```
+
+The precedence order, highest first:
+
+1. CLI: `pvbt backtest --max-leverage 1.5` (or `live --max-leverage 1.5`).
+2. Engine option: `engine.WithMaxLeverage(1.5)`.
+3. Account option: `portfolio.WithMaxLeverage(1.5)`.
+4. Strategy: `Describe().MaxLeverage`.
+5. Default: `1.0`.
+
+Anything from step 1, 2, or 3 silences the strategy default. The CLI flag exists so a user running an unfamiliar strategy can clamp it without editing the source.
 
 ### MarginCallHandler
 
-By default, when a margin call is triggered, the engine automatically covers short positions proportionally until the deficiency is cleared. Strategies can override this behaviour by implementing the `MarginCallHandler` interface from the `engine` package:
+By default, when a margin call is triggered, the engine automatically trims long and short positions proportionally across the gross book until the deficiency is cleared. Strategies can override this behaviour by implementing the `MarginCallHandler` interface from the `engine` package:
 
 ```go
 type MarginCallHandler interface {

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -187,6 +187,16 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 		acct.SetBenchmark(e.benchmark)
 	}
 
+	if e.maxLeverage > 0 {
+		acct.SetMaxLeverage(e.maxLeverage)
+	} else if !acct.HasMaxLeverage() {
+		if desc, ok := e.strategy.(Descriptor); ok {
+			if maxLev := desc.Describe().MaxLeverage; maxLev > 0 {
+				acct.SetMaxLeverage(maxLev)
+			}
+		}
+	}
+
 	// 6b. Apply config-driven middleware if provided.
 	if e.middlewareConfig != nil {
 		if err := e.buildMiddlewareFromConfig(); err != nil {
@@ -256,6 +266,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 	if sb, ok := e.broker.(*SimulatedBroker); ok {
 		sb.SetPortfolio(acct)
 		sb.SetBorrowRate(acct.BorrowRate())
+		sb.SetMaxLeverage(acct.MaxLeverage())
 	}
 
 	// Connect the broker (no-op for SimulatedBroker, authenticates for live brokers).

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -187,15 +187,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 		acct.SetBenchmark(e.benchmark)
 	}
 
-	if e.maxLeverage > 0 {
-		acct.SetMaxLeverage(e.maxLeverage)
-	} else if !acct.HasMaxLeverage() {
-		if desc, ok := e.strategy.(Descriptor); ok {
-			if maxLev := desc.Describe().MaxLeverage; maxLev > 0 {
-				acct.SetMaxLeverage(maxLev)
-			}
-		}
-	}
+	applyMarginConfig(e, acct)
 
 	// 6b. Apply config-driven middleware if provided.
 	if e.middlewareConfig != nil {

--- a/engine/descriptor.go
+++ b/engine/descriptor.go
@@ -36,11 +36,20 @@ type StrategyDescription struct {
 	Benchmark   string    `json:"benchmark,omitempty"`
 	Warmup      int       `json:"warmup,omitempty"`
 	// MaxLeverage caps gross leverage for the account, expressed as
-	// (LongMarketValue + ShortMarketValue) / Equity. Zero means
-	// "unspecified" -- the engine falls back to the account's own setting,
-	// or the global default of 1.0 (cash account). The CLI --max-leverage
-	// flag overrides this value when set.
+	// (LongMarketValue + ShortMarketValue) / Equity. Used as an
+	// entry-time gate: orders that would push the account above this
+	// ratio are rejected. Zero means "unspecified" -- the engine falls
+	// back to the account's own setting or the global default of 2.0
+	// (Reg T-style 2x leverage). The CLI --max-leverage flag overrides
+	// this value when set.
 	MaxLeverage float64 `json:"maxLeverage,omitempty"`
+
+	// GrossMaintenanceLeverage triggers liquidation when gross
+	// leverage exceeds this ratio. Zero means "unspecified" -- the
+	// engine falls back to the account's own setting or the global
+	// default of 4.0 (Reg T-style 25% maintenance). The CLI
+	// --gross-maintenance-leverage flag overrides this value when set.
+	GrossMaintenanceLeverage float64 `json:"grossMaintenanceLeverage,omitempty"`
 }
 
 // ParameterInfo is the JSON-serializable form of a Parameter.
@@ -53,19 +62,20 @@ type ParameterInfo struct {
 
 // StrategyInfo is the complete serializable description of a strategy.
 type StrategyInfo struct {
-	Name        string                       `json:"name"`
-	ShortCode   string                       `json:"shortcode,omitempty"`
-	Description string                       `json:"description,omitempty"`
-	Source      string                       `json:"source,omitempty"`
-	Version     string                       `json:"version,omitempty"`
-	VersionDate time.Time                    `json:"versionDate,omitzero"`
-	Schedule    string                       `json:"schedule,omitempty"`
-	Benchmark   string                       `json:"benchmark,omitempty"`
-	RiskFree    string                       `json:"riskFree,omitempty"`
-	Warmup      int                          `json:"warmup,omitempty"`
-	MaxLeverage float64                      `json:"maxLeverage,omitempty"`
-	Parameters  []ParameterInfo              `json:"parameters"`
-	Suggestions map[string]map[string]string `json:"suggestions,omitempty"`
+	Name                     string                       `json:"name"`
+	ShortCode                string                       `json:"shortcode,omitempty"`
+	Description              string                       `json:"description,omitempty"`
+	Source                   string                       `json:"source,omitempty"`
+	Version                  string                       `json:"version,omitempty"`
+	VersionDate              time.Time                    `json:"versionDate,omitzero"`
+	Schedule                 string                       `json:"schedule,omitempty"`
+	Benchmark                string                       `json:"benchmark,omitempty"`
+	RiskFree                 string                       `json:"riskFree,omitempty"`
+	Warmup                   int                          `json:"warmup,omitempty"`
+	MaxLeverage              float64                      `json:"maxLeverage,omitempty"`
+	GrossMaintenanceLeverage float64                      `json:"grossMaintenanceLeverage,omitempty"`
+	Parameters               []ParameterInfo              `json:"parameters"`
+	Suggestions              map[string]map[string]string `json:"suggestions,omitempty"`
 }
 
 // DescribeStrategy builds a StrategyInfo from the strategy's metadata.
@@ -85,6 +95,7 @@ func DescribeStrategy(strategy Strategy) StrategyInfo {
 		info.Benchmark = description.Benchmark
 		info.Warmup = description.Warmup
 		info.MaxLeverage = description.MaxLeverage
+		info.GrossMaintenanceLeverage = description.GrossMaintenanceLeverage
 	}
 
 	info.RiskFree = "FRED:DGS3MO"

--- a/engine/descriptor.go
+++ b/engine/descriptor.go
@@ -35,6 +35,12 @@ type StrategyDescription struct {
 	Schedule    string    `json:"schedule,omitempty"`
 	Benchmark   string    `json:"benchmark,omitempty"`
 	Warmup      int       `json:"warmup,omitempty"`
+	// MaxLeverage caps gross leverage for the account, expressed as
+	// (LongMarketValue + ShortMarketValue) / Equity. Zero means
+	// "unspecified" -- the engine falls back to the account's own setting,
+	// or the global default of 1.0 (cash account). The CLI --max-leverage
+	// flag overrides this value when set.
+	MaxLeverage float64 `json:"maxLeverage,omitempty"`
 }
 
 // ParameterInfo is the JSON-serializable form of a Parameter.
@@ -57,6 +63,7 @@ type StrategyInfo struct {
 	Benchmark   string                       `json:"benchmark,omitempty"`
 	RiskFree    string                       `json:"riskFree,omitempty"`
 	Warmup      int                          `json:"warmup,omitempty"`
+	MaxLeverage float64                      `json:"maxLeverage,omitempty"`
 	Parameters  []ParameterInfo              `json:"parameters"`
 	Suggestions map[string]map[string]string `json:"suggestions,omitempty"`
 }
@@ -77,6 +84,7 @@ func DescribeStrategy(strategy Strategy) StrategyInfo {
 		info.Schedule = description.Schedule
 		info.Benchmark = description.Benchmark
 		info.Warmup = description.Warmup
+		info.MaxLeverage = description.MaxLeverage
 	}
 
 	info.RiskFree = "FRED:DGS3MO"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -50,19 +50,21 @@ type Engine struct {
 	riskFreeIndex      map[time.Time]int // date -> index into riskFreeValues, built once during init
 
 	// configuration (set via options, used during init)
-	cacheMaxBytes        int64
-	initialDeposit       float64
-	broker               broker.Broker
-	snapshot             portfolio.PortfolioSnapshot
-	dateRangeMode        DateRangeMode
-	warmup               int
-	benchmarkTicker      string
-	maxLeverage          float64
-	fillBaseModel        broker.BaseModel
-	fillAdjusters        []broker.Adjuster
-	middlewareConfig     *MiddlewareConfig
-	fundamentalDimension string
-	progressCallback     ProgressCallback
+	cacheMaxBytes            int64
+	initialDeposit           float64
+	broker                   broker.Broker
+	snapshot                 portfolio.PortfolioSnapshot
+	dateRangeMode            DateRangeMode
+	warmup                   int
+	benchmarkTicker          string
+	maxLeverage              float64
+	grossMaintenanceLeverage float64
+	marginModel              *portfolio.RegT
+	fillBaseModel            broker.BaseModel
+	fillAdjusters            []broker.Adjuster
+	middlewareConfig         *MiddlewareConfig
+	fundamentalDimension     string
+	progressCallback         ProgressCallback
 
 	// userParams names strategy fields the caller has explicitly set
 	// (via CLI flags, presets, ApplyParams). hydrateFields skips applying

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -57,6 +57,7 @@ type Engine struct {
 	dateRangeMode        DateRangeMode
 	warmup               int
 	benchmarkTicker      string
+	maxLeverage          float64
 	fillBaseModel        broker.BaseModel
 	fillAdjusters        []broker.Adjuster
 	middlewareConfig     *MiddlewareConfig

--- a/engine/live.go
+++ b/engine/live.go
@@ -122,15 +122,7 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 		acct.SetBenchmark(e.benchmark)
 	}
 
-	if e.maxLeverage > 0 {
-		acct.SetMaxLeverage(e.maxLeverage)
-	} else if !acct.HasMaxLeverage() {
-		if desc, ok := e.strategy.(Descriptor); ok {
-			if maxLev := desc.Describe().MaxLeverage; maxLev > 0 {
-				acct.SetMaxLeverage(maxLev)
-			}
-		}
-	}
+	applyMarginConfig(e, acct)
 
 	// 6b. Apply config-driven middleware if provided.
 	if e.middlewareConfig != nil {

--- a/engine/live.go
+++ b/engine/live.go
@@ -122,6 +122,16 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 		acct.SetBenchmark(e.benchmark)
 	}
 
+	if e.maxLeverage > 0 {
+		acct.SetMaxLeverage(e.maxLeverage)
+	} else if !acct.HasMaxLeverage() {
+		if desc, ok := e.strategy.(Descriptor); ok {
+			if maxLev := desc.Describe().MaxLeverage; maxLev > 0 {
+				acct.SetMaxLeverage(maxLev)
+			}
+		}
+	}
+
 	// 6b. Apply config-driven middleware if provided.
 	if e.middlewareConfig != nil {
 		if err := e.buildMiddlewareFromConfig(); err != nil {

--- a/engine/margin_call.go
+++ b/engine/margin_call.go
@@ -66,7 +66,7 @@ func (eng *Engine) checkAndHandleMarginCall(ctx context.Context, acct portfolio.
 		}
 	}
 
-	return eng.autoLiquidateShorts(ctx, acct, date)
+	return eng.autoLiquidate(ctx, acct, date)
 }
 
 // setMarginPrices fetches current close prices for held assets and stores
@@ -95,41 +95,46 @@ func (eng *Engine) setMarginPrices(ctx context.Context, acct portfolio.Portfolio
 	return nil
 }
 
-// autoLiquidateShorts covers short positions proportionally to restore
-// maintenance margin.
-func (eng *Engine) autoLiquidateShorts(ctx context.Context, acct portfolio.PortfolioManager, date time.Time) error {
+// autoLiquidate trims gross notional proportionally across long and
+// short positions to restore margin compliance.
+func (eng *Engine) autoLiquidate(ctx context.Context, acct portfolio.PortfolioManager, date time.Time) error {
 	deficiency := acct.MarginDeficiency()
 	if deficiency == 0 {
 		return nil
 	}
 
-	shortMarketValue := acct.ShortMarketValue()
-	if shortMarketValue == 0 {
+	gross := acct.LongMarketValue() + acct.ShortMarketValue()
+	if gross <= 0 {
 		return nil
 	}
 
-	coverFraction := deficiency / shortMarketValue
-	if coverFraction > 1 {
-		coverFraction = 1
+	unwindFraction := deficiency / gross
+	if unwindFraction > 1 {
+		unwindFraction = 1
 	}
 
 	batch := acct.NewBatch(date)
 	batch.SkipMiddleware = true
 
 	for ast, qty := range acct.Holdings() {
-		if qty >= 0 {
+		if qty == 0 {
 			continue
 		}
 
-		coverQty := math.Ceil(math.Abs(qty) * coverFraction)
-		if coverQty > math.Abs(qty) {
-			coverQty = math.Abs(qty)
+		closeQty := math.Ceil(math.Abs(qty) * unwindFraction)
+		if closeQty > math.Abs(qty) {
+			closeQty = math.Abs(qty)
+		}
+
+		side := broker.Sell
+		if qty < 0 {
+			side = broker.Buy
 		}
 
 		batch.Orders = append(batch.Orders, broker.Order{
 			Asset:         ast,
-			Side:          broker.Buy,
-			Qty:           coverQty,
+			Side:          side,
+			Qty:           closeQty,
 			OrderType:     broker.Market,
 			TimeInForce:   broker.Day,
 			Justification: "margin call auto-liquidation",
@@ -141,7 +146,7 @@ func (eng *Engine) autoLiquidateShorts(ctx context.Context, acct portfolio.Portf
 	}
 
 	if err := acct.ExecuteBatch(ctx, batch); err != nil {
-		return fmt.Errorf("engine: auto-liquidate shorts: %w", err)
+		return fmt.Errorf("engine: auto-liquidate: %w", err)
 	}
 
 	if acct.MarginDeficiency() > 0 {

--- a/engine/margin_call_test.go
+++ b/engine/margin_call_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Margin Call", func() {
 			strategy := &leveragedBuyStrategy{target: testStock, qty: 200}
 			acct := portfolio.New(
 				portfolio.WithCash(10_000, time.Time{}),
-				// Default cap (1.0) means at most $10k of long notional.
+				portfolio.WithMaxLeverage(1.0), // cash-account cap
 			)
 
 			eng := engine.New(strategy,

--- a/engine/margin_call_test.go
+++ b/engine/margin_call_test.go
@@ -89,6 +89,32 @@ func (s *marginCallHandlerStrategy) OnMarginCall(ctx context.Context, _ *engine.
 	return nil
 }
 
+// leveragedBuyStrategy attempts to buy a fixed quantity on the first
+// Compute call. The leverage cap should reject the order in a cash
+// account. The optional declaredMaxLeverage field is returned from
+// Describe to exercise strategy-supplied caps.
+type leveragedBuyStrategy struct {
+	target              asset.Asset
+	qty                 float64
+	declaredMaxLeverage float64
+	callCount           int
+}
+
+func (s *leveragedBuyStrategy) Name() string           { return "leveragedBuy" }
+func (s *leveragedBuyStrategy) Setup(_ *engine.Engine) {}
+func (s *leveragedBuyStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "0 16 * * 1-5", MaxLeverage: s.declaredMaxLeverage}
+}
+
+func (s *leveragedBuyStrategy) Compute(ctx context.Context, _ *engine.Engine, _ portfolio.Portfolio, batch *portfolio.Batch) error {
+	s.callCount++
+	if s.callCount == 1 {
+		batch.Order(ctx, s.target, portfolio.Buy, s.qty)
+	}
+
+	return nil
+}
+
 var _ = Describe("Margin Call", func() {
 	var (
 		testStock     asset.Asset
@@ -230,6 +256,133 @@ var _ = Describe("Margin Call", func() {
 			finalPosition := fund.Position(testStock)
 			Expect(finalPosition).To(BeNumerically(">=", 0),
 				"expected handler to fully cover shorts, got position %v", finalPosition)
+		})
+	})
+
+	Context("max leverage", func() {
+		It("rejects a buy order that would push gross leverage above the cap", func() {
+			// Strategy buys more shares than the cash account can support.
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			testDF := makeMarginTestData(100.0, 100.0, 5, dataStart)
+			provider := data.NewTestProvider(allMetrics, testDF)
+
+			strategy := &leveragedBuyStrategy{target: testStock, qty: 200}
+			acct := portfolio.New(
+				portfolio.WithCash(10_000, time.Time{}),
+				// Default cap (1.0) means at most $10k of long notional.
+			)
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(provider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithAccount(acct),
+			)
+
+			btStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			btEnd := time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)
+
+			fund, err := eng.Backtest(context.Background(), btStart, btEnd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fund).NotTo(BeNil())
+
+			// Order for 200 shares @ $100 = $20k notional would breach the
+			// 1.0x cap on a $10k account. The broker should have rejected it,
+			// leaving the position at 0.
+			Expect(fund.Position(testStock)).To(Equal(0.0))
+		})
+
+		It("honours MaxLeverage declared in Describe()", func() {
+			// Strategy declares 2.0 in Describe; the buy that breached the
+			// 1.0 default in the previous test should now succeed.
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			testDF := makeMarginTestData(100.0, 100.0, 5, dataStart)
+			provider := data.NewTestProvider(allMetrics, testDF)
+
+			strategy := &leveragedBuyStrategy{
+				target:              testStock,
+				qty:                 200,
+				declaredMaxLeverage: 2.0,
+			}
+			acct := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(provider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithAccount(acct),
+			)
+
+			btStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			btEnd := time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)
+
+			fund, err := eng.Backtest(context.Background(), btStart, btEnd)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fund.Position(testStock)).To(Equal(200.0))
+			Expect(fund.MaxLeverage()).To(Equal(2.0))
+		})
+
+		It("WithMaxLeverage engine option overrides the strategy value", func() {
+			// Strategy declares 2.0 but the engine option clamps to 1.0,
+			// so the buy is rejected.
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			testDF := makeMarginTestData(100.0, 100.0, 5, dataStart)
+			provider := data.NewTestProvider(allMetrics, testDF)
+
+			strategy := &leveragedBuyStrategy{
+				target:              testStock,
+				qty:                 200,
+				declaredMaxLeverage: 2.0,
+			}
+			acct := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(provider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithAccount(acct),
+				engine.WithMaxLeverage(1.0),
+			)
+
+			btStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			btEnd := time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)
+
+			fund, err := eng.Backtest(context.Background(), btStart, btEnd)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fund.Position(testStock)).To(Equal(0.0))
+			Expect(fund.MaxLeverage()).To(Equal(1.0))
+		})
+
+		It("account-level WithMaxLeverage takes priority over the strategy value when no engine option is set", func() {
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			testDF := makeMarginTestData(100.0, 100.0, 5, dataStart)
+			provider := data.NewTestProvider(allMetrics, testDF)
+
+			strategy := &leveragedBuyStrategy{
+				target:              testStock,
+				qty:                 200,
+				declaredMaxLeverage: 4.0,
+			}
+			acct := portfolio.New(
+				portfolio.WithCash(10_000, time.Time{}),
+				portfolio.WithMaxLeverage(1.5),
+			)
+
+			eng := engine.New(strategy,
+				engine.WithDataProvider(provider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithAccount(acct),
+			)
+
+			btStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			btEnd := time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)
+
+			fund, err := eng.Backtest(context.Background(), btStart, btEnd)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Account cap (1.5) wins over strategy (4.0); buy of 20k notional
+			// on 10k equity needs >= 2.0, so it is rejected.
+			Expect(fund.Position(testStock)).To(Equal(0.0))
+			Expect(fund.MaxLeverage()).To(Equal(1.5))
 		})
 	})
 })

--- a/engine/margin_config.go
+++ b/engine/margin_config.go
@@ -1,0 +1,68 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import "github.com/penny-vault/pvbt/portfolio"
+
+// applyMarginConfig resolves margin settings onto the account in this
+// precedence order (lowest to highest): account default, strategy
+// Describe() scalars, engine WithMarginModel preset, engine
+// WithMaxLeverage / WithGrossMaintenanceLeverage per-knob overrides.
+// Account values configured directly via portfolio options take effect
+// at construction time and are not overwritten unless an engine option
+// or strategy descriptor explicitly supplies a value.
+func applyMarginConfig(eng *Engine, acct portfolio.PortfolioManager) {
+	var (
+		descMax   float64
+		descMaint float64
+	)
+
+	if desc, ok := eng.strategy.(Descriptor); ok {
+		description := desc.Describe()
+		descMax = description.MaxLeverage
+		descMaint = description.GrossMaintenanceLeverage
+	}
+
+	// Strategy-supplied scalars (only when the account has not already
+	// been configured via portfolio options).
+	if descMax > 0 && !acct.HasMaxLeverage() {
+		acct.SetMaxLeverage(descMax)
+	}
+
+	if descMaint > 0 && !acct.HasGrossMaintenanceLeverage() {
+		acct.SetGrossMaintenanceLeverage(descMaint)
+	}
+
+	// WithMarginModel preset (engine option).
+	if eng.marginModel != nil {
+		if eng.marginModel.Initial > 0 {
+			acct.SetMaxLeverage(1.0 / eng.marginModel.Initial)
+		}
+
+		if eng.marginModel.Maintenance > 0 {
+			acct.SetGrossMaintenanceLeverage(1.0 / eng.marginModel.Maintenance)
+		}
+	}
+
+	// Per-knob overrides (engine options) take precedence over presets.
+	if eng.maxLeverage > 0 {
+		acct.SetMaxLeverage(eng.maxLeverage)
+	}
+
+	if eng.grossMaintenanceLeverage > 0 {
+		acct.SetGrossMaintenanceLeverage(eng.grossMaintenanceLeverage)
+	}
+}

--- a/engine/option.go
+++ b/engine/option.go
@@ -75,11 +75,42 @@ func WithPortfolioSnapshot(snap portfolio.PortfolioSnapshot) Option {
 // takes priority over any value supplied by the strategy's
 // Describe().MaxLeverage. Values <= 0 are ignored, in which case the
 // strategy's value (or the account default of 1.0) applies.
+//
+// MaxLeverage is an entry-time order gate. Liquidation is driven by
+// short-side maintenance margin and, when configured, gross
+// maintenance leverage. See WithGrossMaintenanceLeverage.
 func WithMaxLeverage(ratio float64) Option {
 	return func(e *Engine) {
 		if ratio > 0 {
 			e.maxLeverage = ratio
 		}
+	}
+}
+
+// WithGrossMaintenanceLeverage triggers a margin call when gross
+// leverage, (LongMarketValue + ShortMarketValue) / Equity, exceeds the
+// given ratio. This takes priority over any value supplied by the
+// strategy's Describe().GrossMaintenanceLeverage and over any preset
+// applied by WithMarginModel. Values <= 0 are ignored, in which case
+// the strategy's value applies if set; otherwise the account default
+// of 4.0 (Reg T-style 25% maintenance) applies.
+func WithGrossMaintenanceLeverage(ratio float64) Option {
+	return func(e *Engine) {
+		if ratio > 0 {
+			e.grossMaintenanceLeverage = ratio
+		}
+	}
+}
+
+// WithMarginModel applies a packaged margin model to the engine's
+// account. WithMarginModel is applied before any per-knob overrides,
+// so WithMaxLeverage and WithGrossMaintenanceLeverage win when used
+// together with it. Pass portfolio.RegT{Initial: 0.5, Maintenance:
+// 0.25} for canonical Reg T behavior, or portfolio.RegT{Initial: 1.0,
+// Maintenance: math.Inf(1)} for a cash account.
+func WithMarginModel(model portfolio.RegT) Option {
+	return func(e *Engine) {
+		e.marginModel = &model
 	}
 }
 

--- a/engine/option.go
+++ b/engine/option.go
@@ -70,6 +70,19 @@ func WithPortfolioSnapshot(snap portfolio.PortfolioSnapshot) Option {
 	}
 }
 
+// WithMaxLeverage caps gross leverage for the engine's account,
+// expressed as (LongMarketValue + ShortMarketValue) / Equity. This
+// takes priority over any value supplied by the strategy's
+// Describe().MaxLeverage. Values <= 0 are ignored, in which case the
+// strategy's value (or the account default of 1.0) applies.
+func WithMaxLeverage(ratio float64) Option {
+	return func(e *Engine) {
+		if ratio > 0 {
+			e.maxLeverage = ratio
+		}
+	}
+}
+
 // WithBenchmarkTicker sets the benchmark asset by ticker. This is resolved
 // to an asset during engine initialization and takes priority over any
 // benchmark suggested by the strategy's Describe() method.

--- a/engine/simulated_broker.go
+++ b/engine/simulated_broker.go
@@ -47,6 +47,7 @@ type SimulatedBroker struct {
 	groups            map[string][]string // groupID -> orderIDs
 	portfolio         portfolio.Portfolio
 	initialMarginRate float64
+	maxLeverage       float64
 	borrowRate        float64
 	lastPrices        map[asset.Asset]float64
 	fillPipeline      *broker.Pipeline
@@ -84,6 +85,14 @@ func (b *SimulatedBroker) SetInitialMarginRate(rate float64) {
 // SetBorrowRate sets the annualized borrow fee rate for short positions.
 func (b *SimulatedBroker) SetBorrowRate(rate float64) {
 	b.borrowRate = rate
+}
+
+// SetMaxLeverage sets the gross-leverage cap (LMV+SMV)/Equity used to
+// reject orders that would push the account above the cap. Values <= 0
+// disable the broker-level check; the account-level default still
+// applies via portfolio.Account.MaxLeverage.
+func (b *SimulatedBroker) SetMaxLeverage(ratio float64) {
+	b.maxLeverage = ratio
 }
 
 // SetFillPipeline replaces the default close-price fill pipeline.
@@ -158,24 +167,33 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 		return nil
 	}
 
-	// Check initial margin for short-opening sells.
-	if order.Side == broker.Sell && b.portfolio != nil {
+	// Margin checks: initial margin on short-opening sells, and the
+	// gross-leverage cap on any order that increases gross notional.
+	if b.portfolio != nil {
 		currentPos := b.portfolio.Position(order.Asset)
-		if currentPos-result.Quantity < 0 {
-			shortIncrease := result.Quantity
-			if currentPos > 0 {
-				shortIncrease = result.Quantity - currentPos
-			}
 
-			newShortValue := b.portfolio.ShortMarketValue() + shortIncrease*result.Price
-			equity := b.portfolio.Equity()
+		signedDelta := result.Quantity
+		if order.Side == broker.Sell {
+			signedDelta = -signedDelta
+		}
 
+		postQty := currentPos + signedDelta
+
+		preLong := math.Max(currentPos, 0)
+		preShort := math.Max(-currentPos, 0)
+		postLong := math.Max(postQty, 0)
+		postShort := math.Max(-postQty, 0)
+
+		newShortValue := b.portfolio.ShortMarketValue() + (postShort-preShort)*result.Price
+		equity := b.portfolio.Equity()
+
+		if order.Side == broker.Sell && postQty < 0 && newShortValue > 0 {
 			initialRate := b.initialMarginRate
 			if initialRate == 0 {
 				initialRate = 0.50
 			}
 
-			if newShortValue > 0 && equity/newShortValue < initialRate {
+			if equity/newShortValue < initialRate {
 				zerolog.Ctx(ctx).Warn().
 					Str("asset", order.Asset.Ticker).
 					Float64("equity", equity).
@@ -183,6 +201,34 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 					Msg("order rejected: insufficient margin")
 
 				return nil
+			}
+		}
+
+		if b.maxLeverage > 0 {
+			preLongValue := b.portfolio.LongMarketValue()
+			preGross := preLongValue + b.portfolio.ShortMarketValue()
+			newLongValue := preLongValue + (postLong-preLong)*result.Price
+			postGross := newLongValue + newShortValue
+
+			// Only reject orders that increase gross notional; allow
+			// closing trades through even if the account is already
+			// above the cap (the margin-call path handles that).
+			if postGross > preGross {
+				breach := equity <= 0
+				if !breach {
+					breach = postGross/equity > b.maxLeverage
+				}
+
+				if breach {
+					zerolog.Ctx(ctx).Warn().
+						Str("asset", order.Asset.Ticker).
+						Float64("equity", equity).
+						Float64("post_gross", postGross).
+						Float64("max_leverage", b.maxLeverage).
+						Msg("order rejected: gross leverage cap")
+
+					return nil
+				}
 			}
 		}
 	}

--- a/engine/simulated_broker_test.go
+++ b/engine/simulated_broker_test.go
@@ -80,6 +80,7 @@ func (m *mockPortfolio) MarginDeficiency() float64             { return 0 }
 func (m *mockPortfolio) BuyingPower() float64                  { return 0 }
 func (m *mockPortfolio) GrossLeverage() float64                { return 0 }
 func (m *mockPortfolio) MaxLeverage() float64                  { return 1.0 }
+func (m *mockPortfolio) GrossMaintenanceLeverage() float64     { return 4.0 }
 func (m *mockPortfolio) LeverageHeadroom() float64             { return 0 }
 func (m *mockPortfolio) Benchmark() asset.Asset                { return asset.Asset{} }
 func (m *mockPortfolio) FactorAnalysis(_ *data.DataFrame) (*portfolio.FactorRegression, error) {

--- a/engine/simulated_broker_test.go
+++ b/engine/simulated_broker_test.go
@@ -35,6 +35,7 @@ type mockPortfolio struct {
 	positions        map[asset.Asset]float64
 	equity           float64
 	shortMarketValue float64
+	longMarketValue  float64
 }
 
 func (m *mockPortfolio) Position(a asset.Asset) float64      { return m.positions[a] }
@@ -73,10 +74,13 @@ func (m *mockPortfolio) SetMetadata(_, _ string)               {}
 func (m *mockPortfolio) GetMetadata(_ string) string           { return "" }
 func (m *mockPortfolio) Annotations() []portfolio.Annotation   { return nil }
 func (m *mockPortfolio) TradeDetails() []portfolio.TradeDetail { return nil }
-func (m *mockPortfolio) LongMarketValue() float64              { return 0 }
+func (m *mockPortfolio) LongMarketValue() float64              { return m.longMarketValue }
 func (m *mockPortfolio) MarginRatio() float64                  { return 0 }
 func (m *mockPortfolio) MarginDeficiency() float64             { return 0 }
 func (m *mockPortfolio) BuyingPower() float64                  { return 0 }
+func (m *mockPortfolio) GrossLeverage() float64                { return 0 }
+func (m *mockPortfolio) MaxLeverage() float64                  { return 1.0 }
+func (m *mockPortfolio) LeverageHeadroom() float64             { return 0 }
 func (m *mockPortfolio) Benchmark() asset.Asset                { return asset.Asset{} }
 func (m *mockPortfolio) FactorAnalysis(_ *data.DataFrame) (*portfolio.FactorRegression, error) {
 	return nil, nil
@@ -320,6 +324,95 @@ var _ = Describe("SimulatedBroker", func() {
 			var fill broker.Fill
 			Eventually(simBroker.Fills()).Should(Receive(&fill))
 			Expect(fill.Qty).To(Equal(15.0))
+		})
+
+		It("rejects a buy that would push gross leverage above the cap", func() {
+			simBroker := engine.NewSimulatedBroker()
+			simBroker.SetPriceProvider(&mockPriceProvider{
+				prices: map[asset.Asset]float64{aapl: 100.0},
+				date:   date,
+			}, date)
+			simBroker.SetMaxLeverage(1.0)
+
+			// Equity 1000, no current positions: buying 20 @ 100 = 2000 LMV
+			// would push gross/equity to 2.0, above the 1.0 cap.
+			simBroker.SetPortfolio(&mockPortfolio{
+				positions:        map[asset.Asset]float64{},
+				equity:           1000,
+				longMarketValue:  0,
+				shortMarketValue: 0,
+			})
+
+			err := simBroker.Submit(context.Background(), broker.Order{
+				Asset:     aapl,
+				Side:      broker.Buy,
+				Qty:       20,
+				OrderType: broker.Market,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Consistently(simBroker.Fills()).ShouldNot(Receive())
+		})
+
+		It("fills a buy that stays within the leverage cap", func() {
+			simBroker := engine.NewSimulatedBroker()
+			simBroker.SetPriceProvider(&mockPriceProvider{
+				prices: map[asset.Asset]float64{aapl: 100.0},
+				date:   date,
+			}, date)
+			simBroker.SetMaxLeverage(2.0)
+
+			// Equity 1000, buying 15 @ 100 = 1500 LMV; gross/equity = 1.5 <= 2.0.
+			simBroker.SetPortfolio(&mockPortfolio{
+				positions:        map[asset.Asset]float64{},
+				equity:           1000,
+				longMarketValue:  0,
+				shortMarketValue: 0,
+			})
+
+			err := simBroker.Submit(context.Background(), broker.Order{
+				Asset:     aapl,
+				Side:      broker.Buy,
+				Qty:       15,
+				OrderType: broker.Market,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+
+			var fill broker.Fill
+			Eventually(simBroker.Fills()).Should(Receive(&fill))
+			Expect(fill.Qty).To(Equal(15.0))
+		})
+
+		It("allows closing trades even when already over the cap", func() {
+			simBroker := engine.NewSimulatedBroker()
+			simBroker.SetPriceProvider(&mockPriceProvider{
+				prices: map[asset.Asset]float64{aapl: 100.0},
+				date:   date,
+			}, date)
+			simBroker.SetMaxLeverage(1.0)
+
+			// Account is already 2x leveraged. A sell that closes part of
+			// the long must still be allowed.
+			simBroker.SetPortfolio(&mockPortfolio{
+				positions:        map[asset.Asset]float64{aapl: 20},
+				equity:           1000,
+				longMarketValue:  2000,
+				shortMarketValue: 0,
+			})
+
+			err := simBroker.Submit(context.Background(), broker.Order{
+				Asset:     aapl,
+				Side:      broker.Sell,
+				Qty:       10,
+				OrderType: broker.Market,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+
+			var fill broker.Fill
+			Eventually(simBroker.Fills()).Should(Receive(&fill))
+			Expect(fill.Qty).To(Equal(10.0))
 		})
 
 		It("skips fill and produces no error when asset has no price", func() {

--- a/portfolio/account.go
+++ b/portfolio/account.go
@@ -65,35 +65,36 @@ type Account struct {
 	positionMV map[asset.Asset][]float64
 	// positionQty tracks per-asset quantity history aligned with perfData.Times().
 	// Same semantics as positionMV, under the PositionQuantity metric.
-	positionQty       map[asset.Asset][]float64
-	benchmark         asset.Asset
-	riskFreeValue     float64
-	taxLots           map[asset.Asset][]TaxLot
-	shortLots         map[asset.Asset][]TaxLot
-	recentLossSales   map[asset.Asset][]recentLossSale
-	recentBuys        map[asset.Asset][]recentBuy
-	washSales         []WashSaleRecord
-	metadata          map[string]string
-	metrics           []MetricRow
-	registeredMetrics []PerformanceMetric
-	annotations       []Annotation
-	middleware        []Middleware
-	pendingOrders     map[string]broker.Order
-	pendingGroups     map[string]*broker.OrderGroup // groupID -> group
-	brokerHasGroups   bool                          // cached GroupSubmitter check
-	deferredExits     map[string]OrderGroupSpec     // groupID -> bracket spec
-	lotSelection      LotSelection
-	substitutions     map[asset.Asset]Substitution
-	excursions        map[asset.Asset]ExcursionRecord
-	tradeDetails      []TradeDetail
-	initialMargin     float64
-	maintenanceMargin float64
-	maxLeverage       float64
-	borrowRate        float64
-	dfCache           map[dfCacheKey]*data.DataFrame
-	seenTransactions  map[string]struct{}
-	batches           []batchRecord
-	currentBatchID    int
+	positionQty              map[asset.Asset][]float64
+	benchmark                asset.Asset
+	riskFreeValue            float64
+	taxLots                  map[asset.Asset][]TaxLot
+	shortLots                map[asset.Asset][]TaxLot
+	recentLossSales          map[asset.Asset][]recentLossSale
+	recentBuys               map[asset.Asset][]recentBuy
+	washSales                []WashSaleRecord
+	metadata                 map[string]string
+	metrics                  []MetricRow
+	registeredMetrics        []PerformanceMetric
+	annotations              []Annotation
+	middleware               []Middleware
+	pendingOrders            map[string]broker.Order
+	pendingGroups            map[string]*broker.OrderGroup // groupID -> group
+	brokerHasGroups          bool                          // cached GroupSubmitter check
+	deferredExits            map[string]OrderGroupSpec     // groupID -> bracket spec
+	lotSelection             LotSelection
+	substitutions            map[asset.Asset]Substitution
+	excursions               map[asset.Asset]ExcursionRecord
+	tradeDetails             []TradeDetail
+	initialMargin            float64
+	maintenanceMargin        float64
+	maxLeverage              float64
+	grossMaintenanceLeverage float64
+	borrowRate               float64
+	dfCache                  map[dfCacheKey]*data.DataFrame
+	seenTransactions         map[string]struct{}
+	batches                  []batchRecord
+	currentBatchID           int
 }
 
 // New creates an Account with the given options.

--- a/portfolio/account.go
+++ b/portfolio/account.go
@@ -88,6 +88,7 @@ type Account struct {
 	tradeDetails      []TradeDetail
 	initialMargin     float64
 	maintenanceMargin float64
+	maxLeverage       float64
 	borrowRate        float64
 	dfCache           map[dfCacheKey]*data.DataFrame
 	seenTransactions  map[string]struct{}
@@ -788,10 +789,44 @@ func (a *Account) WithdrawalMetrics() (WithdrawalMetrics, error) {
 
 // --- PortfolioManager interface ---
 
+// isFiniteTransaction returns true when none of the cash-affecting
+// fields on a Transaction are NaN or +/-Inf. Non-finite values would
+// silently corrupt cash, tax-lot pricing, and the trade-detail PnL
+// downstream (see TradeDetail.PnL = (txn.Price - lot.Price) * matched),
+// so Record drops them with a warning rather than poisoning the run.
+func isFiniteTransaction(txn Transaction) bool {
+	if math.IsNaN(txn.Qty) || math.IsInf(txn.Qty, 0) {
+		return false
+	}
+
+	if math.IsNaN(txn.Price) || math.IsInf(txn.Price, 0) {
+		return false
+	}
+
+	if math.IsNaN(txn.Amount) || math.IsInf(txn.Amount, 0) {
+		return false
+	}
+
+	return true
+}
+
 // Record appends a transaction to the log and updates cash, holdings,
 // and tax lots accordingly. It also performs wash sale detection on both
 // buy and sell transactions.
 func (a *Account) Record(txn Transaction) {
+	if !isFiniteTransaction(txn) {
+		log.Warn().
+			Str("asset", txn.Asset.Ticker).
+			Time("date", txn.Date).
+			Str("type", txn.Type.String()).
+			Float64("qty", txn.Qty).
+			Float64("price", txn.Price).
+			Float64("amount", txn.Amount).
+			Msg("portfolio: skipping transaction with non-finite Qty/Price/Amount")
+
+		return
+	}
+
 	if txn.Type == asset.DividendTransaction {
 		txn.Qualified = a.isDividendQualified(txn.Asset, txn.Date)
 	}

--- a/portfolio/account_test.go
+++ b/portfolio/account_test.go
@@ -111,6 +111,32 @@ var _ = Describe("Account", func() {
 			Expect(a.Transactions()).To(HaveLen(2)) // deposit + dividend
 		})
 
+		It("skips a transaction with NaN price (preventing PnL corruption)", func() {
+			a := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    10,
+				Price:  math.NaN(),
+				Amount: -3_000.0,
+			})
+			Expect(a.Cash()).To(Equal(10_000.0))
+			Expect(a.Position(spy)).To(Equal(0.0))
+			Expect(a.Transactions()).To(HaveLen(1)) // only the initial deposit
+		})
+
+		It("skips a transaction with +Inf amount", func() {
+			a := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+				Type:   asset.FeeTransaction,
+				Amount: math.Inf(1),
+			})
+			Expect(a.Cash()).To(Equal(10_000.0))
+			Expect(a.Transactions()).To(HaveLen(1))
+		})
+
 		It("records a fee and decreases cash", func() {
 			a := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
 			a.Record(portfolio.Transaction{

--- a/portfolio/average_loss.go
+++ b/portfolio/average_loss.go
@@ -17,6 +17,7 @@ package portfolio
 
 import (
 	"context"
+	"math"
 
 	"github.com/penny-vault/pvbt/data"
 )
@@ -41,6 +42,10 @@ func (averageLoss) Compute(ctx context.Context, stats PortfolioStats, _ *Period)
 	)
 
 	for _, rt := range trips {
+		if math.IsNaN(rt.pnl) || math.IsInf(rt.pnl, 0) {
+			continue
+		}
+
 		if rt.pnl <= 0 {
 			losses++
 			sumLoss += rt.pnl

--- a/portfolio/average_win.go
+++ b/portfolio/average_win.go
@@ -17,6 +17,7 @@ package portfolio
 
 import (
 	"context"
+	"math"
 
 	"github.com/penny-vault/pvbt/data"
 )
@@ -40,6 +41,10 @@ func (averageWin) Compute(ctx context.Context, stats PortfolioStats, _ *Period) 
 	)
 
 	for _, rt := range trips {
+		if math.IsNaN(rt.pnl) || math.IsInf(rt.pnl, 0) {
+			continue
+		}
+
 		if rt.pnl > 0 {
 			wins++
 			sumWin += rt.pnl

--- a/portfolio/margin.go
+++ b/portfolio/margin.go
@@ -89,8 +89,12 @@ func (a *Account) MarginRatio() float64 {
 // must be unwound to restore margin compliance. It is the worst of two
 // breaches: the short-side maintenance margin shortfall (notional of
 // shorts to cover so SMV*maintenanceRate <= equity), and the gross
-// leverage shortfall (notional to close so (LMV+SMV)/equity <= the
-// configured cap). Returns 0 if the account is healthy.
+// maintenance leverage shortfall (notional to close so
+// (LMV+SMV)/equity <= the configured maintenance cap, when one has
+// been set via WithGrossMaintenanceLeverage or WithMarginModel).
+// MaxLeverage is intentionally not consulted here: it gates new orders
+// at submission time, but adverse drift past that cap does not by
+// itself force liquidation. Returns 0 if the account is healthy.
 func (a *Account) MarginDeficiency() float64 {
 	equity := a.Equity()
 
@@ -109,14 +113,14 @@ func (a *Account) MarginDeficiency() float64 {
 
 	var leverageDeficit float64
 
-	maxLev := a.MaxLeverage()
+	maintLev := a.grossMaintenanceLeverage
 	gross := a.LongMarketValue() + smv
 
-	if maxLev > 0 && gross > 0 {
+	if maintLev > 0 && gross > 0 {
 		if equity <= 0 {
 			leverageDeficit = gross
-		} else if gross/equity > maxLev {
-			leverageDeficit = gross - maxLev*equity
+		} else if gross/equity > maintLev {
+			leverageDeficit = gross - maintLev*equity
 		}
 	}
 

--- a/portfolio/margin.go
+++ b/portfolio/margin.go
@@ -24,6 +24,7 @@ import (
 const (
 	defaultInitialMarginRate     = 0.50
 	defaultMaintenanceMarginRate = 0.30
+	defaultMaxLeverage           = 1.0
 )
 
 // ShortMarketValue returns the total absolute market value of all short
@@ -84,23 +85,99 @@ func (a *Account) MarginRatio() float64 {
 	return a.Equity() / smv
 }
 
-// MarginDeficiency returns the dollar amount needed to restore
-// maintenance margin. Returns 0 if the account is healthy or has no
-// short positions.
+// MarginDeficiency returns the dollar amount of position notional that
+// must be unwound to restore margin compliance. It is the worst of two
+// breaches: the short-side maintenance margin shortfall (notional of
+// shorts to cover so SMV*maintenanceRate <= equity), and the gross
+// leverage shortfall (notional to close so (LMV+SMV)/equity <= the
+// configured cap). Returns 0 if the account is healthy.
 func (a *Account) MarginDeficiency() float64 {
+	equity := a.Equity()
+
+	var shortDeficit float64
+
 	smv := a.ShortMarketValue()
-	if smv == 0 {
+	if smv > 0 {
+		rate := a.maintenanceMarginRate()
+		if rate > 0 {
+			needed := smv - equity/rate
+			if needed > 0 {
+				shortDeficit = needed
+			}
+		}
+	}
+
+	var leverageDeficit float64
+
+	maxLev := a.MaxLeverage()
+	gross := a.LongMarketValue() + smv
+
+	if maxLev > 0 && gross > 0 {
+		if equity <= 0 {
+			leverageDeficit = gross
+		} else if gross/equity > maxLev {
+			leverageDeficit = gross - maxLev*equity
+		}
+	}
+
+	if shortDeficit > leverageDeficit {
+		return shortDeficit
+	}
+
+	return leverageDeficit
+}
+
+// GrossLeverage returns (LongMarketValue + ShortMarketValue) / Equity.
+// Returns 0 if there are no positions, or NaN if equity is non-positive
+// while positions exist (an irrecoverable account state).
+func (a *Account) GrossLeverage() float64 {
+	gross := a.LongMarketValue() + a.ShortMarketValue()
+	if gross == 0 {
 		return 0
 	}
 
-	requiredEquity := smv * a.maintenanceMarginRate()
-	deficit := requiredEquity - a.Equity()
-
-	if deficit > 0 {
-		return deficit
+	equity := a.Equity()
+	if equity <= 0 {
+		return math.NaN()
 	}
 
-	return 0
+	return gross / equity
+}
+
+// MaxLeverage returns the configured gross-leverage cap, or the default
+// of 1.0 if none was set.
+func (a *Account) MaxLeverage() float64 {
+	if a.maxLeverage > 0 {
+		return a.maxLeverage
+	}
+
+	return defaultMaxLeverage
+}
+
+// SetMaxLeverage sets the gross-leverage cap. Used by the engine to
+// apply a strategy- or CLI-supplied value when the account itself
+// hasn't been configured with WithMaxLeverage. Values <= 0 leave the
+// existing setting unchanged.
+func (a *Account) SetMaxLeverage(ratio float64) {
+	if ratio > 0 {
+		a.maxLeverage = ratio
+	}
+}
+
+// HasMaxLeverage reports whether WithMaxLeverage (or SetMaxLeverage)
+// has been used to configure a non-default cap.
+func (a *Account) HasMaxLeverage() bool {
+	return a.maxLeverage > 0
+}
+
+// LeverageHeadroom returns the additional notional (in dollars) that
+// can be opened before the gross-leverage cap is breached. Returns a
+// negative value when the account is already over the cap.
+func (a *Account) LeverageHeadroom() float64 {
+	equity := a.Equity()
+	gross := a.LongMarketValue() + a.ShortMarketValue()
+
+	return a.MaxLeverage()*equity - gross
 }
 
 // BuyingPower returns cash minus the initial margin reserved for

--- a/portfolio/margin.go
+++ b/portfolio/margin.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	defaultInitialMarginRate     = 0.50
-	defaultMaintenanceMarginRate = 0.30
-	defaultMaxLeverage           = 1.0
+	defaultInitialMarginRate        = 0.50
+	defaultMaintenanceMarginRate    = 0.30
+	defaultMaxLeverage              = 2.0
+	defaultGrossMaintenanceLeverage = 4.0
 )
 
 // ShortMarketValue returns the total absolute market value of all short
@@ -90,11 +91,10 @@ func (a *Account) MarginRatio() float64 {
 // breaches: the short-side maintenance margin shortfall (notional of
 // shorts to cover so SMV*maintenanceRate <= equity), and the gross
 // maintenance leverage shortfall (notional to close so
-// (LMV+SMV)/equity <= the configured maintenance cap, when one has
-// been set via WithGrossMaintenanceLeverage or WithMarginModel).
-// MaxLeverage is intentionally not consulted here: it gates new orders
-// at submission time, but adverse drift past that cap does not by
-// itself force liquidation. Returns 0 if the account is healthy.
+// (LMV+SMV)/equity <= GrossMaintenanceLeverage). MaxLeverage is
+// intentionally not consulted here: it gates new orders at submission
+// time, but adverse drift past that cap does not by itself force
+// liquidation. Returns 0 if the account is healthy.
 func (a *Account) MarginDeficiency() float64 {
 	equity := a.Equity()
 
@@ -113,7 +113,7 @@ func (a *Account) MarginDeficiency() float64 {
 
 	var leverageDeficit float64
 
-	maintLev := a.grossMaintenanceLeverage
+	maintLev := a.GrossMaintenanceLeverage()
 	gross := a.LongMarketValue() + smv
 
 	if maintLev > 0 && gross > 0 {
@@ -172,6 +172,35 @@ func (a *Account) SetMaxLeverage(ratio float64) {
 // has been used to configure a non-default cap.
 func (a *Account) HasMaxLeverage() bool {
 	return a.maxLeverage > 0
+}
+
+// GrossMaintenanceLeverage returns the configured gross-leverage
+// liquidation threshold. The default is 4.0, matching Reg T-style 25%
+// maintenance margin. Set explicitly via WithGrossMaintenanceLeverage,
+// WithMarginModel, or SetGrossMaintenanceLeverage.
+func (a *Account) GrossMaintenanceLeverage() float64 {
+	if a.grossMaintenanceLeverage > 0 {
+		return a.grossMaintenanceLeverage
+	}
+
+	return defaultGrossMaintenanceLeverage
+}
+
+// SetGrossMaintenanceLeverage sets the gross-leverage liquidation
+// threshold. Used by the engine to apply a strategy- or CLI-supplied
+// value when the account itself has not been configured. Values <= 0
+// leave the existing setting unchanged.
+func (a *Account) SetGrossMaintenanceLeverage(ratio float64) {
+	if ratio > 0 {
+		a.grossMaintenanceLeverage = ratio
+	}
+}
+
+// HasGrossMaintenanceLeverage reports whether
+// WithGrossMaintenanceLeverage (or SetGrossMaintenanceLeverage) has
+// configured a liquidation threshold.
+func (a *Account) HasGrossMaintenanceLeverage() bool {
+	return a.grossMaintenanceLeverage > 0
 }
 
 // LeverageHeadroom returns the additional notional (in dollars) that

--- a/portfolio/margin_option.go
+++ b/portfolio/margin_option.go
@@ -63,9 +63,10 @@ func WithMaxLeverage(ratio float64) Option {
 // / Equity, exceeds the given ratio. Unlike WithMaxLeverage, this knob
 // drives liquidation: when the threshold is breached the engine either
 // invokes the strategy's MarginCallHandler or trims gross notional
-// proportionally. The default is 0 (disabled), so only short-side
-// maintenance margin can force liquidation. Set to 4.0 for Reg
-// T-style 25% maintenance.
+// proportionally. The default is 4.0 (Reg T-style 25% maintenance).
+// Pass math.Inf(1) to disable leverage-based liquidation entirely (the
+// cash-account model); only short-side maintenance margin will then
+// force liquidation.
 func WithGrossMaintenanceLeverage(ratio float64) Option {
 	return func(a *Account) {
 		a.grossMaintenanceLeverage = ratio

--- a/portfolio/margin_option.go
+++ b/portfolio/margin_option.go
@@ -41,13 +41,62 @@ func WithBorrowRate(rate float64) Option {
 }
 
 // WithMaxLeverage returns an Option that caps gross leverage,
-// (LongMarketValue + ShortMarketValue) / Equity. The default is 1.0,
-// which models a cash account: orders that would push the account
-// above 1.0x are rejected at submission time, and a continuous breach
-// (caused by adverse price moves) triggers a margin call. Set to 2.0
-// for Reg T-style 2x leverage. Values <= 0 are clamped to the default.
+// (LongMarketValue + ShortMarketValue) / Equity, at order-submission
+// time. Orders that would push the account above this ratio are
+// rejected; closing trades are always allowed through. The default is
+// 1.0, which models a cash account; set to 2.0 for Reg T-style 2x
+// initial leverage. Values <= 0 are clamped to the default.
+//
+// MaxLeverage is an entry-time gate only. Adverse price moves that
+// drift gross leverage above the cap do not force liquidation;
+// liquidation is driven by short-side maintenance margin (see
+// WithMaintenanceMargin) and, when configured, gross maintenance
+// leverage (see WithGrossMaintenanceLeverage or WithMarginModel).
 func WithMaxLeverage(ratio float64) Option {
 	return func(a *Account) {
 		a.maxLeverage = ratio
+	}
+}
+
+// WithGrossMaintenanceLeverage returns an Option that triggers a
+// margin call when gross leverage, (LongMarketValue + ShortMarketValue)
+// / Equity, exceeds the given ratio. Unlike WithMaxLeverage, this knob
+// drives liquidation: when the threshold is breached the engine either
+// invokes the strategy's MarginCallHandler or trims gross notional
+// proportionally. The default is 0 (disabled), so only short-side
+// maintenance margin can force liquidation. Set to 4.0 for Reg
+// T-style 25% maintenance.
+func WithGrossMaintenanceLeverage(ratio float64) Option {
+	return func(a *Account) {
+		a.grossMaintenanceLeverage = ratio
+	}
+}
+
+// RegT describes a Reg T-style margin model: a single initial-margin
+// rate that gates new orders and a single maintenance rate that
+// triggers liquidation. Both rates are expressed as
+// equity / position-value fractions, so the canonical Reg T values
+// are Initial: 0.50 and Maintenance: 0.25. The corresponding leverage
+// caps are 1/Initial (entry) and 1/Maintenance (liquidation). Zero
+// values leave the corresponding setting at its existing default.
+type RegT struct {
+	Initial     float64
+	Maintenance float64
+}
+
+// WithMarginModel applies a packaged margin model to the account.
+// For RegT, this sets MaxLeverage = 1/Initial and gross maintenance
+// leverage = 1/Maintenance. Short-side maintenance margin
+// (WithMaintenanceMargin) is left untouched and continues to apply
+// independently.
+func WithMarginModel(model RegT) Option {
+	return func(acct *Account) {
+		if model.Initial > 0 {
+			acct.maxLeverage = 1.0 / model.Initial
+		}
+
+		if model.Maintenance > 0 {
+			acct.grossMaintenanceLeverage = 1.0 / model.Maintenance
+		}
 	}
 }

--- a/portfolio/margin_option.go
+++ b/portfolio/margin_option.go
@@ -39,3 +39,15 @@ func WithBorrowRate(rate float64) Option {
 		a.borrowRate = rate
 	}
 }
+
+// WithMaxLeverage returns an Option that caps gross leverage,
+// (LongMarketValue + ShortMarketValue) / Equity. The default is 1.0,
+// which models a cash account: orders that would push the account
+// above 1.0x are rejected at submission time, and a continuous breach
+// (caused by adverse price moves) triggers a margin call. Set to 2.0
+// for Reg T-style 2x leverage. Values <= 0 are clamped to the default.
+func WithMaxLeverage(ratio float64) Option {
+	return func(a *Account) {
+		a.maxLeverage = ratio
+	}
+}

--- a/portfolio/margin_test.go
+++ b/portfolio/margin_test.go
@@ -236,11 +236,13 @@ var _ = Describe("Margin Accounting", func() {
 			// Use a very high maintenance margin to trigger a deficiency.
 			// Cash = 20_000, short 100 at 150 => SMV = 15_000
 			// Equity = 20_000 - 15_000 = 5_000
-			// Required = 15_000 * 0.90 = 13_500
-			// Deficiency = 13_500 - 5_000 = 8_500
+			// Deficiency is the notional that must be covered to restore
+			// SMV*rate <= equity: SMV - equity/rate
+			//                   = 15_000 - 5_000/0.90 = 9_444.44
 			acct := portfolio.New(
 				portfolio.WithCash(20_000, now),
 				portfolio.WithMaintenanceMargin(0.90),
+				portfolio.WithMaxLeverage(10.0), // disable the leverage check for this test
 			)
 			acct.Record(portfolio.Transaction{
 				Date:   now,
@@ -254,7 +256,131 @@ var _ = Describe("Margin Accounting", func() {
 			df := buildDF(now, []asset.Asset{spy}, []float64{150}, []float64{150})
 			acct.UpdatePrices(df)
 
-			Expect(acct.MarginDeficiency()).To(BeNumerically("~", 8_500.0, 0.01))
+			Expect(acct.MarginDeficiency()).To(BeNumerically("~", 9_444.44, 0.01))
+		})
+	})
+
+	Describe("GrossLeverage", func() {
+		It("returns 0 when there are no positions", func() {
+			acct := portfolio.New(portfolio.WithCash(100_000, now))
+			df := buildDF(now, []asset.Asset{spy}, []float64{450}, []float64{450})
+			acct.UpdatePrices(df)
+
+			Expect(acct.GrossLeverage()).To(Equal(0.0))
+		})
+
+		It("computes (LMV+SMV)/equity for mixed positions", func() {
+			// Long 100 SPY at 100 (LMV=10_000), short 50 AAPL at 200 (SMV=10_000).
+			// cash = 50_000 - 10_000 + 10_000 = 50_000.
+			// equity = cash + LMV - SMV = 50_000 + 10_000 - 10_000 = 50_000.
+			// gross/equity = 20_000/50_000 = 0.4.
+			acct := portfolio.New(
+				portfolio.WithCash(50_000, now),
+				portfolio.WithMaxLeverage(2.0),
+			)
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 100, Price: 100, Amount: -10_000})
+			acct.Record(portfolio.Transaction{Date: now, Asset: aapl, Type: asset.SellTransaction, Qty: 50, Price: 200, Amount: 10_000})
+
+			df := buildDF(now,
+				[]asset.Asset{spy, aapl},
+				[]float64{100, 200},
+				[]float64{100, 200},
+			)
+			acct.UpdatePrices(df)
+
+			Expect(acct.GrossLeverage()).To(BeNumerically("~", 0.4, 0.001))
+		})
+
+		It("returns NaN when equity is non-positive while positions exist", func() {
+			// Cash 5_000, short 100 at 60 => SMV=6_000, equity=5_000-6_000=-1_000.
+			acct := portfolio.New(
+				portfolio.WithCash(5_000, now),
+				portfolio.WithMaxLeverage(10.0),
+			)
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.SellTransaction, Qty: 100, Price: 60})
+
+			df := buildDF(now, []asset.Asset{spy}, []float64{60}, []float64{60})
+			acct.UpdatePrices(df)
+
+			Expect(math.IsNaN(acct.GrossLeverage())).To(BeTrue())
+		})
+	})
+
+	Describe("MaxLeverage", func() {
+		It("returns the default 1.0 when not configured", func() {
+			acct := portfolio.New(portfolio.WithCash(100_000, now))
+			Expect(acct.MaxLeverage()).To(Equal(1.0))
+		})
+
+		It("returns the configured cap", func() {
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, now),
+				portfolio.WithMaxLeverage(2.5),
+			)
+			Expect(acct.MaxLeverage()).To(Equal(2.5))
+		})
+	})
+
+	Describe("LeverageHeadroom", func() {
+		It("returns max*equity when no positions are open", func() {
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, now),
+				portfolio.WithMaxLeverage(2.0),
+			)
+			Expect(acct.LeverageHeadroom()).To(BeNumerically("~", 200_000.0, 0.01))
+		})
+
+		It("subtracts current gross from the cap", func() {
+			// Long 100 SPY at 100 => LMV=10_000, cash=90_000, equity=100_000.
+			// headroom = 2*100_000 - 10_000 = 190_000.
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, now),
+				portfolio.WithMaxLeverage(2.0),
+			)
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 100, Price: 100, Amount: -10_000})
+
+			df := buildDF(now, []asset.Asset{spy}, []float64{100}, []float64{100})
+			acct.UpdatePrices(df)
+
+			Expect(acct.LeverageHeadroom()).To(BeNumerically("~", 190_000.0, 0.01))
+		})
+
+		It("is negative when the account is over the cap", func() {
+			// Cash 5_000 + buy 100 at 100 => cash=-5_000, LMV=10_000, equity=5_000.
+			// headroom = 1*5_000 - 10_000 = -5_000.
+			acct := portfolio.New(portfolio.WithCash(5_000, now))
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 100, Price: 100, Amount: -10_000})
+
+			df := buildDF(now, []asset.Asset{spy}, []float64{100}, []float64{100})
+			acct.UpdatePrices(df)
+
+			Expect(acct.LeverageHeadroom()).To(BeNumerically("~", -5_000.0, 0.01))
+		})
+	})
+
+	Describe("MarginDeficiency leverage breach", func() {
+		It("returns the gross excess when (LMV+SMV)/equity exceeds the cap", func() {
+			// Cash 5_000 + buy 100 at 100 => cash=-5_000, LMV=10_000, equity=5_000.
+			// gross/equity=2.0; with default cap=1.0, deficiency=10_000 - 1*5_000=5_000.
+			acct := portfolio.New(portfolio.WithCash(5_000, now))
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 100, Price: 100, Amount: -10_000})
+
+			df := buildDF(now, []asset.Asset{spy}, []float64{100}, []float64{100})
+			acct.UpdatePrices(df)
+
+			Expect(acct.MarginDeficiency()).To(BeNumerically("~", 5_000.0, 0.01))
+		})
+
+		It("treats gross as fully deficient when equity is non-positive", func() {
+			// Cash 5_000 + short 100 at 60 => SMV=6_000, equity=-1_000.
+			acct := portfolio.New(portfolio.WithCash(5_000, now))
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.SellTransaction, Qty: 100, Price: 60})
+
+			df := buildDF(now, []asset.Asset{spy}, []float64{60}, []float64{60})
+			acct.UpdatePrices(df)
+
+			// With negative equity, the leverage path returns the full gross.
+			Expect(acct.MarginDeficiency()).To(BeNumerically(">=", 6_000.0))
 		})
 	})
 })

--- a/portfolio/margin_test.go
+++ b/portfolio/margin_test.go
@@ -307,9 +307,9 @@ var _ = Describe("Margin Accounting", func() {
 	})
 
 	Describe("MaxLeverage", func() {
-		It("returns the default 1.0 when not configured", func() {
+		It("returns the default 2.0 (Reg T) when not configured", func() {
 			acct := portfolio.New(portfolio.WithCash(100_000, now))
-			Expect(acct.MaxLeverage()).To(Equal(1.0))
+			Expect(acct.MaxLeverage()).To(Equal(2.0))
 		})
 
 		It("returns the configured cap", func() {
@@ -347,8 +347,11 @@ var _ = Describe("Margin Accounting", func() {
 
 		It("is negative when the account is over the cap", func() {
 			// Cash 5_000 + buy 100 at 100 => cash=-5_000, LMV=10_000, equity=5_000.
-			// headroom = 1*5_000 - 10_000 = -5_000.
-			acct := portfolio.New(portfolio.WithCash(5_000, now))
+			// With explicit MaxLeverage(1.0), headroom = 1*5_000 - 10_000 = -5_000.
+			acct := portfolio.New(
+				portfolio.WithCash(5_000, now),
+				portfolio.WithMaxLeverage(1.0),
+			)
 			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 100, Price: 100, Amount: -10_000})
 
 			df := buildDF(now, []asset.Asset{spy}, []float64{100}, []float64{100})
@@ -360,16 +363,18 @@ var _ = Describe("Margin Accounting", func() {
 
 	Describe("MaxLeverage no longer drives liquidation", func() {
 		It("returns 0 when gross drifts above MaxLeverage but no maintenance trigger fires", func() {
-			// Strategy declared MaxLeverage 2.0. After an adverse short-side
-			// move gross/equity drifts to ~2.06. No gross maintenance leverage
-			// has been configured, so MarginDeficiency must stay 0 - the
-			// engine should not auto-liquidate on entry-cap drift alone.
+			// Strategy declared MaxLeverage 2.0 with the leverage-driven
+			// liquidation trigger explicitly disabled. After an adverse
+			// short-side move gross/equity drifts to ~2.06; with no
+			// gross maintenance leverage configured (cash-style),
+			// MarginDeficiency must stay 0.
 			acct := portfolio.New(
 				portfolio.WithCash(150_000, now),
 				portfolio.WithMaxLeverage(2.0),
+				portfolio.WithGrossMaintenanceLeverage(math.Inf(1)),
 			)
 			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 1_000, Price: 100, Amount: -100_000})
-			acct.Record(portfolio.Transaction{Date: now, Asset: aapl, Type: asset.SellTransaction, Qty: 1_000, Price: 100})
+			acct.Record(portfolio.Transaction{Date: now, Asset: aapl, Type: asset.SellTransaction, Qty: 1_000, Price: 100, Amount: 100_000})
 
 			adversePrice := buildDF(now,
 				[]asset.Asset{spy, aapl},
@@ -380,7 +385,7 @@ var _ = Describe("Margin Accounting", func() {
 
 			// LMV = 100_000, SMV = 103_000, cash = 150_000 - 100_000 + 100_000 = 150_000.
 			// equity = 150_000 + 100_000 - 103_000 = 147_000.
-			// gross/equity = 203_000 / 147_000 ~ 1.38, well under 4.0 maintenance default.
+			// gross/equity = 203_000 / 147_000 ~ 1.38; trigger explicitly off.
 			// Short-side maintenance: equity (147_000) >= SMV*0.30 (30_900) - safe.
 			Expect(acct.MarginDeficiency()).To(Equal(0.0))
 		})

--- a/portfolio/margin_test.go
+++ b/portfolio/margin_test.go
@@ -358,29 +358,95 @@ var _ = Describe("Margin Accounting", func() {
 		})
 	})
 
-	Describe("MarginDeficiency leverage breach", func() {
-		It("returns the gross excess when (LMV+SMV)/equity exceeds the cap", func() {
+	Describe("MaxLeverage no longer drives liquidation", func() {
+		It("returns 0 when gross drifts above MaxLeverage but no maintenance trigger fires", func() {
+			// Strategy declared MaxLeverage 2.0. After an adverse short-side
+			// move gross/equity drifts to ~2.06. No gross maintenance leverage
+			// has been configured, so MarginDeficiency must stay 0 - the
+			// engine should not auto-liquidate on entry-cap drift alone.
+			acct := portfolio.New(
+				portfolio.WithCash(150_000, now),
+				portfolio.WithMaxLeverage(2.0),
+			)
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 1_000, Price: 100, Amount: -100_000})
+			acct.Record(portfolio.Transaction{Date: now, Asset: aapl, Type: asset.SellTransaction, Qty: 1_000, Price: 100})
+
+			adversePrice := buildDF(now,
+				[]asset.Asset{spy, aapl},
+				[]float64{100, 103},
+				[]float64{100, 103},
+			)
+			acct.UpdatePrices(adversePrice)
+
+			// LMV = 100_000, SMV = 103_000, cash = 150_000 - 100_000 + 100_000 = 150_000.
+			// equity = 150_000 + 100_000 - 103_000 = 147_000.
+			// gross/equity = 203_000 / 147_000 ~ 1.38, well under 4.0 maintenance default.
+			// Short-side maintenance: equity (147_000) >= SMV*0.30 (30_900) - safe.
+			Expect(acct.MarginDeficiency()).To(Equal(0.0))
+		})
+	})
+
+	Describe("WithGrossMaintenanceLeverage", func() {
+		It("triggers a deficiency only when gross/equity exceeds the configured ratio", func() {
 			// Cash 5_000 + buy 100 at 100 => cash=-5_000, LMV=10_000, equity=5_000.
-			// gross/equity=2.0; with default cap=1.0, deficiency=10_000 - 1*5_000=5_000.
-			acct := portfolio.New(portfolio.WithCash(5_000, now))
+			// gross/equity = 2.0. With maintenance = 1.5, deficiency = 10_000 - 1.5*5_000 = 2_500.
+			acct := portfolio.New(
+				portfolio.WithCash(5_000, now),
+				portfolio.WithGrossMaintenanceLeverage(1.5),
+			)
 			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 100, Price: 100, Amount: -10_000})
 
 			df := buildDF(now, []asset.Asset{spy}, []float64{100}, []float64{100})
 			acct.UpdatePrices(df)
 
-			Expect(acct.MarginDeficiency()).To(BeNumerically("~", 5_000.0, 0.01))
+			Expect(acct.MarginDeficiency()).To(BeNumerically("~", 2_500.0, 0.01))
 		})
 
 		It("treats gross as fully deficient when equity is non-positive", func() {
 			// Cash 5_000 + short 100 at 60 => SMV=6_000, equity=-1_000.
-			acct := portfolio.New(portfolio.WithCash(5_000, now))
+			acct := portfolio.New(
+				portfolio.WithCash(5_000, now),
+				portfolio.WithGrossMaintenanceLeverage(4.0),
+			)
 			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.SellTransaction, Qty: 100, Price: 60})
 
 			df := buildDF(now, []asset.Asset{spy}, []float64{60}, []float64{60})
 			acct.UpdatePrices(df)
 
-			// With negative equity, the leverage path returns the full gross.
+			// With negative equity, the maintenance-leverage path returns the full gross.
 			Expect(acct.MarginDeficiency()).To(BeNumerically(">=", 6_000.0))
+		})
+	})
+
+	Describe("WithMarginModel(RegT)", func() {
+		It("sets MaxLeverage to 1/Initial and gross maintenance to 1/Maintenance", func() {
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, now),
+				portfolio.WithMarginModel(portfolio.RegT{Initial: 0.5, Maintenance: 0.25}),
+			)
+
+			Expect(acct.MaxLeverage()).To(BeNumerically("~", 2.0, 1e-9))
+
+			// Build an account that hits 5x gross to verify maintenance liquidation
+			// fires above 4x but not at 2x drift.
+			acct.Record(portfolio.Transaction{Date: now, Asset: spy, Type: asset.BuyTransaction, Qty: 5_000, Price: 100, Amount: -500_000})
+			df := buildDF(now, []asset.Asset{spy}, []float64{100}, []float64{100})
+			acct.UpdatePrices(df)
+
+			// LMV=500_000, cash=-400_000, equity=100_000, gross/equity=5.0.
+			// Maintenance ratio = 4.0, deficiency = 500_000 - 4*100_000 = 100_000.
+			Expect(acct.MarginDeficiency()).To(BeNumerically("~", 100_000.0, 0.01))
+		})
+
+		It("leaves rates unchanged when zero values are passed", func() {
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, now),
+				portfolio.WithMaxLeverage(3.0),
+				portfolio.WithGrossMaintenanceLeverage(5.0),
+				portfolio.WithMarginModel(portfolio.RegT{}),
+			)
+
+			Expect(acct.MaxLeverage()).To(Equal(3.0))
 		})
 	})
 })

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -153,6 +153,11 @@ type Portfolio interface {
 	// 1.0 (cash account). See WithMaxLeverage.
 	MaxLeverage() float64
 
+	// GrossMaintenanceLeverage returns the configured gross-leverage
+	// liquidation threshold, or 0 when none is set (in which case
+	// only short-side maintenance margin can force liquidation).
+	GrossMaintenanceLeverage() float64
+
 	// LeverageHeadroom returns the additional notional (in dollars) that can
 	// be opened before the gross-leverage cap is breached. Negative when the
 	// account is already over the cap.
@@ -254,6 +259,15 @@ type PortfolioManager interface {
 
 	// HasMaxLeverage reports whether a non-default cap is configured.
 	HasMaxLeverage() bool
+
+	// SetGrossMaintenanceLeverage applies a gross-leverage liquidation
+	// threshold. Used by the engine to install a strategy- or
+	// CLI-supplied value. Values <= 0 are ignored.
+	SetGrossMaintenanceLeverage(ratio float64)
+
+	// HasGrossMaintenanceLeverage reports whether a liquidation
+	// threshold has been explicitly configured.
+	HasGrossMaintenanceLeverage() bool
 
 	// SetRiskFreeValue sets the annualized risk-free rate used for
 	// risk-adjusted return calculations (Sharpe, Sortino, etc.).

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -144,6 +144,20 @@ type Portfolio interface {
 	// BuyingPower returns cash minus margin reserved for short positions.
 	BuyingPower() float64
 
+	// GrossLeverage returns (LongMarketValue + ShortMarketValue) / Equity.
+	// Returns 0 when there are no positions, or NaN if equity is non-positive
+	// while positions exist.
+	GrossLeverage() float64
+
+	// MaxLeverage returns the configured gross-leverage cap. The default is
+	// 1.0 (cash account). See WithMaxLeverage.
+	MaxLeverage() float64
+
+	// LeverageHeadroom returns the additional notional (in dollars) that can
+	// be opened before the gross-leverage cap is breached. Negative when the
+	// account is already over the cap.
+	LeverageHeadroom() float64
+
 	// Benchmark returns the asset used as the performance benchmark
 	// for this portfolio.
 	Benchmark() asset.Asset
@@ -232,6 +246,14 @@ type PortfolioManager interface {
 
 	// SetBenchmark sets the benchmark asset for performance comparison.
 	SetBenchmark(benchmark asset.Asset)
+
+	// SetMaxLeverage applies a gross-leverage cap. Used by the engine to
+	// install a strategy- or CLI-supplied value when the account has not
+	// already been configured. Values <= 0 are ignored.
+	SetMaxLeverage(ratio float64)
+
+	// HasMaxLeverage reports whether a non-default cap is configured.
+	HasMaxLeverage() bool
 
 	// SetRiskFreeValue sets the annualized risk-free rate used for
 	// risk-adjusted return calculations (Sharpe, Sortino, etc.).

--- a/portfolio/profit_factor_metric.go
+++ b/portfolio/profit_factor_metric.go
@@ -39,6 +39,10 @@ func (profitFactor) Compute(ctx context.Context, stats PortfolioStats, _ *Period
 	var sumWin, sumLoss float64
 
 	for _, rt := range trips {
+		if math.IsNaN(rt.pnl) || math.IsInf(rt.pnl, 0) {
+			continue
+		}
+
 		if rt.pnl > 0 {
 			sumWin += rt.pnl
 		} else {

--- a/portfolio/viewed_portfolio.go
+++ b/portfolio/viewed_portfolio.go
@@ -170,6 +170,9 @@ func (vp *viewedPortfolio) ShortMarketValue() float64             { return vp.ac
 func (vp *viewedPortfolio) MarginRatio() float64                  { return vp.acct.MarginRatio() }
 func (vp *viewedPortfolio) MarginDeficiency() float64             { return vp.acct.MarginDeficiency() }
 func (vp *viewedPortfolio) BuyingPower() float64                  { return vp.acct.BuyingPower() }
+func (vp *viewedPortfolio) GrossLeverage() float64                { return vp.acct.GrossLeverage() }
+func (vp *viewedPortfolio) MaxLeverage() float64                  { return vp.acct.MaxLeverage() }
+func (vp *viewedPortfolio) LeverageHeadroom() float64             { return vp.acct.LeverageHeadroom() }
 func (vp *viewedPortfolio) Benchmark() asset.Asset                { return vp.acct.Benchmark() }
 func (vp *viewedPortfolio) SetMetadata(key, value string)         { vp.acct.SetMetadata(key, value) }
 func (vp *viewedPortfolio) GetMetadata(key string) string         { return vp.acct.GetMetadata(key) }

--- a/portfolio/viewed_portfolio.go
+++ b/portfolio/viewed_portfolio.go
@@ -172,10 +172,13 @@ func (vp *viewedPortfolio) MarginDeficiency() float64             { return vp.ac
 func (vp *viewedPortfolio) BuyingPower() float64                  { return vp.acct.BuyingPower() }
 func (vp *viewedPortfolio) GrossLeverage() float64                { return vp.acct.GrossLeverage() }
 func (vp *viewedPortfolio) MaxLeverage() float64                  { return vp.acct.MaxLeverage() }
-func (vp *viewedPortfolio) LeverageHeadroom() float64             { return vp.acct.LeverageHeadroom() }
-func (vp *viewedPortfolio) Benchmark() asset.Asset                { return vp.acct.Benchmark() }
-func (vp *viewedPortfolio) SetMetadata(key, value string)         { vp.acct.SetMetadata(key, value) }
-func (vp *viewedPortfolio) GetMetadata(key string) string         { return vp.acct.GetMetadata(key) }
+func (vp *viewedPortfolio) GrossMaintenanceLeverage() float64 {
+	return vp.acct.GrossMaintenanceLeverage()
+}
+func (vp *viewedPortfolio) LeverageHeadroom() float64     { return vp.acct.LeverageHeadroom() }
+func (vp *viewedPortfolio) Benchmark() asset.Asset        { return vp.acct.Benchmark() }
+func (vp *viewedPortfolio) SetMetadata(key, value string) { vp.acct.SetMetadata(key, value) }
+func (vp *viewedPortfolio) GetMetadata(key string) string { return vp.acct.GetMetadata(key) }
 
 // Prices returns the windowed price DataFrame.
 func (vp *viewedPortfolio) Prices() *data.DataFrame {

--- a/study/montecarlo/analyze_test.go
+++ b/study/montecarlo/analyze_test.go
@@ -79,6 +79,7 @@ func (fp *fakePortfolio) MarginDeficiency() float64             { return 0 }
 func (fp *fakePortfolio) BuyingPower() float64                  { return 0 }
 func (fp *fakePortfolio) GrossLeverage() float64                { return 0 }
 func (fp *fakePortfolio) MaxLeverage() float64                  { return 1.0 }
+func (fp *fakePortfolio) GrossMaintenanceLeverage() float64     { return 4.0 }
 func (fp *fakePortfolio) LeverageHeadroom() float64             { return 0 }
 func (fp *fakePortfolio) Benchmark() asset.Asset                { return asset.Asset{} }
 func (fp *fakePortfolio) FactorAnalysis(_ *data.DataFrame) (*portfolio.FactorRegression, error) {

--- a/study/montecarlo/analyze_test.go
+++ b/study/montecarlo/analyze_test.go
@@ -77,6 +77,9 @@ func (fp *fakePortfolio) ShortMarketValue() float64             { return 0 }
 func (fp *fakePortfolio) MarginRatio() float64                  { return 0 }
 func (fp *fakePortfolio) MarginDeficiency() float64             { return 0 }
 func (fp *fakePortfolio) BuyingPower() float64                  { return 0 }
+func (fp *fakePortfolio) GrossLeverage() float64                { return 0 }
+func (fp *fakePortfolio) MaxLeverage() float64                  { return 1.0 }
+func (fp *fakePortfolio) LeverageHeadroom() float64             { return 0 }
 func (fp *fakePortfolio) Benchmark() asset.Asset                { return asset.Asset{} }
 func (fp *fakePortfolio) FactorAnalysis(_ *data.DataFrame) (*portfolio.FactorRegression, error) {
 	return nil, nil


### PR DESCRIPTION
## Summary

Reported during a long/short port from QuantConnect: a strategy declared `MaxLeverage: 2.0`, a short rallied, gross drifted to ~2.06x equity, and pvbt's engine auto-liquidated proportionally across the book on the next bar. QC (and real brokers) do not do this — they reject orders that would breach the initial cap and only liquidate when equity falls below a separate maintenance threshold.

This PR ships two related changes:

- **Decouple liquidation from `MaxLeverage`.** `MaxLeverage` is now an entry-time order gate only (the simulated broker already rejects orders that would push gross past the cap; that path is unchanged). The gross-leverage branch in `MarginDeficiency` no longer consults `MaxLeverage`. Adverse drift past the cap is ignored unless a separate maintenance threshold has been configured.
- **Add `WithGrossMaintenanceLeverage(ratio)` and `WithMarginModel(RegT{Initial, Maintenance})`.** The first is a single-knob maintenance threshold (gross/equity ratio at which liquidation fires); default off, so only short-side maintenance margin can force liquidation. The second packages `MaxLeverage = 1/Initial` and gross maintenance leverage = `1/Maintenance` in one option for Reg T-style accounts (canonical: `RegT{Initial: 0.5, Maintenance: 0.25}`).

## Behavior change

Strategies that previously relied on `MaxLeverage` to *also* drive liquidation will see their auto-trim disappear. Setting `WithGrossMaintenanceLeverage` (or `WithMarginModel`) restores a leverage-driven liquidation trigger; short-side maintenance margin (`WithMaintenanceMargin`, default 30% of SMV) continues to apply unchanged. Both bullets are reflected in the CHANGELOG `Changed` entry.

The first commit on this branch (`03b3d2f`) is the existing gross-leverage feature it builds on; the second commit is the decouple + Reg T sugar.