### PR TITLE
perf(engine): cache intraday minute-bar fetches per firing (#194)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - During an intra-day firing, the account is now marked to the live minute bar as of `engine.Now()` rather than the prior end-of-day close. Order sizing and margin/leverage checks therefore use the price at the firing moment; orders still fill at the next minute bar. Each held asset is marked to its own most recent bar, so a name that did not trade at the firing minute keeps its last known price instead of being valued at zero. End-of-day valuation is unchanged, so daily backtests produce identical results.
+- Intra-day backtests against a remote minute-bar source run substantially faster: the next-minute-bar window for a firing's order fills is now fetched once and reused across all orders, instead of issuing a separate fetch per order. Results are unchanged.
 
 ## [0.10.4] - 2026-06-01
 

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -407,7 +407,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 		}
 
 		// 13-14b. Housekeep parent account (dividends + fill draining).
-		if err := e.housekeepAccount(stepCtx, acct, date, e.benchmark); err != nil {
+		if err := e.housekeepAccount(stepCtx, acct, date); err != nil {
 			return nil, err
 		}
 
@@ -507,7 +507,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 				return nil, fmt.Errorf("engine: child %q prefetch housekeeping on %v: %w", child.name, date, err)
 			}
 
-			if err := e.housekeepAccount(stepCtx, child.account, date, asset.Asset{}); err != nil {
+			if err := e.housekeepAccount(stepCtx, child.account, date); err != nil {
 				return nil, fmt.Errorf("engine: child %q housekeeping on %v: %w", child.name, date, err)
 			}
 
@@ -548,10 +548,9 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 }
 
 // housekeepAccount records dividends for held assets and drains broker fills
