### PR TITLE
feat(engine,portfolio): fail unpriceable intraday orders and add Reconcile hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Strategies can adjust a single position toward a target weight without disturbing the rest of the book. `Batch.Allocate(ctx, asset, weight)` sizes the buy/sell delta to reach the target weight, and `Batch.Liquidate(ctx, asset)` closes a position; both leave all other holdings untouched, unlike `RebalanceTo`.
+- Strategies can move a single position to a target weight or close it without rebalancing the rest of the book.
+- Strategies can react to how their orders filled and revise the batch before it is final.
+
+### Fixed
+
+- An intra-day order that cannot be priced at the firing moment now fails on its own instead of aborting the backtest.
 
 ### Changed
 
-- During an intra-day firing, the account is now marked to the live minute bar as of `engine.Now()` rather than the prior end-of-day close. Order sizing and margin/leverage checks therefore use the price at the firing moment; orders still fill at the next minute bar. Each held asset is marked to its own most recent bar, so a name that did not trade at the firing minute keeps its last known price instead of being valued at zero. End-of-day valuation is unchanged, so daily backtests produce identical results.
-- Intra-day backtests against a remote minute-bar source run substantially faster: the next-minute-bar window for a firing's order fills is now fetched once and reused across all orders, instead of issuing a separate fetch per order. Results are unchanged.
+- Intra-day firings value the account at the live minute price rather than the prior close, so order sizing and margin checks use the firing-moment price.
+- Intra-day backtests against a remote minute-bar source run faster.
 
 ## [0.10.4] - 2026-06-01
 

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -141,12 +141,17 @@ const (
 	OnClose
 )
 
