### PR TITLE
Live intraday marks and weight-target order helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Strategies can adjust a single position toward a target weight without disturbing the rest of the book. `Batch.Allocate(ctx, asset, weight)` sizes the buy/sell delta to reach the target weight, and `Batch.Liquidate(ctx, asset)` closes a position; both leave all other holdings untouched, unlike `RebalanceTo`.
+
+### Changed
+
+- During an intra-day firing, the account is now marked to the live minute bar as of `engine.Now()` rather than the prior end-of-day close. Order sizing and margin/leverage checks therefore use the price at the firing moment; orders still fill at the next minute bar. Each held asset is marked to its own most recent bar, so a name that did not trade at the firing minute keeps its last known price instead of being valued at zero. End-of-day valuation is unchanged, so daily backtests produce identical results.
+
 ## [0.10.4] - 2026-06-01
 
 ### Fixed

--- a/docs/portfolio.md
+++ b/docs/portfolio.md
@@ -296,6 +296,28 @@ batch.Order(ctx, asset, Sell, 50, Stop(140.00), FillOrKill)
 batch.Order(ctx, asset, Buy, 200, OnTheOpen, WithJustification("rebalance after earnings"))
 ```
 
+### Weight-target: Allocate and Liquidate
+
+`RebalanceTo` replaces the entire book: any held name absent from the allocation is liquidated. When a strategy instead wants to adjust a single name toward a target weight and leave everything else alone, use `Allocate` and `Liquidate`.
+
+```go
+// Drive SPY to 50% of the portfolio's projected value, leaving other holdings untouched.
+batch.Allocate(ctx, spy, 0.50)
+
+// Close the SPY position (sell a long, cover a short); no-op if flat.
+batch.Liquidate(ctx, spy)
+```
+
+`Allocate` sizes the order off the portfolio's projected value and the asset's current projected position value, appending only the buy/sell delta needed to reach the target. A negative weight opens or extends a short; a call that is already at the target is a no-op. `Liquidate` closes the full projected position for the named asset.
+
+Both accept the same order-type, time-in-force, and justification modifiers as `Order` (bracket and OCO modifiers are not supported):
+
+```go
+batch.Allocate(ctx, spy, 0.50, portfolio.Limit(150.00), portfolio.WithJustification("scale in"))
+```
+
+These pair naturally with intraday-scheduled strategies: during a firing strictly inside the trading session the account is marked to the live minute bar as of `eng.Now()`, so `Allocate`'s sizing and the broker's margin checks use the price at the firing moment rather than the prior end-of-day close. The order still fills at the next minute bar, so a small sizing-vs-fill gap remains as realistic slippage. See [Scheduling](scheduling.md) for intraday firing details.
+
 ### Mixing approaches
 
 A strategy can use `RebalanceTo` for its core allocation and `Order` for specific adjustments, all on the same batch:

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -56,7 +56,15 @@ Strategies that pull intraday data via `portfolio.MinuteBars(N)` or `portfolio.D
 
 Order fills during intra-day firings land at the next 1-minute bar's close, the same next-bar semantics used for daily strategies (next bar = next minute, not next day). Daily portfolio valuation, equity recording, and performance metrics remain anchored to once-per-day snapshots at the end-of-day boundary.
 
