### PR TITLE
fix(engine): include the requested end date in backtest results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Backtests, snapshots, and studies now include the requested end date in their results. A run ending on a trading day previously stopped one trading day early, omitting that day's close.
+
 ## [0.10.0] - 2026-05-25
 
 ### Added

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -32,6 +32,19 @@ import (
 // configured strategy and data providers. It returns the portfolio
 // after running every scheduled trading date.
 func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.Portfolio, error) {
+	// The daily equity schedule stamps each trading day at the 16:00 ET
+	// close, so date enumeration must treat end as inclusive of the end
+	// date's own close. A date-only end (e.g. the --end flag) parses to
+	// midnight, which would otherwise drop that day's 16:00 close and stop
+	// the backtest on the prior trading day. Extend the enumeration boundary
+	// to the final instant of the end date's New York trading day; the
+	// caller's requested end is preserved separately for reporting.
+	requestedEnd := end
+
+	endLocal := end.In(nyc)
+	end = time.Date(endLocal.Year(), endLocal.Month(), endLocal.Day(),
+		23, 59, 59, int(time.Second-time.Nanosecond), nyc)
+
 	// PHASE 1: INITIALIZATION
 
 	// 1. Load asset registry from assetProvider.
@@ -176,6 +189,14 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 	// day instead of spuriously liquidating every held position.
 	end = e.adjustEndForStaleData(ctx, end)
 
+	// reportedEnd is what we surface via metadata and progress events: the
+	// end the caller requested, unless a stale feed forced an earlier last
+	// fully-priced trading day.
+	reportedEnd := requestedEnd
+	if end.Before(requestedEnd) {
+		reportedEnd = end
+	}
+
 	// 6. Create and configure account.
 	acct, acctErr := e.createAccount(start)
 	if acctErr != nil {
@@ -251,7 +272,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 
 	// 8. Store start/end on engine.
 	e.start = start
-	e.end = end
+	e.end = reportedEnd
 	e.measurementsEvaluated = 0
 
 	// Wire portfolio to simulated broker for margin checks.
@@ -510,7 +531,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 	// PHASE 4: RETURN
 	acct.SetMetadata(portfolio.MetaRunMode, "backtest")
 	acct.SetMetadata(portfolio.MetaRunStart, start.Format(time.RFC3339))
-	acct.SetMetadata(portfolio.MetaRunEnd, end.Format(time.RFC3339))
+	acct.SetMetadata(portfolio.MetaRunEnd, reportedEnd.Format(time.RFC3339))
 
 	return acct, nil
 }

--- a/engine/backtest_test.go
+++ b/engine/backtest_test.go
@@ -456,6 +456,44 @@ var _ = Describe("Backtest", func() {
 		})
 	})
 
+	Context("inclusive end date", func() {
+		It("records equity through the end date's own close when end is a date-only (midnight) trading day", func() {
+			nyc, err := time.LoadLocation("America/New_York")
+			Expect(err).NotTo(HaveOccurred())
+
+			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			df := makeDailyTestData(dataStart, 400, testAssets, metrics)
+			provider := data.NewTestProvider(metrics, df)
+
+			strategy := &backtestStrategy{assets: testAssets}
+			eng := engine.New(strategy,
+				engine.WithDataProvider(provider),
+				engine.WithAssetProvider(assetProvider),
+				engine.WithInitialDeposit(100_000.0),
+			)
+
+			// Parse exactly as the CLI does: a date-only flag becomes
+			// midnight in New York. 2024-02-29 is a Thursday trading day, so
+			// its 16:00 ET close must be recorded rather than dropped.
+			start, err := time.ParseInLocation("2006-01-02", "2024-02-01", nyc)
+			Expect(err).NotTo(HaveOccurred())
+			end, err := time.ParseInLocation("2006-01-02", "2024-02-29", nyc)
+			Expect(err).NotTo(HaveOccurred())
+
+			fund, err := eng.Backtest(context.Background(), start, end)
+			Expect(err).NotTo(HaveOccurred())
+
+			times := fund.PerfData().Times()
+			Expect(times).NotTo(BeEmpty())
+
+			last := times[len(times)-1].In(nyc)
+			Expect(last.Year()).To(Equal(2024))
+			Expect(last.Month()).To(Equal(time.February))
+			Expect(last.Day()).To(Equal(29),
+				"the end date's own close must be recorded, not truncated to the prior trading day")
+		})
+	})
+
 	Context("WithAccount", func() {
 		It("uses a pre-configured account", func() {
 			dataStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/penny-vault/pvbt
 go 1.25.6
 
 require (
+	github.com/ClickHouse/clickhouse-go/v2 v2.46.0
 	github.com/NimbleMarkets/ntcharts v0.5.1
 	github.com/bytedance/sonic v1.15.1
 	github.com/charmbracelet/bubbles v1.0.0
@@ -28,7 +29,6 @@ require (
 
 require (
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
-	github.com/ClickHouse/clickhouse-go/v2 v2.46.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.24.1 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23n
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
## Problem

A backtest, snapshot, or study ending on a trading day stopped one trading day early, omitting the end date's own close. For example, a run with `--end 2026-05-26` (a Tuesday, with fresh data available) recorded its last equity point on Friday 2026-05-22.

## Cause

Date-only end values parse to midnight (`2026-05-26 00:00 ET`), but the daily equity schedule (`@close * * *`) stamps each trading day at the 16:00 ET close. The enumeration loop condition `!cur.After(end)` therefore excluded the end date's 16:00 close, leaving the prior trading day as the last recorded point.

This was not a data-availability or stale-feed problem; the end date's bar existed in pvdb.

## Fix

`Engine.Backtest` now extends the enumeration boundary to the final instant of the end date's New York trading day, so the end date's close is included as the documented `[start, end]` contract implies. The caller's requested end is preserved separately for metadata and progress reporting, and stale-feed truncation still reports the last fully-priced day.

A regression test parses the end date exactly as the CLI does (date-only, midnight ET) and asserts the end date's close is recorded.