-// Fill represents the execution result of an order.
+// Fill represents the execution result of an order. A Fill with a non-nil
+// Err reports an order that resolved without executing -- it could not be
+// priced, was rejected by a risk or margin check, or its limit was not
+// touched. Such a Fill carries Qty 0 and a zero Price; Err describes why the
+// order failed so the originating strategy can react to it.
 type Fill struct {
 	OrderID  string
 	Price    float64
 	Qty      float64
 	FilledAt time.Time
+	Err      error
 }
 
 // Position represents a holding in the account.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -49,7 +49,7 @@ The backtest proceeds in four phases:
 
 1. **Initialization** -- loads assets, hydrates strategy fields from struct tags, builds the provider routing table, calls `strategy.Setup`, validates the schedule, checks warmup data availability (see [Warmup](#warmup)), and creates the portfolio account.
 2. **Date enumeration** -- walks the tradecron schedule from start to end to build the list of trading dates.
-3. **Step loop** -- iterates every engine date (see [Steps and frames](#steps-and-frames) below). At each step: drains the broker fill channel, syncs broker-reported transactions (dividends, splits, borrow fees, delistings), runs a margin check, and updates the equity curve. On frames (dates matching the trading schedule), the engine also cancels open orders, creates a fresh batch, calls `strategy.Compute`, runs the batch through middleware, and submits the resulting orders to the broker.
+3. **Step loop** -- iterates every engine date (see [Steps and frames](#steps-and-frames) below). At each step: drains the broker fill channel, syncs broker-reported transactions (dividends, splits, borrow fees, delistings), runs a margin check, and updates the equity curve. On frames (dates matching the trading schedule), the engine also cancels open orders, creates a fresh batch, calls `strategy.Compute`, runs the batch through middleware, submits the resulting orders to the broker, and -- if the strategy implements `Reconcile` -- calls it so the strategy can react to how its orders resolved.
 4. **Return** -- returns the portfolio with the full transaction log, equity curve, and computed metrics.
 
 ## Steps and frames

--- a/docs/portfolio.md
+++ b/docs/portfolio.md
@@ -341,6 +341,24 @@ func (s *MyStrategy) Compute(ctx context.Context, eng *engine.Engine, port portf
 
 Both paths accumulate orders in the same batch. After `Compute` returns, middleware processes the full batch before any order reaches the broker.
 
+## Order outcomes and reconciliation
+
+Every order in a batch resolves as either filled or failed. An order fails when it cannot be priced (for example an asset whose intraday history begins after the backtest date), when a risk or margin check rejects it, or -- for a limit order -- when its price is never touched. A failed order does not abort the run: it simply does not fill, and the rest of the batch proceeds.
+
+A strategy that wants to react to failures implements the optional `Reconcile` method. After the batch's orders resolve, the engine calls `Reconcile` with the same batch, now carrying each order's outcome. The strategy can inspect the outcomes and amend the batch -- for example, resubmit a failed order as a market order. Any orders it appends are executed, and `Reconcile` is called again with their outcomes; this repeats until a pass appends nothing and the batch settles.
+
+```go
+func (s *MyStrategy) Reconcile(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
+    for _, outcome := range batch.FailedOrders() {
+        // Re-enter the same name at market once its limit order missed.
+        batch.Order(ctx, outcome.Order.Asset, portfolio.Buy, outcome.Order.Qty)
+    }
+    return nil
+}
+```
+
+`batch.Outcomes` holds every order's result; `batch.FailedOrders` returns just the ones that did not fill. Strategies that do not implement `Reconcile` see failed orders simply not fill.
+
 ## Reading portfolio state
 
 During computation the strategy can inspect the current portfolio:

--- a/docs/strategy-guide.md
+++ b/docs/strategy-guide.md
@@ -674,6 +674,23 @@ batch.Order(ctx, spy, portfolio.Sell, 100,
 
 Bracket/OCO modifiers are batch-only. See the [Portfolio documentation](portfolio.md#bracket-and-oco-orders) for full details.
 
+### Reacting to order outcomes
+
+Orders fill after `Compute` returns, so an order does not always execute: it can be unpriceable (an asset with no bar at the firing moment), rejected by a risk or margin check, or -- for a limit order -- never touched. A failed order does not abort the backtest; it simply does not fill.
+
+To react, implement the optional `Reconcile` method. After the batch's orders resolve, the engine calls it with the same batch, now carrying each order's outcome. Inspect the failures and amend the batch -- for instance resubmitting a missed order at market. The engine executes whatever you append and calls `Reconcile` again, until a pass adds nothing and the batch settles.
+
+```go
+func (s *MyStrategy) Reconcile(ctx context.Context, eng *engine.Engine, port portfolio.Portfolio, batch *portfolio.Batch) error {
+    for _, outcome := range batch.FailedOrders() {
+        batch.Order(ctx, outcome.Order.Asset, portfolio.Buy, outcome.Order.Qty)
+    }
+    return nil
+}
+```
+
+`Reconcile` is optional; strategies that omit it see failed orders simply not fill. See the [Portfolio documentation](portfolio.md#order-outcomes-and-reconciliation) for the outcome fields.
+
 ### Short selling
 
 Selling an asset you do not own opens a short position. The position quantity becomes negative in the portfolio. Profits accumulate when the price falls; losses mount when it rises.

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -455,6 +455,10 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 				if err := child.account.ExecuteBatch(stepCtx, childBatch); err != nil {
 					return nil, fmt.Errorf("engine: child %q execute batch on %v: %w", childName, fireTime, err)
 				}
+
+				if err := e.reconcileBatch(stepCtx, child.strategy, child.account, childBatch); err != nil {
+					return nil, fmt.Errorf("engine: child %q reconcile batch on %v: %w", childName, fireTime, err)
+				}
 			}
 
 			e.currentTime = date
@@ -489,6 +493,10 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 
 				if err := acct.ExecuteBatch(stepCtx, batch); err != nil {
 					return nil, fmt.Errorf("engine: execute batch on %v: %w", fireTime, err)
+				}
+
+				if err := e.reconcileBatch(stepCtx, e.strategy, acct, batch); err != nil {
+					return nil, fmt.Errorf("engine: reconcile batch on %v: %w", fireTime, err)
 				}
 			}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -17,6 +17,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"slices"
@@ -1061,6 +1062,13 @@ func (e *Engine) isIntradayFiring() bool {
 	return minutes > marketOpenMinutes && minutes < marketCloseMinutes
 }
 
+// ErrNoMinuteBar reports that no intra-day minute bar is available to fill an
+// order at the firing moment -- for example an asset whose intraday data
+// coverage begins after the backtest date. It is a recoverable, per-order
+// condition: the broker resolves the order as failed rather than aborting the
+// simulation, so callers must test for it with errors.Is.
+var ErrNoMinuteBar = errors.New("engine: no minute bar available for order fill")
+
 // nextMinuteBar returns the 1-minute bar that opens immediately after
 // e.currentTime. Used by Prices during intra-day firings so that order
 // fills land at the next-minute-bar's close (mirrors daily next-bar
@@ -1110,9 +1118,8 @@ func (e *Engine) nextMinuteBar(ctx context.Context, assets []asset.Asset) (*data
 		}
 	}
 
-	return nil, fmt.Errorf(
-		"engine: no minute bar available after %s for order fill",
-		e.currentTime.Format(time.RFC3339))
+	return nil, fmt.Errorf("%w: after %s",
+		ErrNoMinuteBar, e.currentTime.Format(time.RFC3339))
 }
 
 // markBarLookback bounds how far back markBar searches for each asset's most
@@ -1246,6 +1253,14 @@ func (e *Engine) prefetchBrokerPrices(ctx context.Context, orders []broker.Order
 
 	_, err := e.Prices(ctx, assets...)
 	if err != nil {
+		// This call only warms the price cache; per-order Submit resolves
+		// each order individually. When no order asset has a minute bar at
+		// the firing moment there is nothing to warm, and the missing-bar
+		// condition is handled per order (failed fill) rather than aborting.
+		if errors.Is(err, ErrNoMinuteBar) {
+			return nil
+		}
+
 		return fmt.Errorf("prefetch broker prices: %w", err)
 	}
 

--- a/engine/intraday_failed_fill_test.go
+++ b/engine/intraday_failed_fill_test.go
@@ -1,0 +1,300 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/engine"
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+// nodataEntryStrategy buys both SPY (which has minute bars) and NODATA (which
+// has only daily bars, no intraday coverage) on its single intraday firing.
+// It implements no Reconciler, so the NODATA order simply fails.
+type nodataEntryStrategy struct {
+	mu       sync.Mutex
+	spy      asset.Asset
+	nodata   asset.Asset
+	placed   bool
+	schedule string
+}
+
+func (s *nodataEntryStrategy) Name() string           { return "nodataEntry" }
+func (s *nodataEntryStrategy) Setup(_ *engine.Engine) {}
+
+func (s *nodataEntryStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "nodata-entry", Schedule: s.schedule}
+}
+
+func (s *nodataEntryStrategy) Compute(
+	_ context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.placed {
+		return nil
+	}
+
+	s.placed = true
+
+	if err := batch.Order(context.Background(), s.spy, portfolio.Buy, 10); err != nil {
+		return err
+	}
+
+	return batch.Order(context.Background(), s.nodata, portfolio.Buy, 10)
+}
+
+// nodataReconcileStrategy buys NODATA on its firing, then -- when Reconcile
+// reports that order failed -- substitutes SPY exactly once. It records the
+// tickers it saw fail and how many times Reconcile was called.
+type nodataReconcileStrategy struct {
+	mu             sync.Mutex
+	spy            asset.Asset
+	nodata         asset.Asset
+	placed         bool
+	substituted    bool
+	reconcileCalls int
+	failedTickers  []string
+	schedule       string
+}
+
+func (s *nodataReconcileStrategy) Name() string           { return "nodataReconcile" }
+func (s *nodataReconcileStrategy) Setup(_ *engine.Engine) {}
+
+func (s *nodataReconcileStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "nodata-reconcile", Schedule: s.schedule}
+}
+
+func (s *nodataReconcileStrategy) Compute(
+	_ context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.placed {
+		return nil
+	}
+
+	s.placed = true
+
+	return batch.Order(context.Background(), s.nodata, portfolio.Buy, 10)
+}
+
+func (s *nodataReconcileStrategy) Reconcile(
+	_ context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.reconcileCalls++
+
+	for _, outcome := range batch.FailedOrders() {
+		s.failedTickers = append(s.failedTickers, outcome.Order.Asset.Ticker)
+	}
+
+	// Substitute the failed NODATA entry with SPY exactly once. A second
+	// pass finds SPY already filled and appends nothing, so the batch settles.
+	if !s.substituted {
+		s.substituted = true
+
+		return batch.Order(context.Background(), s.spy, portfolio.Buy, 10)
+	}
+
+	return nil
+}
+
+// runawayReconcileStrategy always appends another doomed NODATA order in
+// Reconcile, so the batch never settles -- exercising the pass cap.
+type runawayReconcileStrategy struct {
+	mu       sync.Mutex
+	nodata   asset.Asset
+	placed   bool
+	schedule string
+}
+
+func (s *runawayReconcileStrategy) Name() string           { return "runawayReconcile" }
+func (s *runawayReconcileStrategy) Setup(_ *engine.Engine) {}
+
+func (s *runawayReconcileStrategy) Describe() engine.StrategyDescription {
+	return engine.StrategyDescription{ShortCode: "runaway-reconcile", Schedule: s.schedule}
+}
+
+func (s *runawayReconcileStrategy) Compute(
+	_ context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.placed {
+		return nil
+	}
+
+	s.placed = true
+
+	return batch.Order(context.Background(), s.nodata, portfolio.Buy, 1)
+}
+
+func (s *runawayReconcileStrategy) Reconcile(
+	_ context.Context,
+	_ *engine.Engine,
+	_ portfolio.Portfolio,
+	batch *portfolio.Batch,
+) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return batch.Order(context.Background(), s.nodata, portfolio.Buy, 1)
+}
+
+var _ = Describe("intra-day orders with no minute bar", func() {
+	var (
+		nyc    *time.Location
+		start  time.Time
+		end    time.Time
+		spy    asset.Asset
+		nodata asset.Asset
+	)
+
+	// newEngine wires a backtest where SPY has minute bars but NODATA has
+	// only daily bars, reproducing an asset (e.g. a ticker whose intraday
+	// coverage starts later) that the strategy can select off daily prices
+	// but cannot be filled intraday.
+	newEngine := func(strategy engine.Strategy) *engine.Engine {
+		dailyTimes := []time.Time{time.Date(2026, 5, 11, 16, 0, 0, 0, nyc)}
+
+		dailyMetrics := []data.Metric{
+			data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow,
+			data.Volume, data.Dividend, data.SplitFactor,
+		}
+
+		dailyDF, dailyErr := data.NewDataFrame(dailyTimes,
+			[]asset.Asset{spy, nodata},
+			dailyMetrics,
+			data.Daily,
+			[][]float64{
+				// SPY
+				{100}, {100}, {102}, {99}, {1_000_000}, {0}, {1},
+				// NODATA: daily bars exist, so the strategy can reference it.
+				{50}, {50}, {52}, {49}, {1_000_000}, {0}, {1},
+			})
+		Expect(dailyErr).NotTo(HaveOccurred())
+
+		dailyProvider := data.NewTestProvider(dailyMetrics, dailyDF)
+
+		// Minute frame contains SPY only -- NODATA has no intraday coverage.
+		minuteTimes := []time.Time{
+			time.Date(2026, 5, 11, 10, 0, 0, 0, nyc),
+			time.Date(2026, 5, 11, 10, 1, 0, 0, nyc),
+		}
+
+		minuteDF, minuteErr := data.NewDataFrame(minuteTimes,
+			[]asset.Asset{spy},
+			[]data.Metric{data.MetricClose, data.MetricHigh, data.MetricLow, data.Volume, data.AdjClose},
+			data.Tick,
+			[][]float64{
+				{100.1, 100.2},
+				{100.5, 100.6},
+				{99.5, 99.6},
+				{50_000, 50_000},
+				{100.1, 100.2},
+			})
+		Expect(minuteErr).NotTo(HaveOccurred())
+
+		intradayProvider := data.NewIntradayTestProvider(minuteDF)
+
+		return engine.New(strategy,
+			engine.WithAssetProvider(&mockAssetProvider{assets: []asset.Asset{spy, nodata}}),
+			engine.WithDataProvider(dailyProvider),
+			engine.WithDataProvider(intradayProvider),
+			engine.WithInitialDeposit(10000),
+		)
+	}
+
+	BeforeEach(func() {
+		var locErr error
+
+		nyc, locErr = time.LoadLocation("America/New_York")
+		Expect(locErr).NotTo(HaveOccurred())
+
+		start = time.Date(2026, 5, 11, 0, 0, 0, 0, nyc)
+		end = time.Date(2026, 5, 11, 23, 59, 59, 0, nyc)
+
+		spy = asset.Asset{Ticker: "SPY", CompositeFigi: "BBG000BDTBL9"}
+		nodata = asset.Asset{Ticker: "NODATA", CompositeFigi: "BBG000NODATA0"}
+	})
+
+	It("fails the unpriced order instead of aborting the backtest", func() {
+		strategy := &nodataEntryStrategy{spy: spy, nodata: nodata, schedule: "0 10 * * MON-FRI"}
+		eng := newEngine(strategy)
+
+		acct, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		// SPY filled; NODATA could not be priced intraday, so it did not fill.
+		Expect(acct.Holdings()[spy]).To(BeNumerically("~", 10.0, 1e-9))
+		Expect(acct.Holdings()).NotTo(HaveKey(nodata))
+	})
+
+	It("lets a Reconciler resubmit a failed order until the batch settles", func() {
+		strategy := &nodataReconcileStrategy{spy: spy, nodata: nodata, schedule: "0 10 * * MON-FRI"}
+		eng := newEngine(strategy)
+
+		acct, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).NotTo(HaveOccurred())
+
+		// NODATA failed; the strategy substituted SPY in Reconcile and SPY filled.
+		Expect(acct.Holdings()[spy]).To(BeNumerically("~", 10.0, 1e-9))
+		Expect(acct.Holdings()).NotTo(HaveKey(nodata))
+
+		strategy.mu.Lock()
+		defer strategy.mu.Unlock()
+
+		// Reconcile saw the NODATA failure, and ran twice: once to substitute
+		// SPY, once more that found nothing to do and settled the batch.
+		Expect(strategy.failedTickers).To(ContainElement("NODATA"))
+		Expect(strategy.reconcileCalls).To(Equal(2))
+	})
+
+	It("surfaces an error when a Reconciler never settles the batch", func() {
+		strategy := &runawayReconcileStrategy{nodata: nodata, schedule: "0 10 * * MON-FRI"}
+		eng := newEngine(strategy)
+
+		_, err := eng.Backtest(context.Background(), start, end)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("did not settle"))
+	})
+})

--- a/engine/reconciler.go
+++ b/engine/reconciler.go
@@ -1,0 +1,84 @@
+// Copyright 2021-2026
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/penny-vault/pvbt/portfolio"
+)
+
+// Reconciler is an optional interface a strategy can implement to react to how
+// its batch resolved against the market. After every order in a batch has
+// resolved -- filled or failed -- the engine calls Reconcile with the same
+// batch, now carrying each order's outcome (read via batch.Outcomes or
+// batch.FailedOrders). The strategy may amend the batch in place, for example
+// resubmitting a failed order as a market order or simply logging the miss.
+//
+// Any orders the strategy appends are executed, and Reconcile is then called
+// again with their outcomes. This repeats until a pass appends no new orders,
+// so the strategy can drive a batch to completion. Strategies that do not
+// implement Reconciler see failed orders silently not fill, as before.
+type Reconciler interface {
+	Reconcile(ctx context.Context, eng *Engine, port portfolio.Portfolio, batch *portfolio.Batch) error
+}
+
+// maxReconcilePasses bounds how many times the engine will call Reconcile for a
+// single batch. A well-behaved strategy settles in one or two passes (e.g.
+// resubmit a failed limit as market). The cap exists only to stop a strategy
+// that appends orders unconditionally from looping forever; exceeding it is a
+// strategy bug and surfaces as an error rather than silently truncating.
+const maxReconcilePasses = 16
+
+// reconcileBatch runs the reconcile loop for a strategy that implements
+// Reconciler. It is a no-op for strategies that do not. Each pass calls
+// Reconcile, then executes any orders the strategy appended; the loop ends when
+// a pass appends nothing (the batch has settled).
+func (e *Engine) reconcileBatch(
+	ctx context.Context,
+	strategy Strategy,
+	acct portfolio.PortfolioManager,
+	batch *portfolio.Batch,
+) error {
+	reconciler, ok := strategy.(Reconciler)
+	if !ok {
+		return nil
+	}
+
+	for range maxReconcilePasses {
+		before := len(batch.Orders)
+
+		if err := reconciler.Reconcile(ctx, e, acct, batch); err != nil {
+			return fmt.Errorf("reconcile: %w", err)
+		}
+
+		// No new orders means the strategy is satisfied: the batch is settled.
+		if len(batch.Orders) == before {
+			return nil
+		}
+
+		if err := e.prefetchBrokerPrices(ctx, batch.Orders[before:]); err != nil {
+			return fmt.Errorf("reconcile prefetch broker prices: %w", err)
+		}
+
+		if err := acct.ExecuteBatch(ctx, batch); err != nil {
+			return fmt.Errorf("reconcile execute batch: %w", err)
+		}
+	}
+
+	return fmt.Errorf("reconcile: batch did not settle after %d passes", maxReconcilePasses)
+}

--- a/engine/simulated_broker.go
+++ b/engine/simulated_broker.go
@@ -17,6 +17,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -113,6 +114,18 @@ func (b *SimulatedBroker) Fills() <-chan broker.Fill {
 	return b.fills
 }
 
+// failOrder resolves an order as failed: it emits a fill carrying the reason
+// (Qty 0, no price) on the fills channel so the account records the failure
+// and the originating strategy can react to it, instead of the order silently
+// vanishing or the simulation aborting.
+func (b *SimulatedBroker) failOrder(order broker.Order, reason error) {
+	b.fills <- broker.Fill{
+		OrderID:  order.ID,
+		FilledAt: b.date,
+		Err:      reason,
+	}
+}
+
 func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error {
 	if order.GroupRole == broker.RoleStopLoss || order.GroupRole == broker.RoleTakeProfit {
 		b.pending[order.ID] = order
@@ -130,6 +143,20 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 
 	df, err := b.prices.Prices(ctx, order.Asset)
 	if err != nil {
+		// No price to fill against (e.g. an asset whose intraday data
+		// coverage starts after this date) is a recoverable, per-order
+		// failure: resolve the order as failed rather than aborting the
+		// whole simulation. Any other fetch error is genuine and fatal.
+		if errors.Is(err, ErrNoMinuteBar) {
+			zerolog.Ctx(ctx).Warn().
+				Err(err).
+				Str("asset", order.Asset.Ticker).
+				Msg("order failed: no price available to fill")
+			b.failOrder(order, fmt.Errorf("no price available to fill %s: %w", order.Asset.Ticker, err))
+
+			return nil
+		}
+
 		return fmt.Errorf("simulated broker: fetching price for %s: %w", order.Asset.Ticker, err)
 	}
 
@@ -139,7 +166,8 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 		zerolog.Ctx(ctx).Warn().
 			Err(baseErr).
 			Str("asset", order.Asset.Ticker).
-			Msg("order skipped: fill model error")
+			Msg("order failed: fill model error")
+		b.failOrder(order, fmt.Errorf("fill model error for %s: %w", order.Asset.Ticker, baseErr))
 
 		return nil
 	}
@@ -151,6 +179,8 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 	}
 
 	if qty == 0 {
+		b.failOrder(order, fmt.Errorf("order amount for %s is too small to fill a whole share", order.Asset.Ticker))
+
 		return nil
 	}
 
@@ -199,6 +229,7 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 					Float64("equity", equity).
 					Float64("new_short_value", newShortValue).
 					Msg("order rejected: insufficient margin")
+				b.failOrder(order, fmt.Errorf("order rejected: insufficient margin for %s", order.Asset.Ticker))
 
 				return nil
 			}