-See [Data: Intraday 1-minute bars](data.md#intraday-1-minute-bars) for the data-fetch API and ClickHouse configuration.
+### Live marks during a firing
+
+During a firing strictly inside the trading session, the account is marked to the minute bar as of `engine.Now()` -- the just-closed minute -- rather than the prior end-of-day close. So `port.Value()`, `port.PositionValue(asset)`, and `port.Prices()` reflect the price at the firing moment, and order sizing (`RebalanceTo`, `Allocate`) and the broker's margin and leverage checks all evaluate against that live mark. The mark price (the `engine.Now()` bar) is deliberately distinct from the fill price (the next minute bar), so a small sizing-vs-fill gap remains as realistic slippage.
+
+Each held asset is marked independently to its own most recent bar at or before the firing moment. Minute bars are sparse, so a thinly-traded name may not print at the exact firing minute; such a name keeps its last known mark rather than being valued at zero. (A held asset with no recent bar and no prior mark at all is an error, not a silent drop.)
+
+Firings at exactly the 09:30 open or 16:00 close use the authoritative end-of-day bars instead. End-of-day equity recording is unchanged, so daily (non-intraday) backtests produce identical results.
+
+See [Data: Intraday 1-minute bars](data.md#intraday-1-minute-bars) for the data-fetch API and ClickHouse configuration, and [Portfolio: Weight-target Allocate and Liquidate](portfolio.md#weight-target-allocate-and-liquidate) for the single-name order helpers that build on these live marks.
 
 ## Example
 

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -432,6 +432,11 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 			for _, fireTime := range childFirings {
 				e.currentTime = fireTime
 				child.broker.SetPriceProvider(e, date)
+
+				if err := e.markIntradayPrices(stepCtx, child.account); err != nil {
+					return nil, fmt.Errorf("engine: child %q mark intraday prices on %v: %w", childName, fireTime, err)
+				}
+
 				child.broker.EvaluatePending()
 
 				if err := child.account.CancelOpenOrders(stepCtx); err != nil {
@@ -462,6 +467,10 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 
 				if sb, ok := e.broker.(*SimulatedBroker); ok {
 					sb.SetPriceProvider(e, date)
+				}
+
+				if err := e.markIntradayPrices(stepCtx, acct); err != nil {
+					return nil, fmt.Errorf("engine: mark intraday prices on %v: %w", fireTime, err)
 				}
 
 				if err := acct.CancelOpenOrders(stepCtx); err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1113,6 +1113,117 @@ func (e *Engine) nextMinuteBar(ctx context.Context, assets []asset.Asset) (*data
 	return earliest, nil
 }
 
+// markBarLookback bounds how far back markBar searches for each asset's most
+// recent minute bar before the firing moment.
+const markBarLookback = 6 * time.Minute
+
+// markBar builds a single-row price frame that marks each asset to its most
+// recent 1-minute bar at or before e.currentTime -- the just-closed minute as
+// of the firing moment. Each asset is marked independently: minute bars are
+// sparse, so within one fetch window two held assets routinely have their
+// latest bar at different timestamps, and a thinly-traded name may have no bar
+// at the firing minute at all. For an asset with no bar in the window, markBar
+// carries forward its prior mark (from prior) rather than dropping it -- a
+// dropped asset would be silently valued at zero. An asset with neither a
+// window bar nor a prior mark is a hard error.
+//
+// This is distinct from nextMinuteBar, which returns the next bar after
+// currentTime for order fills; the small mark-vs-fill gap is realistic
+// slippage matching live-trading next-tick behaviour.
+func (e *Engine) markBar(ctx context.Context, assets []asset.Asset, prior *data.DataFrame) (*data.DataFrame, error) {
+	provider := e.findIntradayProvider()
+	if provider == nil {
+		return nil, fmt.Errorf(
+			"engine: intra-day firing requires an IntradayProvider for live marks; " +
+				"none registered")
+	}
+
+	metrics := []data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume}
+
+	window, err := provider.IntradayFetch(ctx, assets, metrics,
+		e.currentTime.Add(-markBarLookback), e.currentTime, nil)
+	if err != nil {
+		return nil, fmt.Errorf("engine: fetch mark bar: %w", err)
+	}
+
+	times := window.Times()
+
+	cols := make([][]float64, len(assets)*len(metrics))
+
+	for assetIdx, held := range assets {
+		// Find this asset's latest window timestamp with a real close.
+		markIdx := -1
+
+		for timeIdx := len(times) - 1; timeIdx >= 0; timeIdx-- {
+			if !math.IsNaN(window.ValueAt(held, data.MetricClose, times[timeIdx])) {
+				markIdx = timeIdx
+
+				break
+			}
+		}
+
+		if markIdx < 0 && (prior == nil || math.IsNaN(prior.Value(held, data.MetricClose))) {
+			return nil, fmt.Errorf(
+				"engine: no minute bar at or before %s and no prior mark for %s",
+				e.currentTime.Format(time.RFC3339), held.Ticker)
+		}
+
+		for metricIdx, metric := range metrics {
+			value := math.NaN()
+			if markIdx >= 0 {
+				value = window.ValueAt(held, metric, times[markIdx])
+			} else if prior != nil {
+				// Carry the asset's last known mark forward; it did not
+				// trade in the window but must remain in the valuation.
+				value = prior.Value(held, metric)
+			}
+
+			cols[assetIdx*len(metrics)+metricIdx] = []float64{value}
+		}
+	}
+
+	marked, err := data.NewDataFrame([]time.Time{e.currentTime}, assets, metrics, data.Tick, cols)
+	if err != nil {
+		return nil, fmt.Errorf("engine: build mark bar frame: %w", err)
+	}
+
+	marked.SetSource(e)
+
+	return marked, nil
+}
+
+// markIntradayPrices marks the account to the live minute-bar prices as of
+// e.currentTime when the engine is mid intra-day firing, so that Value,
+// PositionValue, Prices, margin checks, and batch order sizing reflect the
+// firing moment rather than the prior end-of-day close. It is a no-op for
+// daily firings; the end-of-day updateAccountPrices restores close marks and
+// records the equity point, so daily backtests and the equity curve are
+// unaffected.
+func (e *Engine) markIntradayPrices(ctx context.Context, acct portfolio.PortfolioManager) error {
+	if !e.isIntradayFiring() {
+		return nil
+	}
+
+	holdings := acct.Holdings()
+	if len(holdings) == 0 {
+		return nil
+	}
+
+	heldAssets := make([]asset.Asset, 0, len(holdings))
+	for held := range holdings {
+		heldAssets = append(heldAssets, held)
+	}
+
+	markDF, err := e.markBar(ctx, heldAssets, acct.Prices())
+	if err != nil {
+		return fmt.Errorf("engine: mark intraday prices: %w", err)
+	}
+
+	acct.SetPrices(markDF)
+
+	return nil
+}
+
 // prefetchBrokerPrices batch-fetches price data for all unique assets
 // in the given orders, warming the year-chunk cache so that subsequent
 // per-order Prices calls in Submit are cache hits.

--- a/engine/intraday_firing_test.go
+++ b/engine/intraday_firing_test.go
@@ -17,6 +17,7 @@ package engine_test
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -73,6 +74,525 @@ func (s *intradayRecordStrategy) Compute(
 
 	return nil
 }
+
+// intradayMarkStrategy buys a fixed quantity of SPY on its first firing and
+// thereafter records the prices the engine marks the account to during each
+// firing: the price DataFrame close, the position value, and the total
+// portfolio value. Once it holds the position it also issues an Allocate to a
+// target weight and records the resulting order amount, so the test can prove
+// Allocate sizes off the live eng.Now() mark rather than the prior EOD close.
+type intradayMarkStrategy struct {
+	mu           sync.Mutex
+	spy          asset.Asset
+	bought       bool
+	doAllocate   bool
+	allocated    bool
+	priceSeen    []float64
+	posValueSeen []float64
+	valueSeen    []float64
+	allocAmounts []float64
+	schedule     string
+}
+
+func (s *intradayMarkStrategy) Name() string           { return "intradayMark" }
+func (s *intradayMarkStrategy) Setup(_ *engine.Engine) {}
+
+func (s *intradayMarkStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "intraday-mark", Schedule: s.schedule}
+}
+
+func (s *intradayMarkStrategy) Compute(
+	_ context.Context,
+	_ *engine.Engine,
+	port portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	price := math.NaN()
+	if prices := port.Prices(); prices != nil {
+		price = prices.Value(s.spy, data.MetricClose)
+	}
+
+	s.priceSeen = append(s.priceSeen, price)
+	s.posValueSeen = append(s.posValueSeen, port.PositionValue(s.spy))
+	s.valueSeen = append(s.valueSeen, port.Value())
+
+	if !s.bought {
+		s.bought = true
+
+		return batch.Order(context.Background(), s.spy, portfolio.Buy, 10)
+	}
+
+	// When enabled, exercise Allocate end-to-end exactly once on the day-2
+	// 10:00 firing (the third firing) and capture the order it sizes off the
+	// live projected value. Restricting to a single firing keeps the held
+	// quantity fixed at the day-1 purchase so the expected amount is exact;
+	// fills drain synchronously inside ExecuteBatch.
+	if s.doAllocate && !s.allocated && len(s.priceSeen) == 3 {
+		s.allocated = true
+
+		before := len(batch.Orders)
+		if err := batch.Allocate(context.Background(), s.spy, 0.5); err != nil {
+			return err
+		}
+
+		if len(batch.Orders) > before {
+			s.allocAmounts = append(s.allocAmounts, batch.Orders[before].Amount)
+		}
+	}
+
+	return nil
+}
+
+var _ = Describe("intra-day account marking", func() {
+	var (
+		nyc      *time.Location
+		start    time.Time
+		end      time.Time
+		spy      asset.Asset
+		eng      *engine.Engine
+		strategy *intradayMarkStrategy
+	)
+
+	BeforeEach(func() {
+		var locErr error
+
+		nyc, locErr = time.LoadLocation("America/New_York")
+		Expect(locErr).NotTo(HaveOccurred())
+
+		start = time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end = time.Date(2026, 5, 12, 23, 59, 59, 0, nyc)
+
+		spy = asset.Asset{Ticker: "SPY", CompositeFigi: "BBG000BDTBL9"}
+
+		dailyTimes := []time.Time{
+			time.Date(2026, 5, 11, 16, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 16, 0, 0, 0, nyc),
+		}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes,
+			[]asset.Asset{spy},
+			[]data.Metric{data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow, data.Volume, data.Dividend, data.SplitFactor},
+			data.Daily,
+			[][]float64{
+				{100, 101},             // close (EOD)
+				{100, 101},             // adj close
+				{102, 103},             // high
+				{99, 100},              // low
+				{1_000_000, 1_000_000}, // volume
+				{0, 0},                 // dividend
+				{1, 1},                 // split factor
+			})
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 10, 1, 0, 0, nyc),
+			time.Date(2026, 5, 11, 14, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 14, 1, 0, 0, nyc),
+			time.Date(2026, 5, 12, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 10, 1, 0, 0, nyc),
+			time.Date(2026, 5, 12, 14, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 14, 1, 0, 0, nyc),
+		}
+
+		// Day-2 minute closes (105, 106) are deliberately well above the
+		// day-2 EOD close (101) so the live mark is unambiguously distinct
+		// from the EOD mark the engine would otherwise use.
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes,
+			[]asset.Asset{spy},
+			[]data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume, data.AdjClose},
+			data.Tick,
+			[][]float64{
+				{100.1, 100.2, 100.3, 100.4, 105.0, 105.1, 106.0, 106.1}, // close
+				{100.5, 100.6, 100.7, 100.8, 105.5, 105.6, 106.5, 106.6}, // high
+				{99.5, 99.6, 99.7, 99.8, 104.5, 104.6, 105.5, 105.6},     // low
+				{50_000, 50_000, 50_000, 50_000, 50_000, 50_000, 50_000, 50_000},
+				{100.1, 100.2, 100.3, 100.4, 105.0, 105.1, 106.0, 106.1}, // adj close
+			})
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intradayProvider := data.NewIntradayTestProvider(minuteDF)
+
+		strategy = &intradayMarkStrategy{spy: spy, schedule: "0 10,14 * * MON-FRI"}
+
+		eng = engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: []asset.Asset{spy}}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intradayProvider),
+			engine.WithInitialDeposit(10000),
+		)
+	})
+
+	It("marks held positions to the eng.Now() minute bar, not the prior EOD close", func() {
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		strategy.mu.Lock()
+		defer strategy.mu.Unlock()
+
+		Expect(strategy.priceSeen).To(HaveLen(4)) // 2 days * 2 firings
+
+		// Day 1 buys 10 SPY at 10:00; the fill drains into the account
+		// before day 2's firings. On day 2 the account is marked to the
+		// day-2 minute bars (close 105 at 10:00, 106 at 14:00), not the
+		// day-1 EOD close (100) nor the day-2 EOD close (101).
+		Expect(strategy.priceSeen[2]).To(BeNumerically("~", 105.0, 1e-9))
+		Expect(strategy.priceSeen[3]).To(BeNumerically("~", 106.0, 1e-9))
+
+		Expect(strategy.posValueSeen[2]).To(BeNumerically("~", 10*105.0, 1e-6))
+		Expect(strategy.posValueSeen[3]).To(BeNumerically("~", 10*106.0, 1e-6))
+
+		// Total value reflects the live position mark. Cash after the
+		// fill is 10000 - 10*100.2 (filled at the day-1 10:01 bar) = 8998.
+		Expect(strategy.valueSeen[2]).To(BeNumerically("~", 8998+10*105.0, 1e-6))
+	})
+
+	It("sizes Allocate off the live intraday value, not the prior EOD close", func() {
+		strategy.doAllocate = true
+
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		strategy.mu.Lock()
+		defer strategy.mu.Unlock()
+
+		// Allocate runs once, on the day-2 10:00 firing, holding the 10 SPY
+		// bought on day 1 (cash 8998). The live projected value is
+		// 8998 + 10*105 = 10048; targeting 0.5 against a current position
+		// worth 10*105 = 1050 yields a buy of 0.5*10048 - 1050 = 3974.
+		// Sized off the day-2 EOD close (101) it would instead be
+		// 0.5*(8998+1010) - 1010 = 3994, so the ~20 difference pins the
+		// live mark.
+		Expect(strategy.allocAmounts).To(HaveLen(1))
+		Expect(strategy.allocAmounts[0]).To(BeNumerically("~", 3974.0, 1e-6))
+	})
+})
+
+// intradayMarginStrategy shorts a large SPY position on its first firing,
+// then on the day-2 10:00 firing attempts to extend the short. The attempt is
+// gated by the Reg-T initial-margin check, which depends on account equity --
+// and therefore on the price the engine marks the existing short to.
+type intradayMarginStrategy struct {
+	mu        sync.Mutex
+	spy       asset.Asset
+	firings   int
+	shorted   bool
+	triedMore bool
+	schedule  string
+}
+
+func (s *intradayMarginStrategy) Name() string           { return "intradayMargin" }
+func (s *intradayMarginStrategy) Setup(_ *engine.Engine) {}
+
+func (s *intradayMarginStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "intraday-margin", Schedule: s.schedule}
+}
+
+func (s *intradayMarginStrategy) Compute(
+	_ context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.firings++
+
+	if !s.shorted {
+		s.shorted = true
+
+		return batch.Order(context.Background(), s.spy, portfolio.Sell, 120)
+	}
+
+	// Day-2 10:00 firing: try to extend the short.
+	if !s.triedMore && s.firings == 3 {
+		s.triedMore = true
+
+		return batch.Order(context.Background(), s.spy, portfolio.Sell, 10)
+	}
+
+	return nil
+}
+
+var _ = Describe("intra-day margin checks", func() {
+	var (
+		nyc      *time.Location
+		start    time.Time
+		end      time.Time
+		spy      asset.Asset
+		eng      *engine.Engine
+		strategy *intradayMarginStrategy
+	)
+
+	BeforeEach(func() {
+		var locErr error
+
+		nyc, locErr = time.LoadLocation("America/New_York")
+		Expect(locErr).NotTo(HaveOccurred())
+
+		start = time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end = time.Date(2026, 5, 12, 23, 59, 59, 0, nyc)
+
+		spy = asset.Asset{Ticker: "SPY", CompositeFigi: "BBG000BDTBL9"}
+
+		dailyTimes := []time.Time{
+			time.Date(2026, 5, 11, 16, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 16, 0, 0, 0, nyc),
+		}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes,
+			[]asset.Asset{spy},
+			[]data.Metric{data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow, data.Volume, data.Dividend, data.SplitFactor},
+			data.Daily,
+			[][]float64{
+				{100, 101},             // close (EOD): day-2 short still well-collateralized
+				{100, 101},             // adj close
+				{102, 103},             // high
+				{99, 100},              // low
+				{1_000_000, 1_000_000}, // volume
+				{0, 0},                 // dividend
+				{1, 1},                 // split factor
+			})
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 10, 1, 0, 0, nyc),
+			time.Date(2026, 5, 11, 14, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 14, 1, 0, 0, nyc),
+			time.Date(2026, 5, 12, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 10, 1, 0, 0, nyc),
+			time.Date(2026, 5, 12, 14, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 14, 1, 0, 0, nyc),
+		}
+
+		// The day-2 minute price (130) is far above the day-2 EOD close
+		// (101): the short has moved sharply against the account intraday,
+		// cutting live equity well below what the EOD mark would show.
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes,
+			[]asset.Asset{spy},
+			[]data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume, data.AdjClose},
+			data.Tick,
+			[][]float64{
+				{100.1, 100.2, 100.3, 100.4, 130.0, 130.1, 131.0, 131.1}, // close
+				{100.5, 100.6, 100.7, 100.8, 130.5, 130.6, 131.5, 131.6}, // high
+				{99.5, 99.6, 99.7, 99.8, 129.5, 129.6, 130.5, 130.6},     // low
+				{50_000, 50_000, 50_000, 50_000, 50_000, 50_000, 50_000, 50_000},
+				{100.1, 100.2, 100.3, 100.4, 130.0, 130.1, 131.0, 131.1}, // adj close
+			})
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intradayProvider := data.NewIntradayTestProvider(minuteDF)
+
+		strategy = &intradayMarginStrategy{spy: spy, schedule: "0 10,14 * * MON-FRI"}
+
+		eng = engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: []asset.Asset{spy}}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intradayProvider),
+			engine.WithInitialDeposit(10000),
+		)
+	})
+
+	It("rejects an order that breaches initial margin under the live intraday mark", func() {
+		acct, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Day 1 shorts 120 SPY (fills at 100.2, proceeds 12024, cash 22024).
+		// On day-2 10:00 the live mark is 130, so the short is worth
+		// 120*130 = 15600 and equity is 22024 - 15600 = 6424. Extending the
+		// short by 10 (filling at 130.1) needs equity/newShortValue =
+		// 6424/16901 = 0.38 < 0.50 initial margin, so it is rejected and the
+		// position stays at -120. Marked to the day-2 EOD close (101) instead,
+		// equity would be 9904 and the ratio 9904/13421 = 0.74 >= 0.50, which
+		// would have let the extension through to -130. The -120 result
+		// therefore can only happen if the live intraday mark was used.
+		Expect(acct.Holdings()[spy]).To(BeNumerically("~", -120.0, 1e-9))
+	})
+})
+
+// intradayMultiMarkStrategy buys two assets on its first firing, then records
+// each asset's position value on every firing. It exercises the multi-asset
+// marking path, including held assets whose latest minute bar is older than
+// the firing minute.
+type intradayMultiMarkStrategy struct {
+	mu        sync.Mutex
+	spy       asset.Asset
+	tlt       asset.Asset
+	bought    bool
+	spyValues []float64
+	tltValues []float64
+	schedule  string
+}
+
+func (s *intradayMultiMarkStrategy) Name() string           { return "intradayMultiMark" }
+func (s *intradayMultiMarkStrategy) Setup(_ *engine.Engine) {}
+
+func (s *intradayMultiMarkStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "intraday-multi-mark", Schedule: s.schedule}
+}
+
+func (s *intradayMultiMarkStrategy) Compute(
+	_ context.Context,
+	_ *engine.Engine,
+	port portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.spyValues = append(s.spyValues, port.PositionValue(s.spy))
+	s.tltValues = append(s.tltValues, port.PositionValue(s.tlt))
+
+	if !s.bought {
+		s.bought = true
+
+		if err := batch.Order(context.Background(), s.spy, portfolio.Buy, 10); err != nil {
+			return err
+		}
+
+		return batch.Order(context.Background(), s.tlt, portfolio.Buy, 5)
+	}
+
+	return nil
+}
+
+var _ = Describe("intra-day marking with multiple held assets", func() {
+	var (
+		nyc      *time.Location
+		start    time.Time
+		end      time.Time
+		spy      asset.Asset
+		tlt      asset.Asset
+		eng      *engine.Engine
+		strategy *intradayMultiMarkStrategy
+	)
+
+	BeforeEach(func() {
+		var locErr error
+
+		nyc, locErr = time.LoadLocation("America/New_York")
+		Expect(locErr).NotTo(HaveOccurred())
+
+		start = time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end = time.Date(2026, 5, 12, 23, 59, 59, 0, nyc)
+
+		spy = asset.Asset{Ticker: "SPY", CompositeFigi: "BBG000BDTBL9"}
+		tlt = asset.Asset{Ticker: "TLT", CompositeFigi: "BBG000BDTBL0"}
+
+		dailyTimes := []time.Time{
+			time.Date(2026, 5, 11, 16, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 16, 0, 0, 0, nyc),
+		}
+
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes,
+			[]asset.Asset{spy, tlt},
+			dailyMetrics,
+			data.Daily,
+			[][]float64{
+				// SPY
+				{100, 101}, {100, 101}, {102, 103}, {99, 100}, {1_000_000, 1_000_000}, {0, 0}, {1, 1},
+				// TLT
+				{50, 51}, {50, 51}, {52, 53}, {49, 50}, {1_000_000, 1_000_000}, {0, 0}, {1, 1},
+			})
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		// Time grid is the union across both assets. SPY trades at the firing
+		// minute on day 2; TLT does not -- its latest day-2 morning bar is at
+		// 09:58 (NaN at 10:00), and it has no bar at all in the 13:54-14:00
+		// window before the 14:00 firing.
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 10, 0, 0, 0, nyc), // 0
+			time.Date(2026, 5, 11, 10, 1, 0, 0, nyc), // 1 (day-1 fill bar)
+			time.Date(2026, 5, 11, 14, 0, 0, 0, nyc), // 2
+			time.Date(2026, 5, 11, 14, 1, 0, 0, nyc), // 3
+			time.Date(2026, 5, 12, 9, 58, 0, 0, nyc), // 4 (TLT only)
+			time.Date(2026, 5, 12, 10, 0, 0, 0, nyc), // 5 (SPY only)
+			time.Date(2026, 5, 12, 10, 1, 0, 0, nyc), // 6
+			time.Date(2026, 5, 12, 14, 0, 0, 0, nyc), // 7 (SPY only)
+			time.Date(2026, 5, 12, 14, 1, 0, 0, nyc), // 8
+		}
+
+		nan := math.NaN()
+
+		minuteMetrics := []data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume, data.AdjClose}
+
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes,
+			[]asset.Asset{spy, tlt},
+			minuteMetrics,
+			data.Tick,
+			[][]float64{
+				// SPY close / high / low / volume / adjclose
+				{100.1, 100.2, 100.3, 100.4, nan, 105.0, 105.1, 106.0, 106.1},
+				{100.5, 100.6, 100.7, 100.8, nan, 105.5, 105.6, 106.5, 106.6},
+				{99.5, 99.6, 99.7, 99.8, nan, 104.5, 104.6, 105.5, 105.6},
+				{50_000, 50_000, 50_000, 50_000, nan, 50_000, 50_000, 50_000, 50_000},
+				{100.1, 100.2, 100.3, 100.4, nan, 105.0, 105.1, 106.0, 106.1},
+				// TLT close / high / low / volume / adjclose
+				{50.0, 50.0, 50.0, 50.0, 50.0, nan, 50.1, nan, nan},
+				{50.2, 50.2, 50.2, 50.2, 50.2, nan, 50.3, nan, nan},
+				{49.8, 49.8, 49.8, 49.8, 49.8, nan, 49.9, nan, nan},
+				{50_000, 50_000, 50_000, 50_000, 50_000, nan, 50_000, nan, nan},
+				{50.0, 50.0, 50.0, 50.0, 50.0, nan, 50.1, nan, nan},
+			})
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intradayProvider := data.NewIntradayTestProvider(minuteDF)
+
+		strategy = &intradayMultiMarkStrategy{spy: spy, tlt: tlt, schedule: "0 10,14 * * MON-FRI"}
+
+		eng = engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: []asset.Asset{spy, tlt}}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intradayProvider),
+			engine.WithInitialDeposit(10000),
+		)
+	})
+
+	It("marks each held asset to its own latest bar and never drops one missing the firing minute", func() {
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		strategy.mu.Lock()
+		defer strategy.mu.Unlock()
+
+		Expect(strategy.spyValues).To(HaveLen(4))
+
+		// Day-2 10:00 firing (index 2): SPY trades at 10:00 (105) while TLT's
+		// latest bar in the 09:54-10:00 window is 09:58 (50). TLT must be
+		// marked to 50, not dropped to 0 because it lacks a 10:00 bar.
+		Expect(strategy.spyValues[2]).To(BeNumerically("~", 10*105.0, 1e-6))
+		Expect(strategy.tltValues[2]).To(BeNumerically("~", 5*50.0, 1e-6))
+
+		// Day-2 14:00 firing (index 3): TLT has no bar in the window at all,
+		// so it carries forward its prior mark (50) rather than dropping to 0.
+		Expect(strategy.spyValues[3]).To(BeNumerically("~", 10*106.0, 1e-6))
+		Expect(strategy.tltValues[3]).To(BeNumerically("~", 5*50.0, 1e-6))
+	})
+})
 
 var _ = Describe("intra-day firings", func() {
 	var (

--- a/portfolio/batch.go
+++ b/portfolio/batch.go
@@ -108,55 +108,7 @@ func (b *Batch) Order(_ context.Context, ast asset.Asset, side Side, qty float64
 		order.Side = broker.Sell
 	}
 
-	var hasLimit, hasStop bool
-
-	var bracket *bracketModifier
-
-	var oco *ocoModifier
-
-	for _, mod := range mods {
-		switch modifier := mod.(type) {
-		case limitModifier:
-			order.LimitPrice = modifier.price
-			hasLimit = true
-		case stopModifier:
-			order.StopPrice = modifier.price
-			hasStop = true
-		case dayOrderModifier:
-			order.TimeInForce = broker.Day
-		case goodTilCancelModifier:
-			order.TimeInForce = broker.GTC
-		case fillOrKillModifier:
-			order.TimeInForce = broker.FOK
-		case immediateOrCancelModifier:
-			order.TimeInForce = broker.IOC
-		case onTheOpenModifier:
-			order.TimeInForce = broker.OnOpen
-		case onTheCloseModifier:
-			order.TimeInForce = broker.OnClose
-		case goodTilDateModifier:
-			order.TimeInForce = broker.GTD
-			order.GTDDate = modifier.date
-		case justificationModifier:
-			order.Justification = modifier.reason
-		case lotSelectionModifier:
-			order.LotSelection = int(modifier.method)
-		case bracketModifier:
-			// handled in post-expansion below
-			bracket = &modifier
-		case ocoModifier:
-			// handled in post-expansion below
-			oco = &modifier
-		}
-	}
-
-	if hasLimit && hasStop {
-		order.OrderType = broker.StopLimit
-	} else if hasLimit {
-		order.OrderType = broker.Limit
-	} else if hasStop {
-		order.OrderType = broker.Stop
-	}
+	bracket, oco := applyOrderModifiers(&order, mods)
 
 	groupIndex := len(b.groups)
 	ts := b.Timestamp.UnixNano()
@@ -225,6 +177,139 @@ func (b *Batch) Order(_ context.Context, ast asset.Asset, side Side, qty float64
 		})
 
 		return nil
+	}
+
+	b.Orders = append(b.Orders, order)
+
+	return nil
+}
+
+// applyOrderModifiers applies the order modifiers to order, setting limit and
+// stop prices, time-in-force, justification, and lot selection, and inferring
+// the order type from the presence of limit/stop prices. Bracket and OCO
+// modifiers are not applied to the order directly; they are returned so the
+// caller can perform the group expansion. Either return value is nil when the
+// corresponding modifier is absent.
+func applyOrderModifiers(order *broker.Order, mods []OrderModifier) (*bracketModifier, *ocoModifier) {
+	var hasLimit, hasStop bool
+
+	var bracket *bracketModifier
+
+	var oco *ocoModifier
+
+	for _, mod := range mods {
+		switch modifier := mod.(type) {
+		case limitModifier:
+			order.LimitPrice = modifier.price
+			hasLimit = true
+		case stopModifier:
+			order.StopPrice = modifier.price
+			hasStop = true
+		case dayOrderModifier:
+			order.TimeInForce = broker.Day
+		case goodTilCancelModifier:
+			order.TimeInForce = broker.GTC
+		case fillOrKillModifier:
+			order.TimeInForce = broker.FOK
+		case immediateOrCancelModifier:
+			order.TimeInForce = broker.IOC
+		case onTheOpenModifier:
+			order.TimeInForce = broker.OnOpen
+		case onTheCloseModifier:
+			order.TimeInForce = broker.OnClose
+		case goodTilDateModifier:
+			order.TimeInForce = broker.GTD
+			order.GTDDate = modifier.date
+		case justificationModifier:
+			order.Justification = modifier.reason
+		case lotSelectionModifier:
+			order.LotSelection = int(modifier.method)
+		case bracketModifier:
+			captured := modifier
+			bracket = &captured
+		case ocoModifier:
+			captured := modifier
+			oco = &captured
+		}
+	}
+
+	if hasLimit && hasStop {
+		order.OrderType = broker.StopLimit
+	} else if hasLimit {
+		order.OrderType = broker.Limit
+	} else if hasStop {
+		order.OrderType = broker.Stop
+	}
+
+	return bracket, oco
+}
+
+// Allocate appends a single order that drives the named asset toward the
+// target weight of the portfolio's projected value, leaving every other
+// position untouched. It is the incremental, single-name analogue of
+// RebalanceTo (which replaces the entire book and liquidates any held name
+// absent from the allocation). The order is sized off ProjectedValue and the
+// asset's projected position value at the time of the call; during an
+// intra-day firing those reflect the live eng.Now() marks, so the resulting
+// position value is approximately weight * portfolio value once the order
+// fills at the next bar. A negative weight opens or extends a short position.
+// Allocate is a no-op when the position is already at the target. Bracket and
+// OCO modifiers are not supported.
+func (b *Batch) Allocate(_ context.Context, ast asset.Asset, weight float64, mods ...OrderModifier) error {
+	targetDollars := weight * b.ProjectedValue()
+	diff := targetDollars - b.projectedPositionValue(ast)
+
+	if diff == 0 {
+		return nil
+	}
+
+	order := broker.Order{
+		Asset:       ast,
+		Amount:      math.Abs(diff),
+		OrderType:   broker.Market,
+		TimeInForce: broker.Day,
+		Side:        broker.Buy,
+	}
+
+	if diff < 0 {
+		order.Side = broker.Sell
+	}
+
+	bracket, oco := applyOrderModifiers(&order, mods)
+	if bracket != nil || oco != nil {
+		return fmt.Errorf("portfolio: Allocate does not support bracket or OCO modifiers")
+	}
+
+	b.Orders = append(b.Orders, order)
+
+	return nil
+}
+
+// Liquidate appends a single order that closes the named asset's projected
+// position, leaving every other position untouched. A long position is sold
+// and a short position is covered. It is a no-op when the projected position
+// is flat. Bracket and OCO modifiers are not supported.
+func (b *Batch) Liquidate(_ context.Context, ast asset.Asset, mods ...OrderModifier) error {
+	qty := b.ProjectedHoldings()[ast]
+	if qty == 0 {
+		return nil
+	}
+
+	order := broker.Order{
+		Asset:       ast,
+		Qty:         math.Abs(qty),
+		OrderType:   broker.Market,
+		TimeInForce: broker.Day,
+		Side:        broker.Sell,
+	}
+
+	if qty < 0 {
+		order.Side = broker.Buy
+	}
+
+	bracket, oco := applyOrderModifiers(&order, mods)
+	if bracket != nil || oco != nil {
+		return fmt.Errorf("portfolio: Liquidate does not support bracket or OCO modifiers")
 	}
 
 	b.Orders = append(b.Orders, order)

--- a/portfolio/batch_test.go
+++ b/portfolio/batch_test.go
@@ -789,6 +789,185 @@ var _ = Describe("Batch", func() {
 			Expect(aaplBuys).To(HaveLen(1))
 		})
 	})
