### PR TITLE
fix(engine): fill market-open firings from EOD, not intraday bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Strategies that fire at the market open again fill orders from the end-of-day bars rather than the intraday 1-minute (ClickHouse) source. A firing at the open was incorrectly treated as intra-day; only firings strictly between the open and close now use minute bars.
+
 ## [0.10.1] - 2026-05-26
 
 ### Fixed

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1038,10 +1038,12 @@ func (e *Engine) Prices(ctx context.Context, assets ...asset.Asset) (*data.DataF
 // isIntradayFiring reports whether the engine is currently inside a
 // Compute call fired at an intra-day timestamp (one that is meaningfully
 // different from the trading-day close used by the engine's daily walk).
-// The check is conservative: it requires both that an IntradayProvider
-// is registered (otherwise no intra-day data path exists) and that the
-// firing time falls strictly before the market close hour, which is the
-// only case where "next minute bar" semantics differ from "next day open".
+// The check is conservative: it requires that an IntradayProvider is
+// registered (otherwise no intra-day data path exists) and that the firing
+// time falls strictly inside the trading session -- after the 09:30 open
+// and before the 16:00 close. Firings at the open or close correspond to
+// the authoritative EOD open/close bars, so they use the daily price path
+// rather than the intraday next-minute-bar lookup.
 func (e *Engine) isIntradayFiring() bool {
 	if e.currentTime.IsZero() {
 		return false
@@ -1055,12 +1057,20 @@ func (e *Engine) isIntradayFiring() bool {
 		return false
 	}
 
-	// Firings at or after the market close hour (16:00 Eastern) use the
-	// existing daily next-bar-open fill path. Only firings earlier in
-	// the trading day need the intraday next-minute-bar lookup.
-	hour := e.currentTime.In(nyc).Hour()
+	// The 09:30 open and 16:00 close are EOD session boundaries with
+	// authoritative open/close bars in the daily store. Only firings
+	// strictly between them need the intraday next-minute-bar lookup;
+	// routing the open or close here would fill those EOD bars from
+	// ClickHouse minute data.
+	const (
+		marketOpenMinutes  = 9*60 + 30 // 09:30 Eastern
+		marketCloseMinutes = 16 * 60   // 16:00 Eastern
+	)
 
-	return hour < 16
+	local := e.currentTime.In(nyc)
+	minutes := local.Hour()*60 + local.Minute()
+
+	return minutes > marketOpenMinutes && minutes < marketCloseMinutes
 }
 
 // nextMinuteBar returns the 1-minute bar that opens immediately after

--- a/engine/open_firing_fill_test.go
+++ b/engine/open_firing_fill_test.go
@@ -1,0 +1,191 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+// countingIntradayProvider wraps an IntradayTestProvider and counts how many
+// times IntradayFetch is invoked, so a test can assert that a given engine
+// path never reaches the intraday (ClickHouse) source.
+type countingIntradayProvider struct {
+	*data.IntradayTestProvider
+
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *countingIntradayProvider) IntradayFetch(
+	ctx context.Context,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	start, end time.Time,
+	timesOfDay []data.TimeOfDay,
+) (*data.DataFrame, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+
+	return p.IntradayTestProvider.IntradayFetch(ctx, assets, metrics, start, end, timesOfDay)
+}
+
+func (p *countingIntradayProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.calls
+}
+
+// openBuyStrategy fires at the market open and buys one share on its first
+// firing. It does not request any intraday window, so the only way the
+// engine could reach the intraday provider is via order-fill price lookup.
+type openBuyStrategy struct {
+	spy    asset.Asset
+	mu     sync.Mutex
+	bought bool
+}
+
+func (s *openBuyStrategy) Name() string           { return "openBuy" }
+func (s *openBuyStrategy) Setup(_ *engine.Engine) {}
+
+func (s *openBuyStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{Schedule: "@open * * *"}
+}
+
+func (s *openBuyStrategy) Compute(
+	ctx context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.bought {
+		batch.Order(ctx, s.spy, portfolio.Buy, 1)
+		s.bought = true
+	}
+
+	return nil
+}
+
+var _ = Describe("market-open firing fills", func() {
+	It("fills open-firing orders from the EOD source, never the intraday source", func() {
+		nyc, locErr := time.LoadLocation("America/New_York")
+		Expect(locErr).NotTo(HaveOccurred())
+
+		start := time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)  // Monday
+		end := time.Date(2026, 5, 12, 23, 59, 59, 0, nyc) // Tuesday
+
+		spy := asset.Asset{Ticker: "SPY", CompositeFigi: "BBG000BDTBL9"}
+
+		dailyTimes := []time.Time{
+			time.Date(2026, 5, 11, 16, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 16, 0, 0, 0, nyc),
+		}
+
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes,
+			[]asset.Asset{spy},
+			dailyMetrics,
+			data.Daily,
+			[][]float64{
+				{100, 101},             // close
+				{100, 101},             // adj close
+				{102, 103},             // high
+				{99, 100},              // low
+				{1_000_000, 1_000_000}, // volume
+				{0, 0},                 // dividend
+				{1, 1},                 // split factor
+			})
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		// Minute bars just after the open carry a wildly different price.
+		// If the open-firing order fill (incorrectly) used the intraday
+		// source, the fill would land near 9999 instead of ~100.
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 9, 31, 0, 0, nyc),
+			time.Date(2026, 5, 11, 9, 32, 0, 0, nyc),
+			time.Date(2026, 5, 12, 9, 31, 0, 0, nyc),
+			time.Date(2026, 5, 12, 9, 32, 0, 0, nyc),
+		}
+
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes,
+			[]asset.Asset{spy},
+			[]data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume, data.AdjClose},
+			data.Tick,
+			[][]float64{
+				{9999, 9999, 9999, 9999}, // close
+				{9999, 9999, 9999, 9999}, // high
+				{9999, 9999, 9999, 9999}, // low
+				{50_000, 50_000, 50_000, 50_000},
+				{9999, 9999, 9999, 9999}, // adj close
+			})
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intraday := &countingIntradayProvider{IntradayTestProvider: data.NewIntradayTestProvider(minuteDF)}
+
+		strategy := &openBuyStrategy{spy: spy}
+
+		eng := engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: []asset.Asset{spy}}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intraday),
+			engine.WithInitialDeposit(10000),
+		)
+
+		fund, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(intraday.callCount()).To(Equal(0),
+			"a firing at the market open must source prices from EOD, not the intraday/ClickHouse provider")
+
+		var (
+			buyFound bool
+			buyPrice float64
+		)
+
+		for _, txn := range fund.Transactions() {
+			if txn.Type == asset.BuyTransaction {
+				buyFound = true
+				buyPrice = txn.Price
+
+				break
+			}
+		}
+
+		Expect(buyFound).To(BeTrue(), "expected the open-firing buy to fill")
+		Expect(buyPrice).To(BeNumerically("<", 200),
+			"fill price should come from the EOD bars (~100), not the intraday bars (9999)")
+	})
+})