@@ -226,6 +257,7 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 						Float64("post_gross", postGross).
 						Float64("max_leverage", b.maxLeverage).
 						Msg("order rejected: gross leverage cap")
+					b.failOrder(order, fmt.Errorf("order rejected: gross leverage cap for %s", order.Asset.Ticker))
 
 					return nil
 				}

--- a/engine/simulated_broker_test.go
+++ b/engine/simulated_broker_test.go
@@ -265,7 +265,11 @@ var _ = Describe("SimulatedBroker", func() {
 			})
 
 			Expect(err).NotTo(HaveOccurred())
-			Consistently(simBroker.Fills()).ShouldNot(Receive())
+
+			var fill broker.Fill
+			Eventually(simBroker.Fills()).Should(Receive(&fill))
+			Expect(fill.Err).To(HaveOccurred())
+			Expect(fill.Qty).To(BeZero())
 		})
 
 		It("fills a short order when margin is sufficient", func() {
@@ -352,7 +356,11 @@ var _ = Describe("SimulatedBroker", func() {
 			})
 
 			Expect(err).NotTo(HaveOccurred())
-			Consistently(simBroker.Fills()).ShouldNot(Receive())
+
+			var fill broker.Fill
+			Eventually(simBroker.Fills()).Should(Receive(&fill))
+			Expect(fill.Err).To(HaveOccurred())
+			Expect(fill.Qty).To(BeZero())
 		})
 
 		It("fills a buy that stays within the leverage cap", func() {
@@ -416,7 +424,7 @@ var _ = Describe("SimulatedBroker", func() {
 			Expect(fill.Qty).To(Equal(10.0))
 		})
 
-		It("skips fill and produces no error when asset has no price", func() {
+		It("reports a failed fill and produces no error when asset has no price", func() {
 			unknown := asset.Asset{CompositeFigi: "FIGI-UNKNOWN", Ticker: "UNKNOWN"}
 			simBroker := engine.NewSimulatedBroker()
 			simBroker.SetPriceProvider(&mockPriceProvider{
@@ -432,7 +440,11 @@ var _ = Describe("SimulatedBroker", func() {
 			})
 
 			Expect(err).NotTo(HaveOccurred())
-			Consistently(simBroker.Fills()).ShouldNot(Receive())
+
+			var fill broker.Fill
+			Eventually(simBroker.Fills()).Should(Receive(&fill))
+			Expect(fill.Err).To(HaveOccurred())
+			Expect(fill.Qty).To(BeZero())
 		})
 	})
 

--- a/portfolio/account.go
+++ b/portfolio/account.go
@@ -95,6 +95,9 @@ type Account struct {
 	seenTransactions         map[string]struct{}
 	batches                  []batchRecord
 	currentBatchID           int
+	// currentBatch is the batch being executed; drainFillsFromChannel
+	// records per-order outcomes onto it. Nil outside ExecuteBatch.
+	currentBatch *Batch
 }
 
 // New creates an Account with the given options.
@@ -2026,35 +2029,46 @@ func (a *Account) NewBatch(timestamp time.Time) *Batch {
 // ExecuteBatch runs the middleware chain, records annotations, assigns
 // order IDs, submits orders to the broker, and drains immediate fills.
 func (a *Account) ExecuteBatch(ctx context.Context, batch *Batch) error {
-	batchID := len(a.batches) + 1
-	a.batches = append(a.batches, batchRecord{BatchID: batchID, Timestamp: batch.Timestamp})
+	// Assign a batch ID on the first pass and reuse it on later reconcile
+	// passes so all orders -- original and follow-up -- share one batch.
+	if batch.batchID == 0 {
+		batch.batchID = len(a.batches) + 1
+		a.batches = append(a.batches, batchRecord{BatchID: batch.batchID, Timestamp: batch.Timestamp})
+	}
+
+	batchID := batch.batchID
 	a.currentBatchID = batchID
+	a.currentBatch = batch
 
-	defer func() { a.currentBatchID = 0 }()
+	defer func() { a.currentBatchID = 0; a.currentBatch = nil }()
 
-	// 1. Run middleware chain.
-	if !batch.SkipMiddleware {
-		for _, mw := range a.middleware {
-			if err := mw.Process(ctx, batch); err != nil {
-				return err
+	// 1-2. Run middleware and record annotations only on the first pass.
+	// Reconcile follow-up orders skip the middleware chain: they manage the
+	// execution of orders that already passed risk/tax checks, and re-running
+	// the chain over the whole batch would double-process the resolved orders.
+	if batch.executed == 0 {
+		if !batch.SkipMiddleware {
+			for _, mw := range a.middleware {
+				if err := mw.Process(ctx, batch); err != nil {
+					return err
+				}
 			}
+		}
+
+		for key, value := range batch.Annotations {
+			a.Annotate(batch.Timestamp, key, value)
 		}
 	}
 
-	// 2. Record annotations.
-	for key, value := range batch.Annotations {
-		a.Annotate(batch.Timestamp, key, value)
-	}
-
-	// 3. Only submit if there are orders and a broker is set.
-	if len(batch.Orders) > 0 && a.broker == nil {
+	// 3. Only submit if there are new orders and a broker is set.
+	if len(batch.Orders) > batch.executed && a.broker == nil {
 		return fmt.Errorf("execute batch: no broker set")
 	}
 
-	// 4. Assign IDs to all orders and add to pendingOrders. Collect orders by groupID.
+	// 4. Assign IDs to the new orders and add to pendingOrders. Collect orders by groupID.
 	groupOrders := make(map[string][]broker.Order) // groupID -> orders in that group
 
-	for idx := range batch.Orders {
+	for idx := batch.executed; idx < len(batch.Orders); idx++ {
 		order := &batch.Orders[idx]
 		if order.ID == "" {
 			order.ID = fmt.Sprintf("batch-%d-%d", batch.Timestamp.UnixNano(), idx)
@@ -2069,9 +2083,10 @@ func (a *Account) ExecuteBatch(ctx context.Context, batch *Batch) error {
 		}
 	}
 
-	// 5. Store deferred bracket exits: for each GroupBracket spec, record the spec in
-	// deferredExits keyed by groupID so exit orders can be submitted after the entry fills.
-	for _, spec := range batch.Groups() {
+	// 5. Store deferred bracket exits for new GroupBracket specs.
+	newGroups := batch.Groups()[batch.executedGroups:]
+
+	for _, spec := range newGroups {
 		if spec.Type == broker.GroupBracket {
 			a.deferredExits[spec.GroupID] = spec
 		}
@@ -2080,7 +2095,7 @@ func (a *Account) ExecuteBatch(ctx context.Context, batch *Batch) error {
 	// 6. Submit grouped orders.
 	submittedGroups := make(map[string]bool) // track which groupIDs have been handled
 
-	for _, spec := range batch.Groups() {
+	for _, spec := range newGroups {
 		orders := groupOrders[spec.GroupID]
 
 		switch spec.Type {
@@ -2122,8 +2137,8 @@ func (a *Account) ExecuteBatch(ctx context.Context, batch *Batch) error {
 		submittedGroups[spec.GroupID] = true
 	}
 
-	// 7. Submit remaining non-group orders individually.
-	for idx := range batch.Orders {
+	// 7. Submit remaining new non-group orders individually.
+	for idx := batch.executed; idx < len(batch.Orders); idx++ {
 		order := &batch.Orders[idx]
 		if order.GroupID != "" && submittedGroups[order.GroupID] {
 			// Already handled as part of a group.
@@ -2135,7 +2150,13 @@ func (a *Account) ExecuteBatch(ctx context.Context, batch *Batch) error {
 		}
 	}
 
-	// 8. Drain immediate fills.
+	// 8. Mark these orders and groups executed before draining so the
+	// projected-state helpers (and any follow-up Reconcile pass) see them as
+	// resolved rather than still pending.
+	batch.executed = len(batch.Orders)
+	batch.executedGroups = len(batch.groups)
+
+	// 9. Drain immediate fills, recording per-order outcomes on the batch.
 	a.drainFillsFromChannel()
 
 	return nil
@@ -2182,6 +2203,25 @@ func (a *Account) drainFillsFromChannel() {
 			order, ok := a.pendingOrders[fill.OrderID]
 			if !ok {
 				log.Warn().Str("orderID", fill.OrderID).Msg("received fill for unknown order")
+				continue
+			}
+
+			// Record the outcome on the batch currently executing so a
+			// strategy's Reconcile can see what filled and what failed.
+			if a.currentBatch != nil && order.BatchID == a.currentBatchID {
+				a.currentBatch.Outcomes = append(a.currentBatch.Outcomes, OrderOutcome{
+					Order:  order,
+					Filled: fill.Err == nil,
+					Qty:    fill.Qty,
+					Price:  fill.Price,
+					Err:    fill.Err,
+				})
+			}
+
+			// A failed fill did not execute: drop the order without recording
+			// a transaction or running group/exit handling.
+			if fill.Err != nil {
+				delete(a.pendingOrders, fill.OrderID)
 				continue
 			}
 

--- a/portfolio/batch.go
+++ b/portfolio/batch.go
@@ -50,6 +50,26 @@ type Batch struct {
 	// Annotations holds key-value metadata accumulated by calls to Annotate.
 	Annotations map[string]string
 
+	// Outcomes records how each submitted order resolved -- filled or
+	// failed. Account.ExecuteBatch appends to it as the broker's fills
+	// drain. A strategy's Reconcile reads it (via Outcomes / FailedOrders)
+	// to react to orders the market did not fill.
+	Outcomes []OrderOutcome
+
+	// batchID is the Account-assigned identifier for this batch, set on the
+	// first ExecuteBatch pass and reused across reconcile passes.
+	batchID int
+
+	// executed counts the orders already submitted by ExecuteBatch. A later
+	// pass (after Reconcile appends follow-up orders) submits only
+	// Orders[executed:], and the projected-state helpers replay only those
+	// unexecuted orders so already-filled orders are not counted twice.
+	executed int
+
+	// executedGroups counts the order groups already submitted, mirroring
+	// executed for grouped (bracket/OCO) orders.
+	executedGroups int
+
 	// SkipMiddleware bypasses the middleware chain when true. Used for
 	// margin-call response batches where risk limits must not block
 	// emergency position adjustments.
@@ -74,9 +94,45 @@ func NewBatch(timestamp time.Time, port Portfolio) *Batch {
 	}
 }
 
+// OrderOutcome reports how a single submitted order resolved. A filled order
+// has Filled true with the executed Qty and Price; a failed order has Filled
+// false and Err describing why it did not execute (no price available, a risk
+// or margin rejection, or -- for limit orders -- a price that was never
+// touched).
+type OrderOutcome struct {
+	Order  broker.Order
+	Filled bool
+	Qty    float64
+	Price  float64
+	Err    error
+}
+
+// FailedOrders returns the outcomes of orders that did not fill. A strategy's
+// Reconcile uses it to decide whether to amend the batch (e.g. resubmit a
+// failed order as a market order) before the batch settles.
+func (b *Batch) FailedOrders() []OrderOutcome {
+	failed := make([]OrderOutcome, 0, len(b.Outcomes))
+
+	for _, outcome := range b.Outcomes {
+		if !outcome.Filled {
+			failed = append(failed, outcome)
+		}
+	}
+
+	return failed
+}
+
 // Portfolio returns the read-only portfolio reference associated with this batch.
 func (b *Batch) Portfolio() Portfolio {
 	return b.portfolio
+}
+
+// unexecutedOrders returns the orders appended since the last ExecuteBatch
+// pass -- the ones a subsequent pass still needs to submit. The projected-state
+// helpers replay only these so orders already filled (and thus already
+// reflected in the portfolio) are not counted a second time.
+func (b *Batch) unexecutedOrders() []broker.Order {
+	return b.Orders[b.executed:]
 }
 
 // Groups returns the order group specifications accumulated during Order calls.
@@ -456,7 +512,7 @@ func (b *Batch) ProjectedHoldings() map[asset.Asset]float64 {
 		subs = taxAware.ActiveSubstitutions()
 	}
 
-	for _, order := range b.Orders {
+	for _, order := range b.unexecutedOrders() {
 		price := b.priceOf(order.Asset)
 
 		var qty float64
@@ -518,7 +574,7 @@ func (b *Batch) pendingUnpricedValue() float64 {
 
 	var total float64
 
-	for _, order := range b.Orders {
+	for _, order := range b.unexecutedOrders() {
 		ast := order.Asset
 		if seen[ast] {
 			continue
@@ -543,7 +599,7 @@ func (b *Batch) pendingUnpricedValue() float64 {
 func (b *Batch) pendingDollarFlow(ast asset.Asset) float64 {
 	var flow float64
 
-	for _, order := range b.Orders {
+	for _, order := range b.unexecutedOrders() {
 		if order.Asset != ast || order.Amount <= 0 {
 			continue
 		}
@@ -600,7 +656,7 @@ func (b *Batch) projectedPositionValue(ast asset.Asset) float64 {
 func (b *Batch) projectedCash() float64 {
 	cash := b.portfolio.Cash()
 
-	for _, order := range b.Orders {
+	for _, order := range b.unexecutedOrders() {
 		price := b.priceOf(order.Asset)
 
 		var dollarAmount float64


### PR DESCRIPTION
Closes #196.

## Problem

An intra-day order for an asset with no minute bar at the firing moment -- for example a name whose intraday history starts after the backtest date -- aborted the entire backtest at the fill step. The order could be selected off daily prices but had no intraday data to fill against.

## Change

- The no-minute-bar condition is now a typed `ErrNoMinuteBar`. The simulated broker resolves such an order as **failed** (emitting a failed fill) rather than returning a fatal error, and the price prefetch tolerates it. Other previously-silent skip paths (fill-model error, margin/leverage rejection, sub-share amounts) now report failed fills too.
- `broker.Fill` gains an additive `Err` field so a failed order rides the existing fills channel (Qty 0, reason set).
- `Batch` records per-order outcomes (`Outcomes` / `FailedOrders`), and `ExecuteBatch` is re-runnable: a later pass submits only newly appended orders, and the projected-state helpers replay only unexecuted orders so filled ones are not double-counted.
- New optional `Reconciler` interface (mirrors `Descriptor`): after a batch resolves the engine hands the strategy the same batch with each order's outcome; the strategy may amend it (e.g. resubmit a failed order as market), and the engine re-executes and re-reports until the batch settles, capped at 16 passes.
- Strategies that do not implement `Reconcile` simply see failed orders not fill.

## Tests

Three new engine specs: a failed order no longer crashes the backtest; a `Reconciler` resubmits and the batch settles; a runaway `Reconciler` surfaces an error. Updated broker specs for the new failed-fill behavior.

## Docs

Strategy guide, portfolio, and engine docs updated for order outcomes and the `Reconcile` hook.