### PR TITLE
fix(cli): preserve engine-simulated run range in backtest metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A backtest's recorded end date now reflects the last day actually simulated rather than the requested `--end` flag. Running in the evening on a host whose clock had already rolled past midnight UTC previously stamped a future end date one day beyond the last day of real data.
+
 ## [0.10.3] - 2026-05-27
 
 ### Fixed

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -257,8 +257,11 @@ func runBacktest(cmd *cobra.Command, strategy engine.Strategy) error {
 	result.SetMetadata(portfolio.MetaRunInitialCash, fmt.Sprintf("%.2f", cash))
 	result.SetMetadata("run_id", fullID)
 	result.SetMetadata(portfolio.MetaStrategyName, strategy.Name())
-	result.SetMetadata(portfolio.MetaRunStart, start.Format("2006-01-02"))
-	result.SetMetadata(portfolio.MetaRunEnd, end.Format("2006-01-02"))
+	// MetaRunStart/MetaRunEnd are intentionally not set here. The engine
+	// already records the actual simulated range (engine/backtest.go), trimming
+	// the requested end to the last trading day with expected EOD data.
+	// Overwriting with the raw --start/--end flags would discard that, leaving
+	// run.end one calendar day past the last day of real data.
 
 	params := strategyParams(strategy)
 	for k, v := range params {


### PR DESCRIPTION
## Summary

The `backtest` command overwrote `run.start`/`run.end` with the raw `--start`/`--end` flags after the engine had already recorded the actual simulated range. Because `--end` defaults to the process wall clock, an evening run on a host whose clock had rolled past midnight UTC stamped `run.end` one day beyond the last day of real data, so downstream consumers (pv-api `CurrentHoldings`) displayed a future as-of date.

This drops the overwrite in `cli/backtest.go` so the engine's `reportedEnd` (the requested end trimmed to the last trading day with expected EOD data, written in RFC3339) survives.

## Verification

Built the accelerating-dual-momentum strategy against this branch and ran a backtest:

```
run.start = 2020-01-01T00:00:00-05:00
run.end   = 2026-05-29T23:59:59-04:00   MAX(positions_daily.date) = 2026-05-29
```

`run.end` now matches the last simulated trading day instead of the wall-clock `--end`.

The `snapshot` command was already correct -- it relies on the engine-written metadata and never overwrote it.

Fixes #189