+
+	Describe("Allocate", func() {
+		It("appends a buy sized off projected value for an unheld asset", func() {
+			// 10k cash, no positions. Target SPY weight 0.5 => $5000 buy.
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			batch := portfolio.NewBatch(ts, acct)
+
+			Expect(batch.Allocate(context.Background(), spy, 0.5)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Asset).To(Equal(spy))
+			Expect(batch.Orders[0].Side).To(Equal(broker.Buy))
+			Expect(batch.Orders[0].Amount).To(BeNumerically("~", 5_000.0, 1e-9))
+			Expect(batch.Orders[0].Qty).To(Equal(0.0))
+		})
+
+		It("appends a sell for the delta when reducing an existing position", func() {
+			// Buy 100 SPY @ 100 from 10000 cash => cash 0, holdings 10000,
+			// total 10000. Target 0.3 => $3000; current $10000 => sell $7000.
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: spy, Type: asset.BuyTransaction,
+				Qty: 100, Price: 100, Amount: -10_000,
+			})
+
+			batch := portfolio.NewBatch(ts, acct)
+			Expect(batch.Allocate(context.Background(), spy, 0.3)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Side).To(Equal(broker.Sell))
+			Expect(batch.Orders[0].Amount).To(BeNumerically("~", 7_000.0, 1e-9))
+		})
+
+		It("opens a short for a negative weight", func() {
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			batch := portfolio.NewBatch(ts, acct)
+
+			Expect(batch.Allocate(context.Background(), spy, -0.4)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Side).To(Equal(broker.Sell))
+			Expect(batch.Orders[0].Amount).To(BeNumerically("~", 4_000.0, 1e-9))
+		})
+
+		It("is a no-op when already at the target weight", func() {
+			// Buy 50 SPY @ 100 from 10000 cash => cash 5000, holdings 5000,
+			// total 10000, SPY already at 0.5.
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: spy, Type: asset.BuyTransaction,
+				Qty: 50, Price: 100, Amount: -5_000,
+			})
+
+			batch := portfolio.NewBatch(ts, acct)
+			Expect(batch.Allocate(context.Background(), spy, 0.5)).To(Succeed())
+
+			Expect(batch.Orders).To(BeEmpty())
+		})
+
+		It("adjusts only the named asset, leaving other holdings untouched", func() {
+			// SPY 40 @ 100 = 4000, AAPL 10 @ 200 = 2000, cash 4000, total 10000.
+			df, err := data.NewDataFrame(
+				[]time.Time{ts},
+				[]asset.Asset{spy, aapl},
+				[]data.Metric{data.MetricClose},
+				data.Daily,
+				[][]float64{{100}, {200}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			acct := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+			acct.UpdatePrices(df)
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: spy, Type: asset.BuyTransaction,
+				Qty: 40, Price: 100, Amount: -4_000,
+			})
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: aapl, Type: asset.BuyTransaction,
+				Qty: 10, Price: 200, Amount: -2_000,
+			})
+
+			batch := portfolio.NewBatch(ts, acct)
+			Expect(batch.Allocate(context.Background(), spy, 0.6)).To(Succeed())
+
+			// Only SPY orders; AAPL untouched.
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Asset).To(Equal(spy))
+			Expect(ordersForAsset(batch.Orders, aapl)).To(BeEmpty())
+		})
+
+		It("rejects bracket and OCO modifiers", func() {
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			batch := portfolio.NewBatch(ts, acct)
+
+			err := batch.Allocate(context.Background(), spy, 0.5,
+				portfolio.WithBracket(portfolio.StopLossPrice(90.0), portfolio.TakeProfitPrice(115.0)))
+			Expect(err).To(HaveOccurred())
+			Expect(batch.Orders).To(BeEmpty())
+		})
+
+		It("applies a Limit modifier", func() {
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			batch := portfolio.NewBatch(ts, acct)
+
+			Expect(batch.Allocate(context.Background(), spy, 0.5, portfolio.Limit(99.0))).To(Succeed())
+
+			Expect(batch.Orders[0].OrderType).To(Equal(broker.Limit))
+			Expect(batch.Orders[0].LimitPrice).To(Equal(99.0))
+		})
+	})
+
+	Describe("Liquidate", func() {
+		It("sells the full long position", func() {
+			acct := buildPricedAccount(0, []asset.Asset{spy}, []float64{100})
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: spy, Type: asset.BuyTransaction,
+				Qty: 25, Price: 100, Amount: -2_500,
+			})
+
+			batch := portfolio.NewBatch(ts, acct)
+			Expect(batch.Liquidate(context.Background(), spy)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Side).To(Equal(broker.Sell))
+			Expect(batch.Orders[0].Qty).To(Equal(25.0))
+		})
+
+		It("covers the full short position", func() {
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: spy, Type: asset.SellTransaction,
+				Qty: 30, Price: 100, Amount: 3_000,
+			})
+
+			batch := portfolio.NewBatch(ts, acct)
+			Expect(batch.Liquidate(context.Background(), spy)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Side).To(Equal(broker.Buy))
+			Expect(batch.Orders[0].Qty).To(Equal(30.0))
+		})
+
+		It("is a no-op for a flat position", func() {
+			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
+			batch := portfolio.NewBatch(ts, acct)
+
+			Expect(batch.Liquidate(context.Background(), spy)).To(Succeed())
+			Expect(batch.Orders).To(BeEmpty())
+		})
+
+		It("leaves other holdings untouched", func() {
+			df, err := data.NewDataFrame(
+				[]time.Time{ts},
+				[]asset.Asset{spy, aapl},
+				[]data.Metric{data.MetricClose},
+				data.Daily,
+				[][]float64{{100}, {200}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			acct := portfolio.New(portfolio.WithCash(0, time.Time{}))
+			acct.UpdatePrices(df)
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: spy, Type: asset.BuyTransaction,
+				Qty: 10, Price: 100, Amount: -1_000,
+			})
+			acct.Record(portfolio.Transaction{
+				Date: ts, Asset: aapl, Type: asset.BuyTransaction,
+				Qty: 5, Price: 200, Amount: -1_000,
+			})
+
+			batch := portfolio.NewBatch(ts, acct)
+			Expect(batch.Liquidate(context.Background(), spy)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(1))
+			Expect(batch.Orders[0].Asset).To(Equal(spy))
+			Expect(ordersForAsset(batch.Orders, aapl)).To(BeEmpty())
+		})
+	})
 })
 
 // ordersWithSide filters a slice of orders by side.


