### PR TITLE
fix(portfolio): size Allocate off full value for unpriced new entries

### DIFF
--- a/portfolio/batch.go
+++ b/portfolio/batch.go
@@ -500,7 +500,63 @@ func (b *Batch) ProjectedValue() float64 {
 		}
 	}
 
+	total += b.pendingUnpricedValue()
+
 	return total
+}
+
+// pendingUnpricedValue sums the value of pending dollar-amount orders for
+// assets that have no derivable price (not currently held and absent from the
+// price frame) and therefore never appear in ProjectedHoldings. A $X buy of
+// such an asset creates a position worth $X once it fills. Without this term
+// the cash those orders consume would vanish from projected value, so
+// successive Allocate calls in one batch -- e.g. new entries opened during an
+// intraday firing on an all-cash account -- would each size against a
+// shrinking base and compound their under-sizing.
+func (b *Batch) pendingUnpricedValue() float64 {
+	seen := make(map[asset.Asset]bool)
+
+	var total float64
+
+	for _, order := range b.Orders {
+		ast := order.Asset
+		if seen[ast] {
+			continue
+		}
+
+		seen[ast] = true
+
+		if b.priceOf(ast) > 0 {
+			continue
+		}
+
+		total += b.pendingDollarFlow(ast)
+	}
+
+	return total
+}
+
+// pendingDollarFlow returns the net dollar amount of pending dollar-amount
+// (Amount-based) orders for ast: buy orders add and sell orders subtract.
+// Quantity-based orders are excluded because they cannot be valued without a
+// price, which an unpriced asset by definition lacks.
+func (b *Batch) pendingDollarFlow(ast asset.Asset) float64 {
+	var flow float64
+
+	for _, order := range b.Orders {
+		if order.Asset != ast || order.Amount <= 0 {
+			continue
+		}
+
+		switch order.Side {
+		case broker.Buy:
+			flow += order.Amount
+		case broker.Sell:
+			flow -= order.Amount
+		}
+	}
+
+	return flow
 }
 
 // ProjectedWeights returns position weights after projected execution.
@@ -526,13 +582,17 @@ func (b *Batch) ProjectedWeights() map[asset.Asset]float64 {
 }
 
 // projectedPositionValue returns the dollar value of an asset's position
-// in the projected state (after applying all batch orders so far).
+// in the projected state (after applying all batch orders so far). For an
+// asset with no derivable price (not held, absent from the price frame), the
+// position is valued from its pending dollar-amount orders, since those orders
+// cannot be expressed as a share count and so do not appear in ProjectedHoldings.
 func (b *Batch) projectedPositionValue(ast asset.Asset) float64 {
-	holdings := b.ProjectedHoldings()
-	qty := holdings[ast]
 	price := b.priceOf(ast)
+	if price <= 0 {
+		return b.pendingDollarFlow(ast)
+	}
 
-	return qty * price
+	return b.ProjectedHoldings()[ast] * price
 }
 
 // projectedCash returns the cash balance after all batch orders execute.

--- a/portfolio/batch_test.go
+++ b/portfolio/batch_test.go
@@ -879,6 +879,35 @@ var _ = Describe("Batch", func() {
 			Expect(ordersForAsset(batch.Orders, aapl)).To(BeEmpty())
 		})
 
+		It("sizes successive new entries off the full portfolio value when assets are unpriced", func() {
+			// Reproduces issue #196: on an all-cash account during an intraday
+			// firing the to-be-bought assets are not yet held and absent from
+			// the price frame, so priceOf returns 0 for them. Each Allocate must
+			// still size against the full $100,000, so equal weights produce
+			// equal dollar allocations (matching RebalanceTo).
+			xom := asset.Asset{CompositeFigi: "XOM001", Ticker: "XOM"}
+			msft := asset.Asset{CompositeFigi: "MSFT001", Ticker: "MSFT"}
+			gld := asset.Asset{CompositeFigi: "GLD001", Ticker: "GLD"}
+
+			// No price frame: Prices() is nil, so every target is unpriced.
+			acct := portfolio.New(portfolio.WithCash(100_000, time.Time{}))
+			batch := portfolio.NewBatch(ts, acct)
+
+			Expect(batch.Allocate(context.Background(), aapl, 0.1575)).To(Succeed())
+			Expect(batch.Allocate(context.Background(), xom, 0.1575)).To(Succeed())
+			Expect(batch.Allocate(context.Background(), msft, 0.1575)).To(Succeed())
+			Expect(batch.Allocate(context.Background(), gld, 0.27)).To(Succeed())
+
+			Expect(batch.Orders).To(HaveLen(4))
+			Expect(batch.Orders[0].Amount).To(BeNumerically("~", 15_750.0, 1e-6))
+			Expect(batch.Orders[1].Amount).To(BeNumerically("~", 15_750.0, 1e-6))
+			Expect(batch.Orders[2].Amount).To(BeNumerically("~", 15_750.0, 1e-6))
+			Expect(batch.Orders[3].Amount).To(BeNumerically("~", 27_000.0, 1e-6))
+
+			// Projected value is conserved at the full account value throughout.
+			Expect(batch.ProjectedValue()).To(BeNumerically("~", 100_000.0, 1e-6))
+		})
+
 		It("rejects bracket and OCO modifiers", func() {
 			acct := buildPricedAccount(10_000, []asset.Asset{spy}, []float64{100})
 			batch := portfolio.NewBatch(ts, acct)


### PR DESCRIPTION
Fixes #196.

## Problem

`Batch.Allocate` under-sizes orders during an intraday firing when allocating assets that are not yet held. Each `Allocate` recomputes `ProjectedValue()`, but a pending dollar-amount buy for an asset that is not held and absent from the price frame (`priceOf == 0`) contributed nothing to projected value -- the cash it consumed simply vanished. Successive `Allocate` calls in one batch each sized against a shrinking base, compounding under-deployment. On an all-cash account (day 1, empty holdings, `markIntradayPrices` no-ops) a book intended at ~90% deployed only ~54%.

`RebalanceTo` was immune because it captures `ProjectedValue()` once up front.

## Fix

A pending dollar-amount order on an otherwise-unpriced asset is now valued at its own dollar amount: a $X buy creates a $X position. `ProjectedValue` adds these via `pendingUnpricedValue`, and `projectedPositionValue` returns the pending dollar flow for unpriced assets. Projected value is conserved across the batch, so equal weights produce equal dollar allocations, matching `RebalanceTo`.

The change is inert when a price exists (held assets, daily firings), so daily firings and existing `RebalanceTo` behavior are unchanged.

## Test

Added a reproducing test: four `Allocate` calls on a $100,000 all-cash account with unpriced targets now emit $15,750 / $15,750 / $15,750 / $27,000. Before the fix the second order was $13,269 (the compounding under-deployment).