-// for the given account on date. benchmark controls whether the benchmark asset
-// is included in the housekeeping data fetch; pass asset.Asset{} for child
-// accounts that have no benchmark.
-func (eng *Engine) housekeepAccount(ctx context.Context, acct portfolio.PortfolioManager, date time.Time, benchmark asset.Asset) error {
+// for the given account on date. Price prefetching, including the benchmark, is
+// handled separately by prefetchHousekeepingPrices.
+func (eng *Engine) housekeepAccount(ctx context.Context, acct portfolio.PortfolioManager, date time.Time) error {
 	// Drain fills from previous step (before syncing transactions).
 	if acct.HasBroker() {
 		if drainErr := acct.DrainFills(ctx); drainErr != nil {

--- a/engine/backtest_test.go
+++ b/engine/backtest_test.go
@@ -210,16 +210,19 @@ func (s *buyThenSellStrategy) Describe() engine.StrategyDescription {
 
 func (s *buyThenSellStrategy) Compute(ctx context.Context, eng *engine.Engine, fund portfolio.Portfolio, batch *portfolio.Batch) error {
 	s.callCount++
-	if s.callCount == 1 {
+
+	switch s.callCount {
+	case 1:
 		// Buy 10 shares on first call.
 		batch.Order(ctx, s.target, portfolio.Buy, 10)
-	} else if s.callCount == 2 {
+	case 2:
 		// Sell all shares on second call.
 		qty := fund.Position(s.target)
 		if qty > 0 {
 			batch.Order(ctx, s.target, portfolio.Sell, qty)
 		}
 	}
+
 	return nil
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"time"
 
@@ -77,6 +78,7 @@ type Engine struct {
 	// populated during initialization
 	assets                map[string]asset.Asset
 	cache                 *dataCache
+	intradayFill          *intradayFillCache // per-firing next-minute-bar window cache; keyed by currentTime
 	currentDate           time.Time
 	currentTime           time.Time // intra-day firing timestamp; equals currentDate (end-of-day) outside of intra-day Compute calls
 	start                 time.Time
@@ -762,14 +764,7 @@ func (e *Engine) fetchRange(ctx context.Context, assets []asset.Asset, metrics [
 	// Fast path: point-in-time queries (rangeStart == rangeEnd) skip the
 	// union-time-axis rebuild and binary-search cached year chunks directly.
 	if rangeStart.Equal(rangeEnd) {
-		hasFundamental := false
-
-		for _, m := range metrics {
-			if data.IsFundamental(m) {
-				hasFundamental = true
-				break
-			}
-		}
+		hasFundamental := slices.ContainsFunc(metrics, data.IsFundamental)
 
 		result, pitErr := e.assemblePointInTime(assets, metrics, rangeEnd, hasFundamental)
 		if pitErr != nil {
@@ -812,14 +807,7 @@ func (e *Engine) fetchRange(ctx context.Context, assets []asset.Asset, metrics [
 	// recent prior filing. Otherwise, asking for fundamentals on a calendar
 	// date that happens to fall on a weekend or holiday returns an empty
 	// frame because no provider emitted data on that exact day.
-	hasFundamental := false
-
-	for _, metric := range metrics {
-		if data.IsFundamental(metric) {
-			hasFundamental = true
-			break
-		}
-	}
+	hasFundamental := slices.ContainsFunc(metrics, data.IsFundamental)
 
 	if hasFundamental && rangeStart.Equal(rangeEnd) {
 		timeSet[rangeEnd.Unix()] = rangeEnd
@@ -999,7 +987,7 @@ func (e *Engine) Close() error {
 
 	// Close the broker.
 	if e.broker != nil {
-		if err := e.broker.Close(); err != nil && firstErr == nil {
+		if err := e.broker.Close(); err != nil {
 			firstErr = err
 		}
 	}
@@ -1092,25 +1080,39 @@ func (e *Engine) nextMinuteBar(ctx context.Context, assets []asset.Asset) (*data
 	start := e.currentTime.Add(time.Minute)
 	end := e.currentTime.Add(6 * time.Minute)
 
-	df, err := provider.IntradayFetch(ctx, assets,
+	// The fill path re-enters nextMinuteBar once per order plus once for the
+	// batch prefetch, all within a single firing for the same window. Serve
+	// every call after the first from a per-firing cache so a remote source
+	// sees one round-trip instead of N+1.
+	window, err := e.intradayFillWindow(ctx, provider, assets,
 		[]data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume},
-		start, end, nil)
+		start, end)
 	if err != nil {
-		return nil, fmt.Errorf("engine: fetch next minute bar: %w", err)
+		return nil, err
 	}
 
-	if df.Len() == 0 {
-		return nil, fmt.Errorf(
-			"engine: no minute bar available after %s for order fill",
-			e.currentTime.Format(time.RFC3339))
+	// Slice the window to the requested assets and return the earliest bar
+	// at which any of them traded. A direct per-asset IntradayFetch builds
+	// its time axis from only that asset's bars, so its first row is the
+	// asset's first bar; selecting the earliest non-empty bar out of the
+	// shared window reproduces that row exactly, changing only the number
+	// of provider round-trips, not the returned values.
+	sliced := window.Assets(assets...)
+
+	for _, ts := range sliced.Times() {
+		for _, want := range assets {
+			if !math.IsNaN(sliced.ValueAt(want, data.MetricClose, ts)) {
+				earliest := sliced.At(ts)
+				earliest.SetSource(e)
+
+				return earliest, nil
+			}
+		}
 	}
 
-	// Slice to the earliest bar so the broker fills on the immediate
-	// next minute rather than an arbitrary later one.
-	earliest := df.At(df.Times()[0])
-	earliest.SetSource(e)
-
-	return earliest, nil
+	return nil, fmt.Errorf(
+		"engine: no minute bar available after %s for order fill",
+		e.currentTime.Format(time.RFC3339))
 }
 
 // markBarLookback bounds how far back markBar searches for each asset's most

--- a/engine/intraday_fill_cache.go
+++ b/engine/intraday_fill_cache.go
@@ -1,0 +1,113 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+)
+
+// intradayFillCache memoizes the next-minute-bar window fetched during a single
+// intra-day firing. Order fills route through nextMinuteBar once per order (via
+// SimulatedBroker.Submit) plus once for the batch prefetch
+// (prefetchBrokerPrices); against a remote ClickHouse source each call is an
+// independent round-trip for the same [currentTime+1m, currentTime+6m] window.
+// The cache holds the window fetched for the union of requested assets so every
+// per-order lookup within the firing is served locally. It is keyed by the
+// firing timestamp and is invalid once currentTime advances to the next firing,
+// so it never serves stale bars across firings.
+type intradayFillCache struct {
+	firingTime time.Time
+	assets     []asset.Asset
+	covered    map[string]bool
+	window     *data.DataFrame
+}
+
+// covers reports whether the cached window already includes every requested
+// asset.
+func (c *intradayFillCache) covers(assets []asset.Asset) bool {
+	for _, want := range assets {
+		if !c.covered[want.CompositeFigi] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// intradayFillWindow returns the minute-bar window covering the requested
+// assets for the current firing, issuing an IntradayFetch only on a cache miss.
+// A miss within the same firing widens the fetch to the union of previously
+// cached and newly requested assets, so an asset fetched earlier in the firing
+// is never evicted by a later lookup for a different one.
+func (e *Engine) intradayFillWindow(
+	ctx context.Context,
+	provider IntradayProvider,
+	assets []asset.Asset,
+	metrics []data.Metric,
+	start, end time.Time,
+) (*data.DataFrame, error) {
+	if e.intradayFill != nil && e.intradayFill.firingTime.Equal(e.currentTime) {
+		if e.intradayFill.covers(assets) {
+			return e.intradayFill.window, nil
+		}
+
+		assets = unionAssets(e.intradayFill.assets, assets)
+	}
+
+	window, err := provider.IntradayFetch(ctx, assets, metrics, start, end, nil)
+	if err != nil {
+		return nil, fmt.Errorf("engine: fetch intraday fill window: %w", err)
+	}
+
+	covered := make(map[string]bool, len(assets))
+	for _, held := range assets {
+		covered[held.CompositeFigi] = true
+	}
+
+	e.intradayFill = &intradayFillCache{
+		firingTime: e.currentTime,
+		assets:     assets,
+		covered:    covered,
+		window:     window,
+	}
+
+	return window, nil
+}
+
+// unionAssets returns the assets in base followed by any in extra not already
+// present, deduplicating by composite figi while preserving order.
+func unionAssets(base, extra []asset.Asset) []asset.Asset {
+	seen := make(map[string]bool, len(base)+len(extra))
+	union := make([]asset.Asset, 0, len(base)+len(extra))
+
+	for _, group := range [][]asset.Asset{base, extra} {
+		for _, held := range group {
+			if seen[held.CompositeFigi] {
+				continue
+			}
+
+			seen[held.CompositeFigi] = true
+			union = append(union, held)
+		}
+	}
+
+	return union
+}

--- a/engine/intraday_fill_cache_test.go
+++ b/engine/intraday_fill_cache_test.go
@@ -1,0 +1,351 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine_test
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+// intradayBasketStrategy buys one share of each asset in its basket on every
+// scheduled firing. A multi-order firing routes one order-fill price lookup per
+// asset through the intraday path, so it exercises the per-firing fill cache.
+type intradayBasketStrategy struct {
+	mu       sync.Mutex
+	basket   []asset.Asset
+	schedule string
+}
+
+func (s *intradayBasketStrategy) Name() string           { return "intradayBasket" }
+func (s *intradayBasketStrategy) Setup(_ *engine.Engine) {}
+
+func (s *intradayBasketStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "intraday-basket", Schedule: s.schedule}
+}
+
+func (s *intradayBasketStrategy) Compute(
+	ctx context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, held := range s.basket {
+		if err := batch.Order(ctx, held, portfolio.Buy, 1); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// intradayProbeStrategy queries Engine.Prices for assetX, then assetY, then
+// assetX again on its single firing, placing no orders. It exercises the
+// fill-window cache directly: the assetY lookup is a miss against a cache that
+// holds only assetX, and the repeat assetX lookup must still be a hit.
+type intradayProbeStrategy struct {
+	mu       sync.Mutex
+	assetX   asset.Asset
+	assetY   asset.Asset
+	schedule string
+}
+
+func (s *intradayProbeStrategy) Name() string           { return "intradayProbe" }
+func (s *intradayProbeStrategy) Setup(_ *engine.Engine) {}
+
+func (s *intradayProbeStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "intraday-probe", Schedule: s.schedule}
+}
+
+func (s *intradayProbeStrategy) Compute(
+	ctx context.Context,
+	eng *engine.Engine,
+	_ portfolio.Portfolio,
+	_ *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, want := range []asset.Asset{s.assetX, s.assetY, s.assetX} {
+		if _, err := eng.Prices(ctx, want); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var _ = Describe("intra-day fill window caching", func() {
+	var (
+		nyc    *time.Location
+		basket []asset.Asset
+	)
+
+	// buildEngine wires an engine for the given strategy whose intraday source
+	// is a counting provider, over a basket of three assets that all trade at
+	// 10:00 and 10:01 on both 2026-05-11 and 2026-05-12.
+	buildEngine := func(strategy engine.Strategy) (*engine.Engine, *countingIntradayProvider) {
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+
+		dailyTimes := []time.Time{
+			time.Date(2026, 5, 11, 16, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 16, 0, 0, 0, nyc),
+		}
+
+		// Three assets with distinct, easily-checked EOD closes.
+		dailyCols := [][]float64{
+			// AAA
+			{10, 11}, {10, 11}, {12, 13}, {9, 10}, {1_000_000, 1_000_000}, {0, 0}, {1, 1},
+			// BBB
+			{20, 21}, {20, 21}, {22, 23}, {19, 20}, {1_000_000, 1_000_000}, {0, 0}, {1, 1},
+			// CCC
+			{30, 31}, {30, 31}, {32, 33}, {29, 30}, {1_000_000, 1_000_000}, {0, 0}, {1, 1},
+		}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes, basket, dailyMetrics, data.Daily, dailyCols)
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 10, 1, 0, 0, nyc),
+			time.Date(2026, 5, 12, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 12, 10, 1, 0, 0, nyc),
+		}
+
+		minuteMetrics := []data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume}
+
+		// Per asset: close at 10:00 / 10:01 across the two days. The 10:01 bar
+		// is the next-minute-bar that fills a 10:00 firing.
+		minuteCols := [][]float64{
+			// AAA close / high / low / volume
+			{10.0, 10.05, 11.0, 11.05},
+			{10.1, 10.15, 11.1, 11.15},
+			{9.9, 9.95, 10.9, 10.95},
+			{50_000, 50_000, 50_000, 50_000},
+			// BBB
+			{20.0, 20.05, 21.0, 21.05},
+			{20.1, 20.15, 21.1, 21.15},
+			{19.9, 19.95, 20.9, 20.95},
+			{50_000, 50_000, 50_000, 50_000},
+			// CCC
+			{30.0, 30.05, 31.0, 31.05},
+			{30.1, 30.15, 31.1, 31.15},
+			{29.9, 29.95, 30.9, 30.95},
+			{50_000, 50_000, 50_000, 50_000},
+		}
+
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes, basket, minuteMetrics, data.Tick, minuteCols)
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intraday := &countingIntradayProvider{IntradayTestProvider: data.NewIntradayTestProvider(minuteDF)}
+
+		eng := engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: basket}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intraday),
+			engine.WithInitialDeposit(10000),
+		)
+
+		return eng, intraday
+	}
+
+	BeforeEach(func() {
+		var locErr error
+
+		nyc, locErr = time.LoadLocation("America/New_York")
+		Expect(locErr).NotTo(HaveOccurred())
+
+		basket = []asset.Asset{
+			{Ticker: "AAA", CompositeFigi: "BBG000000001"},
+			{Ticker: "BBB", CompositeFigi: "BBG000000002"},
+			{Ticker: "CCC", CompositeFigi: "BBG000000003"},
+		}
+	})
+
+	It("serves every per-order fill in a firing from a single IntradayFetch", func() {
+		// One trading day, one 10:00 firing buying all three assets. The
+		// prefetch issues one IntradayFetch; the three per-order Submit price
+		// lookups are cache hits. No prior holdings means no mark-bar fetch.
+		start := time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end := time.Date(2026, 5, 11, 23, 59, 59, 0, nyc)
+
+		eng, intraday := buildEngine(&intradayBasketStrategy{basket: basket, schedule: "0 10 * * MON-FRI"})
+
+		fund, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(intraday.callCount()).To(Equal(1),
+			"a 3-order firing must fetch the next-minute-bar window once, not once per order")
+
+		// Each order fills at its asset's 10:01 close, proving the cached
+		// window serves correct per-asset bars.
+		fills := map[string]float64{}
+		for _, txn := range fund.Transactions() {
+			if txn.Type == asset.BuyTransaction {
+				fills[txn.Asset.Ticker] = txn.Price
+			}
+		}
+
+		Expect(fills["AAA"]).To(BeNumerically("~", 10.05, 1e-9))
+		Expect(fills["BBB"]).To(BeNumerically("~", 20.05, 1e-9))
+		Expect(fills["CCC"]).To(BeNumerically("~", 30.05, 1e-9))
+	})
+
+	It("re-fetches the window on the next firing rather than serving a stale one", func() {
+		// Two trading days, one 10:00 firing each buying all three assets.
+		// Day 1: no holdings, so prefetch issues 1 fetch and the 3 fills hit
+		// the cache. Day 2: holdings exist, so mark-bar issues 1 fetch; the
+		// cache from day 1 is invalid at the new firing time, so the prefetch
+		// issues a fresh fetch and the 3 fills hit it. Total: 1 + 2 = 3.
+		// A stale cache that survived across firings would total 2; no caching
+		// at all would total 9.
+		start := time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end := time.Date(2026, 5, 12, 23, 59, 59, 0, nyc)
+
+		eng, intraday := buildEngine(&intradayBasketStrategy{basket: basket, schedule: "0 10 * * MON-FRI"})
+
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(intraday.callCount()).To(Equal(3))
+	})
+
+	It("fills each asset at its own earliest bar when bars are staggered in the window", func() {
+		// The riskiest equivalence case: within the shared next-minute-bar
+		// window the three assets first trade at different minutes. A direct
+		// per-asset fetch builds its time axis from only that asset's bars, so
+		// each fills at its own first bar. Serving from a single multi-asset
+		// window (which carries the union time axis) must reproduce that: AAA
+		// and BBB fill at 10:01, while CCC -- absent at 10:01 -- must fill at
+		// its 10:03 bar, not be valued NaN at 10:01 and dropped.
+		nan := math.NaN()
+
+		start := time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end := time.Date(2026, 5, 11, 23, 59, 59, 0, nyc)
+
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+
+		dailyTimes := []time.Time{time.Date(2026, 5, 11, 16, 0, 0, 0, nyc)}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes, basket, dailyMetrics, data.Daily,
+			[][]float64{
+				{10}, {10}, {12}, {9}, {1_000_000}, {0}, {1}, // AAA
+				{20}, {20}, {22}, {19}, {1_000_000}, {0}, {1}, // BBB
+				{30}, {30}, {32}, {29}, {1_000_000}, {0}, {1}, // CCC
+			})
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		// Union time axis [10:00, 10:01, 10:03]. CCC has no 10:01 bar; AAA and
+		// BBB have no 10:03 bar.
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 10, 1, 0, 0, nyc),
+			time.Date(2026, 5, 11, 10, 3, 0, 0, nyc),
+		}
+
+		minuteMetrics := []data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume}
+
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes, basket, minuteMetrics, data.Tick,
+			[][]float64{
+				// AAA close / high / low / volume -- no 10:03 bar
+				{10.0, 10.05, nan},
+				{10.0, 10.06, nan},
+				{10.0, 9.95, nan},
+				{50_000, 50_000, nan},
+				// BBB -- no 10:03 bar
+				{20.0, 20.05, nan},
+				{20.0, 20.06, nan},
+				{20.0, 19.95, nan},
+				{50_000, 50_000, nan},
+				// CCC -- no 10:01 bar, first window bar at 10:03
+				{30.0, nan, 30.3},
+				{30.0, nan, 30.4},
+				{30.0, nan, 30.2},
+				{50_000, nan, 50_000},
+			})
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intraday := &countingIntradayProvider{IntradayTestProvider: data.NewIntradayTestProvider(minuteDF)}
+
+		strategy := &intradayBasketStrategy{basket: basket, schedule: "0 10 * * MON-FRI"}
+
+		eng := engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: basket}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intraday),
+			engine.WithInitialDeposit(10000),
+		)
+
+		fund, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(intraday.callCount()).To(Equal(1))
+
+		fills := map[string]float64{}
+		for _, txn := range fund.Transactions() {
+			if txn.Type == asset.BuyTransaction {
+				fills[txn.Asset.Ticker] = txn.Price
+			}
+		}
+
+		Expect(fills["AAA"]).To(BeNumerically("~", 10.05, 1e-9))
+		Expect(fills["BBB"]).To(BeNumerically("~", 20.05, 1e-9))
+		Expect(fills).To(HaveKey("CCC"), "CCC must fill from its 10:03 bar, not be dropped for lacking a 10:01 bar")
+		Expect(fills["CCC"]).To(BeNumerically("~", 30.3, 1e-9))
+	})
+
+	It("widens the cached window on a miss rather than evicting earlier assets", func() {
+		// One firing queries Prices for AAA, then BBB, then AAA again. AAA is a
+		// cold miss (1 fetch). BBB is not covered by the AAA-only cache, so the
+		// window widens to {AAA, BBB} (1 fetch). The repeat AAA query must hit
+		// the widened window. Total: 2 fetches. A cache that replaced rather
+		// than widened would evict AAA on the BBB miss, making the repeat AAA
+		// query a third fetch.
+		start := time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end := time.Date(2026, 5, 11, 23, 59, 59, 0, nyc)
+
+		probe := &intradayProbeStrategy{assetX: basket[0], assetY: basket[1], schedule: "0 10 * * MON-FRI"}
+
+		eng, intraday := buildEngine(probe)
+
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(intraday.callCount()).To(Equal(2))
+	})
+})


### PR DESCRIPTION
Closes #194.

## Problem

Profiling a 10-day intraday backtest against a remote ClickHouse source showed it was I/O-bound (~16% CPU / ~84% off-CPU wait), dominated by redundant minute-bar round-trips. The intraday fill path was uncached: each firing routed through `nextMinuteBar` once per order (`SimulatedBroker.Submit`) plus once for the batch prefetch (`prefetchBrokerPrices`), each issuing an independent `IntradayFetch` for the same next-minute-bar window. A 6-order firing cost ~7 round-trips where 1 would do.

## Fix

A per-firing fill-window cache (`intradayFillCache`), keyed by the firing timestamp (`currentTime`):

- `nextMinuteBar` fetches the window for the union of requested assets once and serves every subsequent per-order lookup from it, so a firing collapses to a single round-trip.
- The cache self-invalidates when `currentTime` advances to the next firing (no hook into the assignment sites needed).
- A miss within the same firing widens the fetch to the union of previously-cached and newly-requested assets, so an asset fetched earlier in the firing is never evicted.
- Per-asset bars are sliced out of the shared window by selecting each asset's earliest non-NaN bar. A direct per-asset fetch builds its time axis from only that asset's bars, so this reproduces the prior return value exactly: results are unchanged, only the number of network calls drops.

The daily price path is untouched.

## Tests

`engine/intraday_fill_cache_test.go` adds four specs:

- a 3-order firing issues exactly one `IntradayFetch`, and each order fills at its correct per-asset bar;
- two firings issue exactly three fetches, distinguishing correct per-firing invalidation (3) from a stale cache surviving across firings (2) or no caching at all (9);
- assets whose first bars are staggered within the window each fill at their own earliest bar (an asset absent at the first minute is not dropped) -- verified to fail against the naive earliest-row approach;
- a miss widens the cached window rather than evicting earlier assets -- verified to fail against replace-on-miss.

All 242 engine specs and the full suite pass; `make lint` reports 0 issues.

## Incidental

While in these files: removed a dead `benchmark` parameter from `housekeepAccount` (price prefetching, including the benchmark, is handled by `prefetchHousekeepingPrices`) and cleared a few gopls findings (tautological nil check, `slices.ContainsFunc`, tagged switch in a test).