### PR DESCRIPTION
## Problem

A strategy scheduled at the market open (`@open`, 9:30 ET) had its order-fill prices sourced from the intraday 1-minute (ClickHouse) bars instead of the end-of-day bars, whenever an intraday data source was configured. The market close (16:00) was already handled correctly; only the open regressed. (Reported via an RSI strategy whose open fills were coming from ClickHouse.)

## Cause

`isIntradayFiring()` treated **any** firing before 16:00 ET as intra-day:

```go
hour := e.currentTime.In(nyc).Hour()
return hour < 16
```

So a 9:30 firing routed `Prices()` to `nextMinuteBar()` (the intraday provider) rather than the EOD `FetchAt` path. The 9:30 open and 16:00 close are EOD session boundaries with authoritative open/close bars and full history in the daily store; only firings strictly inside the session need minute bars. Before v0.10.0 (no intraday provider) open firings always used the EOD path, so this was a v0.10.0 regression.

## Fix

Restrict intra-day firing to timestamps strictly after the 09:30 open and before the 16:00 close. Open and close firings fill from the EOD bars as before; genuinely intra-session firings (e.g. 10:00, 14:00) still use minute bars.

A regression test wraps the intraday test provider in a call-counter and asserts that an open-firing order fills without ever reaching the intraday provider (and at the EOD price, not the minute-bar price).