### PR DESCRIPTION
Closes #192.

## Problem 1: live intraday marks
During an intra-day firing the account was marked to the prior end-of-day close, so order sizing and margin/leverage checks used stale prices even though fills land at the next minute bar.

Now, when a firing is strictly inside the trading session, the account is marked to the minute bar as of `eng.Now()`. `Value`, `PositionValue`, `Prices`, `RebalanceTo`/`Allocate` sizing, and the simulated broker's margin and gross-leverage checks all evaluate against that live mark. The mark price (the `eng.Now()` bar) is distinct from the fill price (the next minute bar), so a small sizing-vs-fill gap remains as realistic slippage. End-of-day equity recording is unchanged, so daily backtests are identical.

Each held asset is marked to its **own** most recent bar. Minute bars are sparse, so a thinly-traded name may not print at the firing minute; it keeps its last known mark rather than being silently valued at zero. A held asset with neither a window bar nor a prior mark is a hard error.

## Problem 2: weight-target order helpers
`RebalanceTo` replaces the whole book. New `Batch.Allocate(ctx, asset, weight)` and `Batch.Liquidate(ctx, asset)` adjust a single name and leave all other holdings untouched.

## Tests
- `Allocate`/`Liquidate` unit tests (sizing, short, no-op, only-named-asset, modifiers).
- End-to-end engine tests for: marks reflect the `eng.Now()` bar; `Allocate` sizes off the live mark; margin rejection uses live marks; multi-asset sparse-data marking (per-asset latest + carry-forward). The marking tests fail if the mark is removed.

Full suite (26 Ginkgo suites) and `make lint` pass.