### PR TITLE
fix: repair 85 bugs found in full-codebase review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `@monthbegin` and `@quarterbegin` schedules fire once per period instead of also firing on the following trading day.
+- Market-hours and trading-day checks evaluate times in Eastern time, so live trading works on hosts in any timezone.
+- Strategies scheduled intraday no longer see the current day's not-yet-printed close in daily data requests.
+- In live mode, intraday schedules fire at their scheduled times instead of collapsing into the daily close firing.
+- Child strategies in meta-strategies receive dividends, splits, and delist sells from their own holdings instead of the parent portfolio's.
+- The drawdown circuit breaker measures the current drawdown from peak rather than latching permanently on the worst historical drawdown, and no longer oversells positions into unintended shorts when triggered.
+- The max-position-count middleware ranks positions by absolute value and closes shorts with buy orders instead of negative-quantity sells.
+- The volatility scaler measures realized volatility over the configured number of trading days rather than calendar days.
+- Batches with more than 1024 orders no longer deadlock the backtest.
+- Orders skipped by a fill adjuster error now surface as failed fills instead of silently vanishing.
+- Technical indicators (Stochastic, MACD, MFI, RSI, ATR, Keltner) fetch enough trading days of history to compute; previously most errored or silently used too little data whenever the window spanned a weekend.
+- RSI, ATR, and Keltner Channels apply Wilder/EMA smoothing as documented instead of returning simple averages.
+- Bollinger Bands use the population standard deviation per the standard definition.
+- PairsRatio and PairsResidual align the two assets' time axes instead of pairing bars from different dates or panicking on mismatched history.
+- Wash-sale basis adjustments on a rebuy apply only to the matched shares instead of the whole lot.
+- Trade details attribute entry price, date, and PnL to the lots actually consumed under LIFO and HighestCost lot selection.
+- Windowed portfolio views compute tax, trade, withdrawal, and all risk metrics over the view's date range; several risk fields previously returned zero and the rest used full history.
+- MWRR computed over a window (1yr, ytd, mtd) reflects that window instead of the since-inception rate.
+- Calmar, Recovery Factor, Keller Ratio, Treynor, and Active Return no longer count deposits and withdrawals as investment return.
+- Benchmark-relative TWRR, CAGR, and MWRR no longer subtract the portfolio's deposits from the benchmark's return.
+- Realized gain, after-tax, and tax-metric calculations handle short round trips and stock splits correctly.
+- Trade Capture Ratio computes the correct sign for short trades.
+- Probabilistic Sharpe Ratio uses the published Bailey & López de Prado standard-error formula; confidence was previously overstated.
+- K-Ratio is normalized by observation count per the 2003 revision so values are comparable across window lengths.
+- The StdDev metric's series is an expanding annualized standard deviation instead of mislabeled raw returns.
+- Drawdowns over an absolute date window measure from peaks within the window, matching relative-period windows.
+- Cloned accounts keep their margin configuration and no longer panic on price updates, so prediction runs see the same leverage limits as real runs.
+- OCO order pairs cancel the surviving leg on brokers without native group support.
+- Writing a backtest over an existing output file succeeds instead of failing after the run completes.
+- Saved backtests reload benchmark gaps as missing data instead of zeros, and accounts restored from a database no longer panic when new activity is recorded.
+- `RebalanceTo` in a batch no longer sells positions twice when earlier orders in the same batch already sold them.
+- Fills are matched to their orders by ID, so partial fills and queued fills from earlier orders are recorded against the correct order.
+- Parameter sweeps include the documented max endpoint for fractional steps and no longer hang on a zero or negative step; walk-forward splits validate their durations.
+- Bayesian optimization learns from all evaluated combinations instead of only the previous batch, and failed runs no longer poison the surrogate model.
+- Walk-forward duration flags such as `--test-len 6m` parse as months instead of minutes.
+- Quitting the backtest progress view reports an interruption instead of crashing.
+- The library browser acts on the strategy row that is highlighted; previously the cursor and the displayed list could diverge.
+- Buy and sell rows in the recent-trades table are colored again.
+- Intraday adjusted prices include each split and dividend's own adjustment; bars before an event were previously missing exactly that event's factor.
+- Rated universes use the most recent rating on or before the query date instead of requiring an exact date match.
+- Snapshot recording and replay honor the strategy's fundamental dimension, and replaying fundamentals with date-key metrics no longer errors.
+- Parallel studies sharing one data provider no longer crash on concurrent index-membership lookups or corrupt each other's index cursors.
+- `Downsample(Daily)` groups intraday bars by calendar day instead of treating every bar as its own period.
+- Stress-test rankings omit scenarios the data does not cover instead of reporting them as flat results.
+- Numerous live-broker fixes: Schwab and TradeStation token refresh no longer deadlocks, and TradeStation no longer loses its refresh token; TradeStation API paths, response decoding, and order-side mapping match the v3 API; IBKR performs its OAuth handshake and session keepalive and no longer double-counts partial fills; E*TRADE signs query parameters, tracks fill deltas, and guards credentials during rotation; Alpaca recovers fills missed during a disconnect without duplicating them and formats GTD expirations in UTC; Tradier sandbox delivers completing and repeated partial fills; Webull order placement includes the account ID; tastytrade can open and cover short positions, closes its fill stream cleanly, and dollar-amount orders too small for one share return an error everywhere instead of vanishing; VWAP fills skip missing intraday bars instead of filling at NaN.
+
 ## [0.11.0] - 2026-06-08
 
 ### Added

--- a/broker/alpaca/broker.go
+++ b/broker/alpaca/broker.go
@@ -173,7 +173,8 @@ func (alpacaBroker *AlpacaBroker) Submit(ctx context.Context, order broker.Order
 
 		computedQty := math.Floor(order.Amount / price)
 		if computedQty == 0 {
-			return nil
+			return fmt.Errorf("alpaca: order for %s: amount %.2f is less than the share price %.2f",
+				order.Asset.Ticker, order.Amount, price)
 		}
 
 		order.Qty = computedQty

--- a/broker/alpaca/broker_test.go
+++ b/broker/alpaca/broker_test.go
@@ -250,7 +250,7 @@ var _ = Describe("AlpacaBroker", func() {
 			Expect(receivedBody["qty"]).To(BeNil())
 		})
 
-		It("returns nil without submitting when dollar amount yields zero shares", func() {
+		It("returns an error without submitting when dollar amount yields zero shares", func() {
 			var submitCalled atomic.Int32
 
 			alpacaBroker := authenticatedBroker(func(mux *http.ServeMux) {
@@ -278,7 +278,8 @@ var _ = Describe("AlpacaBroker", func() {
 				TimeInForce: broker.Day,
 			})
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("less than the share price"))
 			Expect(submitCalled.Load()).To(Equal(int32(0)))
 		})
 	})

--- a/broker/alpaca/client.go
+++ b/broker/alpaca/client.go
@@ -151,6 +151,33 @@ func (client *apiClient) getOrders(ctx context.Context) ([]orderResponse, error)
 	return result, nil
 }
 
+// getOrdersSince retrieves orders of every status submitted after the given
+// time. Used by the fill streamer to recover fills that completed while the
+// WebSocket was disconnected; closed orders must be included because a fully
+// filled order no longer appears in the open-order listing.
+func (client *apiClient) getOrdersSince(ctx context.Context, after time.Time) ([]orderResponse, error) {
+	var result []orderResponse
+
+	resp, err := client.resty.R().
+		SetContext(ctx).
+		SetQueryParams(map[string]string{
+			"status": "all",
+			"limit":  "500",
+			"after":  after.UTC().Format(time.RFC3339),
+		}).
+		SetResult(&result).
+		Get("/v2/orders")
+	if err != nil {
+		return nil, fmt.Errorf("get orders since %s: %w", after.Format(time.RFC3339), err)
+	}
+
+	if resp.IsError() {
+		return nil, broker.NewHTTPError(resp.StatusCode(), resp.String())
+	}
+
+	return result, nil
+}
+
 // getPositions retrieves all positions.
 func (client *apiClient) getPositions(ctx context.Context) ([]positionResponse, error) {
 	var result []positionResponse

--- a/broker/alpaca/streamer.go
+++ b/broker/alpaca/streamer.go
@@ -46,6 +46,8 @@ type fillStreamer struct {
 	wsURL        string
 	wsConn       *websocket.Conn
 	seenFills    map[string]time.Time // execution_id -> seen time
+	cumFilled    map[string]float64   // order ID -> cumulative qty delivered
+	startedAt    time.Time
 	mu           sync.Mutex
 	done         chan struct{}
 	wg           sync.WaitGroup
@@ -58,6 +60,14 @@ type fillStreamer struct {
 // and starts the background read loop.
 func (streamer *fillStreamer) connect(ctx context.Context) error {
 	streamer.ctx = ctx
+
+	if streamer.cumFilled == nil {
+		streamer.cumFilled = make(map[string]float64)
+	}
+
+	if streamer.startedAt.IsZero() {
+		streamer.startedAt = time.Now()
+	}
 
 	conn, _, dialErr := websocket.DefaultDialer.DialContext(ctx, streamer.wsURL, nil)
 	if dialErr != nil {
@@ -254,17 +264,35 @@ func (streamer *fillStreamer) handleMessage(data []byte) {
 	}
 
 	executionID := tradeUpdate.ExecutionID
+	execQty := parseFloat(tradeUpdate.Qty)
+	cumQty := parseFloat(tradeUpdate.Order.FilledQty)
 
 	streamer.mu.Lock()
+
+	var delta float64
 
 	_, alreadySeen := streamer.seenFills[executionID]
 	if !alreadySeen {
 		streamer.seenFills[executionID] = time.Now()
+
+		// Reconcile against the cumulative total so quantities already
+		// delivered by pollMissedFills are not double-counted. Fall back
+		// to the execution quantity when the order snapshot is absent.
+		prev := streamer.cumFilled[tradeUpdate.Order.ID]
+
+		delta = execQty
+		if cumQty > 0 {
+			delta = cumQty - prev
+		}
+
+		if delta > 0 {
+			streamer.cumFilled[tradeUpdate.Order.ID] = prev + delta
+		}
 	}
 
 	streamer.mu.Unlock()
 
-	if alreadySeen {
+	if alreadySeen || delta <= 0 {
 		return
 	}
 
@@ -276,7 +304,7 @@ func (streamer *fillStreamer) handleMessage(data []byte) {
 	fill := broker.Fill{
 		OrderID:  tradeUpdate.Order.ID,
 		Price:    parseFloat(tradeUpdate.Price),
-		Qty:      parseFloat(tradeUpdate.Qty),
+		Qty:      delta,
 		FilledAt: filledAt,
 	}
 
@@ -404,37 +432,39 @@ func (streamer *fillStreamer) reconnect(ctx context.Context) error {
 	return broker.ErrStreamDisconnected
 }
 
-// pollMissedFills queries orders via REST and sends any fills not yet seen.
+// pollMissedFills queries all orders submitted since the streamer started
+// (closed orders included -- an order that fully filled while the WebSocket
+// was down no longer shows up as open) and delivers the portion of each
+// order's cumulative filled quantity that has not been delivered yet.
 func (streamer *fillStreamer) pollMissedFills(ctx context.Context) {
-	orders, fetchErr := streamer.client.getOrders(ctx)
+	orders, fetchErr := streamer.client.getOrdersSince(ctx, streamer.startedAt)
 	if fetchErr != nil {
 		return
 	}
 
 	for _, order := range orders {
-		if order.Status != "filled" && order.Status != "partially_filled" {
+		filledQty := parseFloat(order.FilledQty)
+		if filledQty <= 0 {
 			continue
 		}
 
-		dedupKey := "poll-" + order.ID
-
 		streamer.mu.Lock()
 
-		_, alreadySeen := streamer.seenFills[dedupKey]
-		if !alreadySeen {
-			streamer.seenFills[dedupKey] = time.Now()
+		delta := filledQty - streamer.cumFilled[order.ID]
+		if delta > 0 {
+			streamer.cumFilled[order.ID] = filledQty
 		}
 
 		streamer.mu.Unlock()
 
-		if alreadySeen {
+		if delta <= 0 {
 			continue
 		}
 
 		fill := broker.Fill{
 			OrderID:  order.ID,
 			Price:    parseFloat(order.FilledAvgPrice),
-			Qty:      parseFloat(order.FilledQty),
+			Qty:      delta,
 			FilledAt: time.Now(),
 		}
 

--- a/broker/alpaca/types.go
+++ b/broker/alpaca/types.go
@@ -129,7 +129,8 @@ type wsTradeUpdate struct {
 }
 
 type wsOrderData struct {
-	ID string `json:"id"`
+	ID        string `json:"id"`
+	FilledQty string `json:"filled_qty"`
 }
 
 type wsAuthResponse struct {
@@ -176,9 +177,10 @@ func toAlpacaOrder(order broker.Order, fractional bool) orderRequest {
 		request.StopPrice = formatFloat(order.StopPrice)
 	}
 
-	// Set expire time for GTD orders.
+	// Set expire time for GTD orders. Convert to UTC first: formatting a
+	// local wall-clock time with a literal 'Z' would mislabel it as UTC.
 	if order.TimeInForce == broker.GTD {
-		request.ExpireTime = order.GTDDate.Format("2006-01-02T15:04:05Z")
+		request.ExpireTime = order.GTDDate.UTC().Format("2006-01-02T15:04:05Z")
 	}
 
 	// For fractional dollar-amount orders, use notional instead of qty.

--- a/broker/etrade/client.go
+++ b/broker/etrade/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/bytedance/sonic"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -13,19 +14,22 @@ import (
 )
 
 // apiClient is a resty-based HTTP client for the E*TRADE API. It signs every
-// request with OAuth 1.0a credentials via an OnBeforeRequest middleware.
+// request with OAuth 1.0a credentials via an OnBeforeRequest middleware. The
+// credentials are held in an atomic pointer because the background token
+// renewal goroutine swaps them while requests are being signed.
 type apiClient struct {
 	resty        *resty.Client
-	creds        *oauthCredentials
+	creds        atomic.Pointer[oauthCredentials]
 	accountIDKey string
 }
 
 // newAPIClient constructs an apiClient targeting baseURL with OAuth signing.
 func newAPIClient(baseURL string, creds *oauthCredentials, accountIDKey string) *apiClient {
 	cl := &apiClient{
-		creds:        creds,
 		accountIDKey: accountIDKey,
 	}
+
+	cl.creds.Store(creds)
 
 	httpClient := resty.New().
 		SetBaseURL(baseURL).
@@ -44,12 +48,17 @@ func newAPIClient(baseURL string, creds *oauthCredentials, accountIDKey string) 
 	httpClient.OnBeforeRequest(func(rc *resty.Client, req *resty.Request) error {
 		rawURL := rc.HostURL + req.URL
 
+		// Query parameters set via SetQueryParam are not yet part of req.URL
+		// at this point, so they are passed explicitly to be included in the
+		// OAuth signature base string.
+		signCreds := cl.creds.Load()
+
 		authHdr := buildAuthHeader(
 			req.Method, rawURL,
-			cl.creds.ConsumerKey, cl.creds.ConsumerSecret,
-			cl.creds.AccessToken, cl.creds.AccessSecret,
+			signCreds.ConsumerKey, signCreds.ConsumerSecret,
+			signCreds.AccessToken, signCreds.AccessSecret,
 			generateNonce(), generateTimestamp(),
-			nil,
+			req.QueryParam,
 		)
 
 		req.SetHeader("Authorization", authHdr)
@@ -64,7 +73,7 @@ func newAPIClient(baseURL string, creds *oauthCredentials, accountIDKey string) 
 
 // setCreds updates the stored credentials pointer used for OAuth signing.
 func (cl *apiClient) setCreds(creds *oauthCredentials) {
-	cl.creds = creds
+	cl.creds.Store(creds)
 }
 
 // getBalance fetches the account balance from E*TRADE.

--- a/broker/etrade/streamer.go
+++ b/broker/etrade/streamer.go
@@ -14,11 +14,13 @@ const defaultPollInterval = 2 * time.Second
 
 // orderPoller periodically polls the E*TRADE orders endpoint and emits fills
 // onto the fills channel when an order transitions to EXECUTED or
-// INDIVIDUAL_FILLS status. Duplicate fills are suppressed via seenFills.
+// INDIVIDUAL_FILLS status. E*TRADE reports the cumulative filled quantity per
+// order, so the poller tracks a running total per order and emits only the
+// delta on each change; this also suppresses duplicates across polls.
 type orderPoller struct {
 	client       *apiClient
 	fills        chan broker.Fill
-	seenFills    map[string]bool // key: "orderID-qty-price"
+	cumFilled    map[string]float64 // key: orderID, value: cumulative filled qty
 	mu           sync.Mutex
 	cancel       context.CancelFunc
 	pollInterval time.Duration
@@ -29,7 +31,7 @@ func newOrderPoller(client *apiClient, fills chan broker.Fill) *orderPoller {
 	return &orderPoller{
 		client:       client,
 		fills:        fills,
-		seenFills:    make(map[string]bool),
+		cumFilled:    make(map[string]float64),
 		pollInterval: defaultPollInterval,
 	}
 }
@@ -87,25 +89,25 @@ func (op *orderPoller) poll(ctx context.Context) error {
 		}
 
 		instr := leg.Instrument[0]
-		fillKey := fmt.Sprintf("%d-%.4f-%.4f", order.OrderID, instr.FilledQty, instr.AveragePrice)
+		orderID := fmt.Sprintf("%d", order.OrderID)
 
 		op.mu.Lock()
-		alreadySeen := op.seenFills[fillKey]
 
-		if !alreadySeen {
-			op.seenFills[fillKey] = true
+		delta := instr.FilledQty - op.cumFilled[orderID]
+		if delta > 0 {
+			op.cumFilled[orderID] = instr.FilledQty
 		}
 
 		op.mu.Unlock()
 
-		if alreadySeen {
+		if delta <= 0 {
 			continue
 		}
 
 		fill := broker.Fill{
-			OrderID:  fmt.Sprintf("%d", order.OrderID),
+			OrderID:  orderID,
 			Price:    instr.AveragePrice,
-			Qty:      instr.FilledQty,
+			Qty:      delta,
 			FilledAt: time.Now(),
 		}
 

--- a/broker/fill_vwap.go
+++ b/broker/fill_vwap.go
@@ -78,13 +78,19 @@ func (vf *vwapFill) intradayVWAP(ctx context.Context, order Order, bar *data.Dat
 	var sumPV, sumVol float64
 
 	for ii := range highCol {
+		// Missing bars are marked NaN; one would otherwise poison the
+		// whole accumulation and fill the order at price NaN.
+		if math.IsNaN(highCol[ii]) || math.IsNaN(lowCol[ii]) || math.IsNaN(closeCol[ii]) || math.IsNaN(volCol[ii]) {
+			continue
+		}
+
 		tp := (highCol[ii] + lowCol[ii] + closeCol[ii]) / 3.0
 		vol := volCol[ii]
 		sumPV += tp * vol
 		sumVol += vol
 	}
 
-	if sumVol == 0 {
+	if sumVol == 0 || math.IsNaN(sumVol) {
 		return 0, false
 	}
 

--- a/broker/ibkr/broker.go
+++ b/broker/ibkr/broker.go
@@ -33,11 +33,12 @@ const (
 
 // IBBroker implements broker.Broker for the Interactive Brokers brokerage.
 type IBBroker struct {
-	client     *apiClient
-	fills      chan broker.Fill
-	streamer   *orderStreamer
-	accountID  string
-	conidCache map[string]int64
+	client          *apiClient
+	fills           chan broker.Fill
+	streamer        *orderStreamer
+	accountID       string
+	conidCache      map[string]int64
+	cancelKeepalive context.CancelFunc
 }
 
 // Option configures an IBBroker.
@@ -83,6 +84,12 @@ func (ib *IBBroker) Connect(ctx context.Context) error {
 	ib.client.secdef = nil
 	ib.client.lastTrade = nil
 
+	if ib.client.auth != nil {
+		if initErr := ib.client.auth.Init(ctx); initErr != nil {
+			return fmt.Errorf("ibkr: connect: %w", initErr)
+		}
+	}
+
 	accountID, resolveErr := ib.client.resolveAccount(ctx)
 	if resolveErr != nil {
 		return resolveErr
@@ -97,11 +104,31 @@ func (ib *IBBroker) Connect(ctx context.Context) error {
 		return connectErr
 	}
 
+	if ib.client.auth != nil {
+		// The keepalive must outlive the Connect context; it is cancelled
+		// explicitly in Close.
+		keepaliveCtx, cancelKeepalive := context.WithCancel(context.Background())
+		ib.cancelKeepalive = cancelKeepalive
+
+		go ib.client.auth.Keepalive(keepaliveCtx)
+	}
+
 	return nil
 }
 
 // Close tears down the broker session and stops the order streamer.
 func (ib *IBBroker) Close() error {
+	if ib.cancelKeepalive != nil {
+		ib.cancelKeepalive()
+		ib.cancelKeepalive = nil
+	}
+
+	if ib.client.auth != nil {
+		if closeErr := ib.client.auth.Close(); closeErr != nil {
+			return closeErr
+		}
+	}
+
 	if ib.streamer != nil {
 		return ib.streamer.close()
 	}

--- a/broker/ibkr/client.go
+++ b/broker/ibkr/client.go
@@ -68,13 +68,14 @@ func newAPIClient(baseURL string, auth Authenticator) *apiClient {
 		return resp.StatusCode() >= 500 || resp.StatusCode() == http.StatusTooManyRequests
 	})
 
-	httpClient.OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
-		if auth != nil {
-			return auth.Decorate(req.RawRequest)
-		}
-
-		return nil
-	})
+	// Decorate must run after resty builds the underlying *http.Request;
+	// OnBeforeRequest middleware runs before RawRequest exists, so a
+	// pre-request hook is used instead.
+	if auth != nil {
+		httpClient.SetPreRequestHook(func(_ *resty.Client, rawReq *http.Request) error {
+			return auth.Decorate(rawReq)
+		})
+	}
 
 	return &apiClient{
 		resty:   httpClient,

--- a/broker/ibkr/streamer.go
+++ b/broker/ibkr/streamer.go
@@ -54,6 +54,7 @@ type orderStreamer struct {
 	conn              *websocket.Conn
 	fills             chan<- broker.Fill
 	seenFills         map[string]time.Time
+	cumFilled         map[string]float64
 	heartbeatInterval time.Duration
 	tradesFn          func(ctx context.Context) ([]ibTradeEntry, error)
 	cancel            context.CancelFunc
@@ -67,6 +68,7 @@ func newOrderStreamer(fills chan broker.Fill, wsURL string, tradesFn func(ctx co
 		wsURL:             wsURL,
 		fills:             fills,
 		seenFills:         make(map[string]time.Time),
+		cumFilled:         make(map[string]float64),
 		heartbeatInterval: defaultHeartbeatInterval,
 		tradesFn:          tradesFn,
 	}
@@ -149,7 +151,7 @@ func (os *orderStreamer) readLoop(ctx context.Context) {
 			continue
 		}
 
-		os.deliverFill(ctx, args.OrderID, args.FilledQuantity, args.AvgPrice)
+		os.deliverCumulativeFill(ctx, args.OrderID, args.FilledQuantity, args.AvgPrice)
 	}
 }
 
@@ -233,6 +235,9 @@ func (os *orderStreamer) reconnect(ctx context.Context) error {
 }
 
 // pollMissedFills calls tradesFn (if set) and delivers any unseen fills.
+// Individual trades (executions) are deduplicated by execution ID and counted
+// toward the per-order cumulative total so subsequent WebSocket status
+// updates do not double-report them.
 func (os *orderStreamer) pollMissedFills(ctx context.Context) {
 	if os.tradesFn == nil {
 		return
@@ -245,26 +250,50 @@ func (os *orderStreamer) pollMissedFills(ctx context.Context) {
 	}
 
 	for _, trade := range trades {
-		os.deliverFill(ctx, trade.OrderID, trade.Quantity, trade.Price)
+		fillKey := trade.ExecID
+		if fillKey == "" {
+			fillKey = fmt.Sprintf("%s-%.4f-%.4f", trade.OrderID, trade.Quantity, trade.Price)
+		}
+
+		os.mu.Lock()
+
+		_, alreadySeen := os.seenFills[fillKey]
+		if !alreadySeen {
+			os.seenFills[fillKey] = time.Now()
+			os.cumFilled[trade.OrderID] += trade.Quantity
+		}
+
+		os.mu.Unlock()
+
+		if alreadySeen {
+			continue
+		}
+
+		os.sendFill(ctx, trade.OrderID, trade.Quantity, trade.Price)
 	}
 }
 
-// deliverFill deduplicates and sends a fill on the fills channel.
-func (os *orderStreamer) deliverFill(ctx context.Context, orderID string, qty float64, price float64) {
-	fillKey := fmt.Sprintf("%s-%.4f-%.4f", orderID, qty, price)
-
+// deliverCumulativeFill converts the cumulative filledQuantity reported by a
+// WebSocket "sor" update into an incremental fill and delivers the delta.
+func (os *orderStreamer) deliverCumulativeFill(ctx context.Context, orderID string, cumQty float64, price float64) {
 	os.mu.Lock()
 
-	_, alreadySeen := os.seenFills[fillKey]
-	if !alreadySeen {
-		os.seenFills[fillKey] = time.Now()
+	delta := cumQty - os.cumFilled[orderID]
+	if delta > 0 {
+		os.cumFilled[orderID] = cumQty
 	}
+
 	os.mu.Unlock()
 
-	if alreadySeen {
+	if delta <= 0 {
 		return
 	}
 
+	os.sendFill(ctx, orderID, delta, price)
+}
+
+// sendFill sends a fill on the fills channel unless the context is cancelled.
+func (os *orderStreamer) sendFill(ctx context.Context, orderID string, qty float64, price float64) {
 	fill := broker.Fill{
 		OrderID:  orderID,
 		Price:    price,

--- a/broker/ibkr/types.go
+++ b/broker/ibkr/types.go
@@ -87,10 +87,10 @@ type ibOrderReply struct {
 }
 
 type ibTradeEntry struct {
-	OrderID       string  `json:"order_ref"`
-	Price         float64 `json:"price"`
-	Quantity      float64 `json:"size"`
-	ExecutionTime string  `json:"execution_id"`
+	OrderID  string  `json:"order_ref"`
+	Price    float64 `json:"price"`
+	Quantity float64 `json:"size"`
+	ExecID   string  `json:"execution_id"`
 }
 
 // --- Mapping functions ---

--- a/broker/schwab/auth.go
+++ b/broker/schwab/auth.go
@@ -286,7 +286,7 @@ func (manager *tokenManager) startBackgroundRefresh() {
 				if manager.accessTokenExpired() && !manager.refreshTokenExpired() {
 					refreshErr := manager.refreshAccessToken()
 					if refreshErr == nil && manager.onRefresh != nil {
-						manager.onRefresh(manager.accessToken())
+						manager.onRefresh(manager.tokens.AccessToken)
 					}
 				}
 				manager.mu.Unlock()

--- a/broker/schwab/broker.go
+++ b/broker/schwab/broker.go
@@ -180,7 +180,8 @@ func (schwabBroker *SchwabBroker) Submit(ctx context.Context, order broker.Order
 
 		qty = math.Floor(order.Amount / price)
 		if qty == 0 {
-			return nil
+			return fmt.Errorf("schwab: order for %s: amount %.2f is less than the share price %.2f",
+				order.Asset.Ticker, order.Amount, price)
 		}
 	}
 

--- a/broker/schwab/broker_test.go
+++ b/broker/schwab/broker_test.go
@@ -163,7 +163,7 @@ var _ = Describe("SchwabBroker", func() {
 			Expect(submittedQty).To(Equal(50.0)) // floor(5000 / 100) = 50
 		})
 
-		It("returns nil without submitting when dollar amount yields zero shares", func() {
+		It("returns an error without submitting when dollar amount yields zero shares", func() {
 			var submitCalled atomic.Int32
 
 			schwabBroker := authenticatedBroker(func(mux *http.ServeMux) {
@@ -193,7 +193,8 @@ var _ = Describe("SchwabBroker", func() {
 				TimeInForce: broker.Day,
 			})
 
-			Expect(submitErr).ToNot(HaveOccurred())
+			Expect(submitErr).To(HaveOccurred())
+			Expect(submitErr.Error()).To(ContainSubstring("less than the share price"))
 			Expect(submitCalled.Load()).To(Equal(int32(0)))
 		})
 	})

--- a/broker/schwab/client.go
+++ b/broker/schwab/client.go
@@ -157,8 +157,11 @@ func (client *apiClient) getOrders(ctx context.Context) ([]schwabOrderResponse, 
 	resp, reqErr := client.resty.R().
 		SetContext(ctx).
 		SetQueryParams(map[string]string{
-			"fromEnteredTime": startOfDay.Format(time.RFC3339),
-			"toEnteredTime":   now.Format(time.RFC3339),
+			// Schwab requires ISO-8601 with milliseconds and a Z suffix
+			// (yyyy-MM-dd'T'HH:mm:ss.SSSZ); RFC3339 with a local offset
+			// is rejected with a 400.
+			"fromEnteredTime": startOfDay.UTC().Format("2006-01-02T15:04:05.000Z"),
+			"toEnteredTime":   now.UTC().Format("2006-01-02T15:04:05.000Z"),
 		}).
 		SetResult(&orders).
 		Get(endpoint)

--- a/broker/tastytrade/broker.go
+++ b/broker/tastytrade/broker.go
@@ -86,13 +86,16 @@ func (ttBroker *TastytradeBroker) Connect(ctx context.Context) error {
 }
 
 func (ttBroker *TastytradeBroker) Close() error {
+	var err error
 	if ttBroker.streamer != nil {
-		return ttBroker.streamer.close()
+		err = ttBroker.streamer.close()
 	}
 
+	// Always close the fills channel so consumers ranging over Fills()
+	// terminate, matching the other broker implementations.
 	close(ttBroker.fills)
 
-	return nil
+	return err
 }
 
 func (ttBroker *TastytradeBroker) Fills() <-chan broker.Fill {
@@ -112,12 +115,18 @@ func (ttBroker *TastytradeBroker) Submit(ctx context.Context, order broker.Order
 
 		qty = math.Floor(order.Amount / price)
 		if qty == 0 {
-			return nil
+			return fmt.Errorf("tastytrade: order for %s: amount %.2f is less than the share price %.2f",
+				order.Asset.Ticker, order.Amount, price)
 		}
 	}
 
+	positions, posErr := ttBroker.client.getPositions(ctx)
+	if posErr != nil {
+		return fmt.Errorf("tastytrade: get positions for order action: %w", posErr)
+	}
+
 	order.Qty = qty
-	ttOrder := toTastytradeOrder(order)
+	ttOrder := toTastytradeOrder(order, detectAction(order.Side, order.Asset.Ticker, positions))
 
 	_, err := ttBroker.client.submitOrder(ctx, ttOrder)
 	if err != nil {
@@ -140,7 +149,13 @@ func (ttBroker *TastytradeBroker) Cancel(ctx context.Context, orderID string) er
 }
 
 func (ttBroker *TastytradeBroker) Replace(ctx context.Context, orderID string, order broker.Order) error {
-	ttOrder := toTastytradeOrder(order)
+	positions, posErr := ttBroker.client.getPositions(ctx)
+	if posErr != nil {
+		return fmt.Errorf("tastytrade: get positions for order action: %w", posErr)
+	}
+
+	ttOrder := toTastytradeOrder(order, detectAction(order.Side, order.Asset.Ticker, positions))
+
 	return ttBroker.client.replaceOrder(ctx, orderID, ttOrder)
 }
 
@@ -214,9 +229,14 @@ func (ttBroker *TastytradeBroker) SubmitGroup(ctx context.Context, orders []brok
 }
 
 func (ttBroker *TastytradeBroker) submitOCO(ctx context.Context, orders []broker.Order) error {
+	positions, posErr := ttBroker.client.getPositions(ctx)
+	if posErr != nil {
+		return fmt.Errorf("tastytrade: get positions for order action: %w", posErr)
+	}
+
 	ttOrders := make([]orderRequest, len(orders))
 	for idx, order := range orders {
-		ttOrders[idx] = toTastytradeOrder(order)
+		ttOrders[idx] = toTastytradeOrder(order, detectAction(order.Side, order.Asset.Ticker, positions))
 	}
 
 	req := complexOrderRequest{
@@ -236,17 +256,53 @@ func (ttBroker *TastytradeBroker) submitOCO(ctx context.Context, orders []broker
 
 func (ttBroker *TastytradeBroker) submitOTOCO(ctx context.Context, orders []broker.Order) error {
 	var (
+		entrySide  broker.Side
+		entryFound bool
+	)
+
+	for _, order := range orders {
+		if order.GroupRole == broker.RoleEntry {
+			if entryFound {
+				return ErrMultipleEntryOrders
+			}
+
+			entrySide = order.Side
+			entryFound = true
+		}
+	}
+
+	if !entryFound {
+		return ErrNoEntryOrder
+	}
+
+	positions, posErr := ttBroker.client.getPositions(ctx)
+	if posErr != nil {
+		return fmt.Errorf("tastytrade: get positions for order action: %w", posErr)
+	}
+
+	var (
 		triggerOrder     *orderRequest
 		contingentOrders []orderRequest
 	)
 
 	for _, order := range orders {
-		ttOrder := toTastytradeOrder(order)
-		if order.GroupRole == broker.RoleEntry {
-			if triggerOrder != nil {
-				return ErrMultipleEntryOrders
-			}
+		var action string
 
+		switch {
+		case order.GroupRole == broker.RoleEntry:
+			action = detectAction(order.Side, order.Asset.Ticker, positions)
+		case entrySide == broker.Buy:
+			// Contingent exits close the position the entry opens. That
+			// position does not exist at submit time, so the action is the
+			// closing complement of the entry rather than position-detected.
+			action = "Sell to Close"
+		default:
+			action = "Buy to Close"
+		}
+
+		ttOrder := toTastytradeOrder(order, action)
+
+		if order.GroupRole == broker.RoleEntry {
 			triggerOrder = &ttOrder
 		} else {
 			contingentOrders = append(contingentOrders, ttOrder)

--- a/broker/tastytrade/broker_test.go
+++ b/broker/tastytrade/broker_test.go
@@ -77,6 +77,19 @@ var _ = Describe("TastytradeBroker", func() {
 		return ttBroker
 	}
 
+	// registerEmptyPositions serves an empty positions list; Submit, Replace,
+	// and SubmitGroup fetch positions to detect the order action.
+	registerEmptyPositions := func(mux *http.ServeMux) {
+		mux.HandleFunc("GET /accounts/ACCT-001/positions", func(writer http.ResponseWriter, req *http.Request) {
+			writer.Header().Set("Content-Type", "application/json")
+			sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+				"data": map[string]any{
+					"items": []map[string]any{},
+				},
+			})
+		})
+	}
+
 	Describe("Constructor and options", func() {
 		It("creates a broker with a non-nil fills channel", func() {
 			ttBroker := tastytrade.New()
@@ -117,6 +130,7 @@ var _ = Describe("TastytradeBroker", func() {
 			var receivedBody map[string]any
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
+				registerEmptyPositions(mux)
 				mux.HandleFunc("POST /accounts/ACCT-001/orders", func(writer http.ResponseWriter, req *http.Request) {
 					submitCalled.Add(1)
 					sonic.ConfigDefault.NewDecoder(req.Body).Decode(&receivedBody)
@@ -156,6 +170,7 @@ var _ = Describe("TastytradeBroker", func() {
 			var submittedQty float64
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
+				registerEmptyPositions(mux)
 				mux.HandleFunc("GET /market-data/by-type", func(writer http.ResponseWriter, req *http.Request) {
 					writer.Header().Set("Content-Type", "application/json")
 					sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
@@ -203,7 +218,7 @@ var _ = Describe("TastytradeBroker", func() {
 			Expect(submittedQty).To(Equal(50.0)) // floor(5000 / 100) = 50
 		})
 
-		It("returns nil without submitting when dollar amount yields zero shares", func() {
+		It("returns an error without submitting when dollar amount yields zero shares", func() {
 			var submitCalled atomic.Int32
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
@@ -236,7 +251,8 @@ var _ = Describe("TastytradeBroker", func() {
 				TimeInForce: broker.Day,
 			})
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("less than the share price"))
 			Expect(submitCalled.Load()).To(Equal(int32(0)))
 		})
 	})
@@ -261,6 +277,7 @@ var _ = Describe("TastytradeBroker", func() {
 			var complexCancelCalled atomic.Int32
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
+				registerEmptyPositions(mux)
 				mux.HandleFunc("POST /accounts/ACCT-001/complex-orders", func(writer http.ResponseWriter, req *http.Request) {
 					writer.Header().Set("Content-Type", "application/json")
 					sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
@@ -298,6 +315,7 @@ var _ = Describe("TastytradeBroker", func() {
 			var replaceCalled atomic.Int32
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
+				registerEmptyPositions(mux)
 				mux.HandleFunc("PUT /accounts/ACCT-001/orders/ORD-REPLACE-1", func(writer http.ResponseWriter, req *http.Request) {
 					replaceCalled.Add(1)
 					writer.WriteHeader(http.StatusOK)
@@ -404,6 +422,7 @@ var _ = Describe("TastytradeBroker", func() {
 			var complexCancelCalled atomic.Int32
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
+				registerEmptyPositions(mux)
 				mux.HandleFunc("POST /accounts/ACCT-001/complex-orders", func(writer http.ResponseWriter, req *http.Request) {
 					sonic.ConfigDefault.NewDecoder(req.Body).Decode(&receivedBody)
 					writer.Header().Set("Content-Type", "application/json")
@@ -446,6 +465,7 @@ var _ = Describe("TastytradeBroker", func() {
 			var receivedBody map[string]any
 
 			ttBroker := authenticatedBroker(func(mux *http.ServeMux) {
+				registerEmptyPositions(mux)
 				mux.HandleFunc("POST /accounts/ACCT-001/complex-orders", func(writer http.ResponseWriter, req *http.Request) {
 					sonic.ConfigDefault.NewDecoder(req.Body).Decode(&receivedBody)
 					writer.Header().Set("Content-Type", "application/json")

--- a/broker/tastytrade/types.go
+++ b/broker/tastytrade/types.go
@@ -152,7 +152,7 @@ type quoteItem struct {
 
 // --- Translation functions ---
 
-func toTastytradeOrder(order broker.Order) orderRequest {
+func toTastytradeOrder(order broker.Order, action string) orderRequest {
 	return orderRequest{
 		TimeInForce:     mapTimeInForce(order.TimeInForce),
 		OrderType:       mapOrderType(order.OrderType),
@@ -164,7 +164,7 @@ func toTastytradeOrder(order broker.Order) orderRequest {
 			{
 				InstrumentType: "Equity",
 				Symbol:         order.Asset.Ticker,
-				Action:         mapSide(order.Side),
+				Action:         action,
 				Quantity:       order.Qty,
 			},
 		},
@@ -235,11 +235,32 @@ func mapPriceEffect(side broker.Side, orderType broker.OrderType) string {
 	}
 }
 
-func mapSide(side broker.Side) string {
+// detectAction returns the tastytrade order action for the requested side,
+// accounting for the current position: an existing short is covered with
+// "Buy to Close" and a new short is opened with "Sell to Open"; long
+// positions use "Buy to Open" and "Sell to Close".
+func detectAction(side broker.Side, ticker string, positions []positionResponse) string {
+	var currentQty float64
+
+	for _, pos := range positions {
+		if pos.Symbol == ticker {
+			currentQty = pos.Quantity
+			break
+		}
+	}
+
 	switch side {
 	case broker.Buy:
+		if currentQty < 0 {
+			return "Buy to Close"
+		}
+
 		return "Buy to Open"
 	case broker.Sell:
+		if currentQty <= 0 {
+			return "Sell to Open"
+		}
+
 		return "Sell to Close"
 	default:
 		return "Buy to Open"

--- a/broker/tastytrade/types_test.go
+++ b/broker/tastytrade/types_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				TimeInForce: broker.Day,
 			}
 
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Buy to Open")
 
 			Expect(result.OrderType).To(Equal("Market"))
 			Expect(result.TimeInForce).To(Equal("Day"))
@@ -43,7 +43,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				TimeInForce: broker.GTC,
 			}
 
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Sell to Close")
 
 			Expect(result.OrderType).To(Equal("Limit"))
 			Expect(result.Price).To(Equal(350.0))
@@ -61,7 +61,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				TimeInForce: broker.Day,
 			}
 
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Sell to Close")
 
 			Expect(result.OrderType).To(Equal("Stop"))
 			Expect(result.StopTrigger).To(Equal(200.0))
@@ -79,7 +79,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				TimeInForce: broker.Day,
 			}
 
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Buy to Open")
 
 			Expect(result.OrderType).To(Equal("Stop Limit"))
 			Expect(result.StopTrigger).To(Equal(150.0))
@@ -95,7 +95,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				LimitPrice:  150.0,
 				TimeInForce: broker.Day,
 			}
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Buy to Open")
 			Expect(result.PriceEffect).To(Equal("Debit"))
 		})
 
@@ -108,7 +108,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				LimitPrice:  150.0,
 				TimeInForce: broker.Day,
 			}
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Sell to Close")
 			Expect(result.PriceEffect).To(Equal("Credit"))
 		})
 
@@ -120,7 +120,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				OrderType:   broker.Market,
 				TimeInForce: broker.Day,
 			}
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Buy to Open")
 			Expect(result.PriceEffect).To(BeEmpty())
 		})
 
@@ -133,7 +133,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				StopPrice:   150.0,
 				TimeInForce: broker.Day,
 			}
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Buy to Open")
 			Expect(result.PriceEffect).To(Equal("Debit"))
 		})
 
@@ -146,7 +146,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				StopPrice:   150.0,
 				TimeInForce: broker.Day,
 			}
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Sell to Close")
 			Expect(result.PriceEffect).To(Equal("Credit"))
 		})
 
@@ -158,7 +158,7 @@ var _ = Describe("Types", Label("translation"), func() {
 				OrderType:   broker.Market,
 				TimeInForce: broker.Day,
 			}
-			result := toTastytradeOrder(order)
+			result := toTastytradeOrder(order, "Buy to Open")
 			Expect(result.AutomatedSource).To(BeTrue())
 		})
 
@@ -182,9 +182,36 @@ var _ = Describe("Types", Label("translation"), func() {
 					OrderType:   broker.Market,
 					TimeInForce: tc.tif,
 				}
-				result := toTastytradeOrder(order)
+				result := toTastytradeOrder(order, "Buy to Open")
 				Expect(result.TimeInForce).To(Equal(tc.expect), "for TIF %d", tc.tif)
 			}
+		})
+	})
+
+	Describe("detectAction", func() {
+		longPos := []positionResponse{{Symbol: "AAPL", Quantity: 100}}
+		shortPos := []positionResponse{{Symbol: "AAPL", Quantity: -100}}
+
+		It("opens a long when flat", func() {
+			Expect(detectAction(broker.Buy, "AAPL", nil)).To(Equal("Buy to Open"))
+		})
+
+		It("closes a long on sell", func() {
+			Expect(detectAction(broker.Sell, "AAPL", longPos)).To(Equal("Sell to Close"))
+		})
+
+		It("opens a short when selling flat", func() {
+			Expect(detectAction(broker.Sell, "AAPL", nil)).To(Equal("Sell to Open"))
+		})
+
+		It("covers a short on buy", func() {
+			Expect(detectAction(broker.Buy, "AAPL", shortPos)).To(Equal("Buy to Close"))
+		})
+
+		It("ignores positions in other tickers", func() {
+			other := []positionResponse{{Symbol: "MSFT", Quantity: -50}}
+			Expect(detectAction(broker.Buy, "AAPL", other)).To(Equal("Buy to Open"))
+			Expect(detectAction(broker.Sell, "AAPL", other)).To(Equal("Sell to Open"))
 		})
 	})
 

--- a/broker/tradestation/auth.go
+++ b/broker/tradestation/auth.go
@@ -143,7 +143,13 @@ func (manager *tokenManager) refreshAccessToken() error {
 	}
 
 	manager.tokens.AccessToken = tokenResp.AccessToken
-	manager.tokens.RefreshToken = tokenResp.RefreshToken
+
+	// TradeStation does not rotate refresh tokens; refresh responses omit
+	// refresh_token, so only overwrite the stored value when one is returned.
+	if tokenResp.RefreshToken != "" {
+		manager.tokens.RefreshToken = tokenResp.RefreshToken
+	}
+
 	manager.tokens.AccessExpiresAt = time.Now().Add(time.Duration(tokenResp.ExpiresIn) * time.Second)
 
 	return saveTokens(manager.tokenFile, manager.tokens)
@@ -291,7 +297,7 @@ func (manager *tokenManager) startBackgroundRefresh() {
 				if manager.accessTokenExpired() && manager.tokens.RefreshToken != "" {
 					refreshErr := manager.refreshAccessToken()
 					if refreshErr == nil && manager.onRefresh != nil {
-						manager.onRefresh(manager.accessToken())
+						manager.onRefresh(manager.tokens.AccessToken)
 					}
 				}
 				manager.mu.Unlock()

--- a/broker/tradestation/broker.go
+++ b/broker/tradestation/broker.go
@@ -15,8 +15,8 @@ import (
 
 const (
 	fillChannelSize   = 1024
-	apiBaseURLDefault = "https://api.tradestation.com/v3"
-	apiBaseURLSandbox = "https://sim-api.tradestation.com/v3"
+	apiBaseURLDefault = "https://api.tradestation.com"
+	apiBaseURLSandbox = "https://sim-api.tradestation.com"
 )
 
 // TradeStationBroker implements broker.Broker and broker.GroupSubmitter for the
@@ -194,7 +194,7 @@ func (tsBroker *TradeStationBroker) Submit(ctx context.Context, order broker.Ord
 
 		qty = math.Floor(order.Amount / price)
 		if qty == 0 {
-			return nil
+			return fmt.Errorf("tradestation: submit: dollar-amount order for %s results in zero shares at price %.4f", order.Asset.Ticker, price)
 		}
 	}
 

--- a/broker/tradestation/broker_test.go
+++ b/broker/tradestation/broker_test.go
@@ -166,7 +166,7 @@ var _ = Describe("TradeStationBroker", func() {
 			Expect(submittedQty).To(Equal("50")) // floor(5000 / 100) = 50
 		})
 
-		It("returns nil without submitting when dollar amount yields zero shares", func() {
+		It("returns an error without submitting when dollar amount yields zero shares", func() {
 			var submitCalled atomic.Int32
 
 			tsBroker := authenticatedBroker(func(mux *http.ServeMux) {
@@ -194,7 +194,7 @@ var _ = Describe("TradeStationBroker", func() {
 				TimeInForce: broker.Day,
 			})
 
-			Expect(submitErr).ToNot(HaveOccurred())
+			Expect(submitErr).To(MatchError(ContainSubstring("zero shares")))
 			Expect(submitCalled.Load()).To(Equal(int32(0)))
 		})
 	})
@@ -284,14 +284,16 @@ var _ = Describe("TradeStationBroker", func() {
 			tsBroker := authenticatedBroker(func(mux *http.ServeMux) {
 				mux.HandleFunc("GET /v3/brokerage/accounts/ACCT-TEST/positions", func(writer http.ResponseWriter, req *http.Request) {
 					writer.Header().Set("Content-Type", "application/json")
-					sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]any{
-						{
-							"Symbol":           "NVDA",
-							"Quantity":         "200",
-							"AveragePrice":     "450.00",
-							"MarketValue":      "95000.00",
-							"TodaysProfitLoss": "1250.00",
-							"Last":             "475.00",
+					sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+						"Positions": []map[string]any{
+							{
+								"Symbol":           "NVDA",
+								"Quantity":         "200",
+								"AveragePrice":     "450.00",
+								"MarketValue":      "95000.00",
+								"TodaysProfitLoss": "1250.00",
+								"Last":             "475.00",
+							},
 						},
 					})
 				})
@@ -311,12 +313,14 @@ var _ = Describe("TradeStationBroker", func() {
 			tsBroker := authenticatedBroker(func(mux *http.ServeMux) {
 				mux.HandleFunc("GET /v3/brokerage/accounts/ACCT-TEST/balances", func(writer http.ResponseWriter, req *http.Request) {
 					writer.Header().Set("Content-Type", "application/json")
-					sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]any{
-						{
-							"CashBalance": "30000.00",
-							"Equity":      "75000.00",
-							"BuyingPower": "60000.00",
-							"MarketValue": "45000.00",
+					sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+						"Balances": []map[string]any{
+							{
+								"CashBalance": "30000.00",
+								"Equity":      "75000.00",
+								"BuyingPower": "60000.00",
+								"MarketValue": "45000.00",
+							},
 						},
 					})
 				})

--- a/broker/tradestation/client.go
+++ b/broker/tradestation/client.go
@@ -42,11 +42,13 @@ func (client *apiClient) setToken(token string) {
 }
 
 func (client *apiClient) resolveAccount(ctx context.Context, desiredAccountID string) (string, error) {
-	var accounts []tsAccountEntry
+	var result struct {
+		Accounts []tsAccountEntry `json:"Accounts"`
+	}
 
 	resp, reqErr := client.resty.R().
 		SetContext(ctx).
-		SetResult(&accounts).
+		SetResult(&result).
 		Get("/v3/brokerage/accounts")
 	if reqErr != nil {
 		return "", fmt.Errorf("resolve account: %w", reqErr)
@@ -55,6 +57,8 @@ func (client *apiClient) resolveAccount(ctx context.Context, desiredAccountID st
 	if resp.IsError() {
 		return "", broker.NewHTTPError(resp.StatusCode(), resp.String())
 	}
+
+	accounts := result.Accounts
 
 	if len(accounts) == 0 {
 		return "", ErrAccountNotFound
@@ -149,11 +153,13 @@ func (client *apiClient) getOrders(ctx context.Context) ([]tsOrderResponse, erro
 func (client *apiClient) getPositions(ctx context.Context) ([]tsPositionEntry, error) {
 	endpoint := fmt.Sprintf("/v3/brokerage/accounts/%s/positions", client.accountID)
 
-	var positions []tsPositionEntry
+	var result struct {
+		Positions []tsPositionEntry `json:"Positions"`
+	}
 
 	resp, reqErr := client.resty.R().
 		SetContext(ctx).
-		SetResult(&positions).
+		SetResult(&result).
 		Get(endpoint)
 	if reqErr != nil {
 		return nil, fmt.Errorf("get positions: %w", reqErr)
@@ -163,17 +169,19 @@ func (client *apiClient) getPositions(ctx context.Context) ([]tsPositionEntry, e
 		return nil, broker.NewHTTPError(resp.StatusCode(), resp.String())
 	}
 
-	return positions, nil
+	return result.Positions, nil
 }
 
 func (client *apiClient) getBalance(ctx context.Context) (tsBalanceResponse, error) {
 	endpoint := fmt.Sprintf("/v3/brokerage/accounts/%s/balances", client.accountID)
 
-	var balances []tsBalanceResponse
+	var result struct {
+		Balances []tsBalanceResponse `json:"Balances"`
+	}
 
 	resp, reqErr := client.resty.R().
 		SetContext(ctx).
-		SetResult(&balances).
+		SetResult(&result).
 		Get(endpoint)
 	if reqErr != nil {
 		return tsBalanceResponse{}, fmt.Errorf("get balance: %w", reqErr)
@@ -183,11 +191,11 @@ func (client *apiClient) getBalance(ctx context.Context) (tsBalanceResponse, err
 		return tsBalanceResponse{}, broker.NewHTTPError(resp.StatusCode(), resp.String())
 	}
 
-	if len(balances) == 0 {
+	if len(result.Balances) == 0 {
 		return tsBalanceResponse{}, fmt.Errorf("get balance: no balance data returned")
 	}
 
-	return balances[0], nil
+	return result.Balances[0], nil
 }
 
 func (client *apiClient) getQuote(ctx context.Context, symbol string) (float64, error) {

--- a/broker/tradestation/client_test.go
+++ b/broker/tradestation/client_test.go
@@ -26,9 +26,11 @@ var _ = Describe("apiClient", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 				Expect(req.URL.Path).To(Equal("/v3/brokerage/accounts"))
 				writer.Header().Set("Content-Type", "application/json")
-				sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]string{
-					{"AccountID": "11111111", "AccountType": "Margin", "Status": "Active"},
-					{"AccountID": "22222222", "AccountType": "Cash", "Status": "Active"},
+				sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+					"Accounts": []map[string]string{
+						{"AccountID": "11111111", "AccountType": "Margin", "Status": "Active"},
+						{"AccountID": "22222222", "AccountType": "Cash", "Status": "Active"},
+					},
 				})
 			}))
 			DeferCleanup(server.Close)
@@ -43,9 +45,11 @@ var _ = Describe("apiClient", func() {
 		It("matches the specified account ID", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 				writer.Header().Set("Content-Type", "application/json")
-				sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]string{
-					{"AccountID": "11111111", "AccountType": "Margin", "Status": "Active"},
-					{"AccountID": "22222222", "AccountType": "Cash", "Status": "Active"},
+				sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+					"Accounts": []map[string]string{
+						{"AccountID": "11111111", "AccountType": "Margin", "Status": "Active"},
+						{"AccountID": "22222222", "AccountType": "Cash", "Status": "Active"},
+					},
 				})
 			}))
 			DeferCleanup(server.Close)
@@ -60,7 +64,9 @@ var _ = Describe("apiClient", func() {
 		It("returns ErrAccountNotFound when no accounts exist", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 				writer.Header().Set("Content-Type", "application/json")
-				sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]string{})
+				sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+					"Accounts": []map[string]string{},
+				})
 			}))
 			DeferCleanup(server.Close)
 
@@ -73,8 +79,10 @@ var _ = Describe("apiClient", func() {
 		It("returns ErrAccountNotFound when specified account is not found", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
 				writer.Header().Set("Content-Type", "application/json")
-				sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]string{
-					{"AccountID": "11111111", "AccountType": "Margin", "Status": "Active"},
+				sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+					"Accounts": []map[string]string{
+						{"AccountID": "11111111", "AccountType": "Margin", "Status": "Active"},
+					},
 				})
 			}))
 			DeferCleanup(server.Close)
@@ -212,14 +220,16 @@ var _ = Describe("apiClient", func() {
 				Expect(req.URL.Path).To(Equal("/v3/brokerage/accounts/ACCT-TEST/positions"))
 
 				writer.Header().Set("Content-Type", "application/json")
-				sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]any{
-					{
-						"Symbol":           "AAPL",
-						"Quantity":         "100",
-						"AveragePrice":     "150.00",
-						"MarketValue":      "15500.00",
-						"TodaysProfitLoss": "200.00",
-						"Last":             "155.00",
+				sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+					"Positions": []map[string]any{
+						{
+							"Symbol":           "AAPL",
+							"Quantity":         "100",
+							"AveragePrice":     "150.00",
+							"MarketValue":      "15500.00",
+							"TodaysProfitLoss": "200.00",
+							"Last":             "155.00",
+						},
 					},
 				})
 			}))
@@ -242,12 +252,14 @@ var _ = Describe("apiClient", func() {
 				Expect(req.URL.Path).To(Equal("/v3/brokerage/accounts/ACCT-TEST/balances"))
 
 				writer.Header().Set("Content-Type", "application/json")
-				sonic.ConfigDefault.NewEncoder(writer).Encode([]map[string]any{
-					{
-						"CashBalance": "25000.00",
-						"Equity":      "50000.00",
-						"BuyingPower": "45000.00",
-						"MarketValue": "25000.00",
+				sonic.ConfigDefault.NewEncoder(writer).Encode(map[string]any{
+					"Balances": []map[string]any{
+						{
+							"CashBalance": "25000.00",
+							"Equity":      "50000.00",
+							"BuyingPower": "45000.00",
+							"MarketValue": "25000.00",
+						},
 					},
 				})
 			}))

--- a/broker/tradestation/streamer.go
+++ b/broker/tradestation/streamer.go
@@ -122,12 +122,8 @@ func (streamer *orderStreamer) run(ctx context.Context, resp *http.Response) {
 			default:
 			}
 
-			if reconnectErr := streamer.reconnect(ctx); reconnectErr != nil {
-				return
-			}
-
-			// Re-open the stream and restart the decoder.
-			newResp, openErr := streamer.openStream(ctx)
+			// Re-open the stream (with retries) and restart the decoder.
+			newResp, openErr := streamer.reconnectStream(ctx)
 			if openErr != nil {
 				return
 			}
@@ -210,42 +206,6 @@ func (streamer *orderStreamer) handleEvent(event tsStreamOrderEvent) {
 			}
 		}
 	}
-}
-
-func (streamer *orderStreamer) reconnect(ctx context.Context) error {
-	backoff := 1 * time.Second
-
-	for attempt := range maxReconnectAttempts {
-		select {
-		case <-streamer.done:
-			return ErrStreamDisconnected
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		if attempt > 0 {
-			timer := time.NewTimer(backoff)
-			select {
-			case <-timer.C:
-			case <-streamer.done:
-				timer.Stop()
-				return ErrStreamDisconnected
-			case <-ctx.Done():
-				timer.Stop()
-				return ctx.Err()
-			}
-
-			backoff *= 2
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
-		}
-	}
-
-	streamer.pollMissedFills(ctx)
-
-	return nil
 }
 
 func (streamer *orderStreamer) reconnectStream(ctx context.Context) (*http.Response, error) {

--- a/broker/tradestation/types.go
+++ b/broker/tradestation/types.go
@@ -226,13 +226,14 @@ func mapSide(side broker.Side) string {
 	}
 }
 
-// mapTSSide maps TradeStation BuySellSideCode to broker.Side.
-// 1=Buy, 2=Sell, 3=SellShort, 4=BuyToCover.
+// mapTSSide maps the TradeStation Legs[].BuyOrSell value to broker.Side. The
+// v3 API returns Buy/Sell/SellShort/BuyToCover; legacy numeric codes
+// (1=Buy, 2=Sell, 3=SellShort, 4=BuyToCover) are also accepted.
 func mapTSSide(code string) broker.Side {
 	switch code {
-	case "1", "4":
+	case "Buy", "BuyToCover", "1", "4":
 		return broker.Buy
-	case "2", "3":
+	case "Sell", "SellShort", "2", "3":
 		return broker.Sell
 	default:
 		return broker.Buy

--- a/broker/tradier/streamer.go
+++ b/broker/tradier/streamer.go
@@ -33,7 +33,7 @@ type accountStreamer struct {
 	ctx          context.Context
 	lastPruneDay time.Time
 	sandbox      bool
-	lastOrders   map[int64]string // orderID -> last known status
+	cumFilled    map[int64]float64 // orderID -> cumulative executed qty delivered
 }
 
 type wsSubscription struct {
@@ -44,14 +44,14 @@ type wsSubscription struct {
 
 func newAccountStreamer(client *apiClient, fills chan broker.Fill, wsURL string, sessionID string, sandbox bool) *accountStreamer {
 	return &accountStreamer{
-		client:     client,
-		fills:      fills,
-		wsURL:      wsURL,
-		sessionID:  sessionID,
-		seenFills:  make(map[string]time.Time),
-		done:       make(chan struct{}),
-		sandbox:    sandbox,
-		lastOrders: make(map[int64]string),
+		client:    client,
+		fills:     fills,
+		wsURL:     wsURL,
+		sessionID: sessionID,
+		seenFills: make(map[string]time.Time),
+		cumFilled: make(map[int64]float64),
+		done:      make(chan struct{}),
+		sandbox:   sandbox,
 	}
 }
 
@@ -343,47 +343,32 @@ func (streamer *accountStreamer) pollOrders(ctx context.Context) {
 	}
 
 	for _, order := range orders {
-		prev, known := streamer.lastOrders[order.ID]
-		currentStatus := order.Status
-
-		streamer.mu.Lock()
-		streamer.lastOrders[order.ID] = currentStatus
-		streamer.mu.Unlock()
-
-		if known && prev == currentStatus {
+		// Emit the delta of the cumulative executed quantity rather than
+		// gating on status transitions: a partially_filled -> filled
+		// transition carries the completing quantity, and repeated partial
+		// executions can occur without any status change at all.
+		if order.ExecQuantity <= 0 {
 			continue
 		}
-
-		if currentStatus != "filled" && currentStatus != "partially_filled" {
-			continue
-		}
-
-		// Only emit if this is a new fill transition.
-		if known && (prev == "filled" || prev == "partially_filled") {
-			continue
-		}
-
-		orderID := fmt.Sprintf("%d", order.ID)
-		fillTime := parseFillTime(order.TransactionDate)
-		fillKey := fmt.Sprintf("%s-%.2f-%s", orderID, order.ExecQuantity, order.TransactionDate)
 
 		streamer.mu.Lock()
 
-		_, alreadySeen := streamer.seenFills[fillKey]
-		if !alreadySeen {
-			streamer.seenFills[fillKey] = time.Now()
+		delta := order.ExecQuantity - streamer.cumFilled[order.ID]
+		if delta > 0 {
+			streamer.cumFilled[order.ID] = order.ExecQuantity
 		}
+
 		streamer.mu.Unlock()
 
-		if alreadySeen {
+		if delta <= 0 {
 			continue
 		}
 
 		fill := broker.Fill{
-			OrderID:  orderID,
+			OrderID:  fmt.Sprintf("%d", order.ID),
 			Price:    order.LastFillPrice,
-			Qty:      order.LastFillQuantity,
-			FilledAt: fillTime,
+			Qty:      delta,
+			FilledAt: parseFillTime(order.TransactionDate),
 		}
 
 		select {

--- a/broker/webull/client.go
+++ b/broker/webull/client.go
@@ -180,7 +180,7 @@ func (client *apiClient) submitOrder(ctx context.Context, accountID string, orde
 		SetContext(ctx).
 		SetBody(order).
 		SetResult(&result).
-		SetPathParam("account_id", accountID).
+		SetQueryParam("account_id", accountID).
 		Post("/api/trade/order/place")
 	if err != nil {
 		return "", fmt.Errorf("submit order: %w", err)
@@ -194,7 +194,7 @@ func (client *apiClient) submitOrder(ctx context.Context, accountID string, orde
 				SetContext(ctx).
 				SetBody(order).
 				SetResult(&result).
-				SetPathParam("account_id", accountID).
+				SetQueryParam("account_id", accountID).
 				Post("/api/trade/order/place")
 			if err != nil {
 				return "", fmt.Errorf("submit order: %w", err)

--- a/cli/backtest.go
+++ b/cli/backtest.go
@@ -356,5 +356,11 @@ func runEngineBacktest(eng *engine.Engine, program *tea.Program, logWriter io.Wr
 		return nil, fmt.Errorf("progress UI: unexpected model type %T", finalModel)
 	}
 
+	if !final.done {
+		// The user quit the progress UI (q or ctrl+c) before the engine
+		// finished; there is no result to return.
+		return nil, fmt.Errorf("backtest interrupted before completion")
+	}
+
 	return final.result, final.err
 }

--- a/cli/library.go
+++ b/cli/library.go
@@ -803,27 +803,29 @@ func (model *libraryModel) markInstalled(installed []library.InstalledStrategy) 
 	}
 }
 
-// visibleItems returns the indices of items that match the current filter.
+// visibleItems returns the indices of items that match the current filter, in
+// the same category-grouped order that listView renders. The cursor indexes
+// this slice, so any divergence between the two orders would make key actions
+// target a different item than the one highlighted.
 func (model libraryModel) visibleItems() []int {
-	if model.filter == "" {
-		indices := make([]int, len(model.items))
-		for idx := range model.items {
-			indices[idx] = idx
+	lowerFilter := strings.ToLower(model.filter)
+
+	matches := func(item libraryItem) bool {
+		if model.filter == "" {
+			return true
 		}
 
-		return indices
+		return strings.Contains(strings.ToLower(item.listing.Name), lowerFilter) ||
+			strings.Contains(strings.ToLower(item.listing.Description), lowerFilter)
 	}
-
-	lowerFilter := strings.ToLower(model.filter)
 
 	var indices []int
 
-	for idx, item := range model.items {
-		nameMatch := strings.Contains(strings.ToLower(item.listing.Name), lowerFilter)
-		descMatch := strings.Contains(strings.ToLower(item.listing.Description), lowerFilter)
-
-		if nameMatch || descMatch {
-			indices = append(indices, idx)
+	for _, cat := range model.categories {
+		for idx, item := range model.items {
+			if item.category == cat && matches(item) {
+				indices = append(indices, idx)
+			}
 		}
 	}
 

--- a/cli/library_test.go
+++ b/cli/library_test.go
@@ -82,6 +82,7 @@ var _ = Describe("libraryModel", func() {
 	Describe("list view navigation", func() {
 		BeforeEach(func() {
 			model.state = libStateBrowsing
+			model.categories = []string{""}
 			model.items = []libraryItem{
 				{listing: library.Listing{Name: "strat1", Description: "first"}},
 				{listing: library.Listing{Name: "strat2", Description: "second"}},
@@ -191,6 +192,7 @@ var _ = Describe("libraryModel", func() {
 	Describe("search filtering", func() {
 		BeforeEach(func() {
 			model.state = libStateBrowsing
+			model.categories = []string{""}
 			model.items = []libraryItem{
 				{listing: library.Listing{Name: "momentum", Description: "A momentum strategy"}},
 				{listing: library.Listing{Name: "value-pick", Description: "A value strategy"}},
@@ -255,6 +257,7 @@ var _ = Describe("libraryModel", func() {
 			model.state = libStateBrowsing
 			model.width = 80
 			model.height = 24
+			model.categories = []string{""}
 			model.items = []libraryItem{
 				{listing: library.Listing{Name: "momentum", Owner: "alice", Description: "A momentum strategy"}},
 				{listing: library.Listing{Name: "value-pick", Owner: "bob", Description: "A value strategy"}},
@@ -362,6 +365,7 @@ var _ = Describe("libraryModel", func() {
 	Describe("uninstall flow", func() {
 		BeforeEach(func() {
 			model.state = libStateBrowsing
+			model.categories = []string{""}
 			model.items = []libraryItem{
 				{listing: library.Listing{Name: "momentum", Owner: "alice"}, installed: true},
 				{listing: library.Listing{Name: "value-pick", Owner: "bob"}, installed: false},

--- a/cli/study.go
+++ b/cli/study.go
@@ -225,16 +225,13 @@ func parseSimpleDuration(input string) (time.Duration, error) {
 		return 0, fmt.Errorf("empty duration string")
 	}
 
-	// Try standard Go duration parsing first (handles "72h", "30m", etc.).
-	if dur, err := time.ParseDuration(input); err == nil {
-		return dur, nil
-	}
-
 	unit := input[len(input)-1:]
 	numStr := input[:len(input)-1]
 
 	var multiplier time.Duration
 
+	// The y/m/d suffixes take priority: "6m" must mean 6 months, not 6 minutes,
+	// so time.ParseDuration is only a fallback for formats like "72h".
 	switch unit {
 	case "y":
 		multiplier = 365 * 24 * time.Hour
@@ -243,6 +240,10 @@ func parseSimpleDuration(input string) (time.Duration, error) {
 	case "d":
 		multiplier = 24 * time.Hour
 	default:
+		if dur, err := time.ParseDuration(input); err == nil {
+			return dur, nil
+		}
+
 		return 0, fmt.Errorf("unrecognised duration %q: use a number followed by y, m, or d (e.g. 5y, 6m, 30d)", input)
 	}
 

--- a/cli/summary/trades.go
+++ b/cli/summary/trades.go
@@ -175,9 +175,9 @@ func renderTrades(builder *strings.Builder, tr trades) {
 
 		actionStyled := valueStyle.Render(trade.action)
 		switch trade.action {
-		case "BUY":
+		case "Buy":
 			actionStyled = positiveStyle.Render(trade.action)
-		case "SELL":
+		case "Sell":
 			actionStyled = negativeStyle.Render(trade.action)
 		}
 

--- a/data/data_frame.go
+++ b/data/data_frame.go
@@ -1898,6 +1898,8 @@ func (df *DataFrame) Upsample(freq Frequency) *UpsampledDataFrame {
 
 func periodChanged(prev, curr time.Time, freq Frequency) bool {
 	switch freq {
+	case Daily:
+		return prev.Year() != curr.Year() || prev.YearDay() != curr.YearDay()
 	case Weekly:
 		_, pw := prev.ISOWeek()
 		_, cw := curr.ISOWeek()

--- a/data/data_frame_test.go
+++ b/data/data_frame_test.go
@@ -1073,6 +1073,24 @@ var _ = Describe("DataFrame", func() {
 			Expect(col[1]).To(Equal(29.0))
 		})
 
+		It("Last picks last intraday value per day", func() {
+			base := time.Date(2024, 1, 2, 9, 30, 0, 0, time.UTC)
+			t := make([]time.Time, 6)
+			col := make([]float64, 6)
+			for i := range t {
+				// Three bars per day across two days.
+				t[i] = base.AddDate(0, 0, i/3).Add(time.Duration(i%3) * time.Minute)
+				col[i] = float64(i + 1)
+			}
+			intradayDF, err := data.NewDataFrame(t, []asset.Asset{aapl}, []data.Metric{data.Price}, data.Tick, [][]float64{col})
+			Expect(err).NotTo(HaveOccurred())
+			result := intradayDF.Downsample(data.Daily).Last()
+			Expect(result.Len()).To(Equal(2))
+			resCol := result.Column(aapl, data.Price)
+			Expect(resCol[0]).To(Equal(3.0))
+			Expect(resCol[1]).To(Equal(6.0))
+		})
+
 		It("Std uses sample (N-1) denominator", func() {
 			// [1,2,3,4,5,6,7] in one week: mean=4, sum sq diffs=28, var=28/6, std=sqrt(28/6)
 			result := weeklyDF.Downsample(data.Weekly).Std()

--- a/data/index_state.go
+++ b/data/index_state.go
@@ -36,7 +36,8 @@ type indexChange struct {
 }
 
 // indexState holds the stacks and current membership for one index.
-// Dates passed to advance must be monotonically increasing.
+// Dates passed to advance must be monotonically increasing; Advance handles
+// backward dates by rewinding and replaying from the beginning.
 type indexState struct {
 	snapshots    []indexSnapshot    // sorted by date, earliest first (index 0 = earliest)
 	changelog    []indexChange      // sorted by date, earliest first
@@ -44,6 +45,7 @@ type indexState struct {
 	logIdx       int                // next unprocessed changelog entry
 	constituents []IndexConstituent // current constituents; mutated in place
 	assets       []asset.Asset      // parallel view for asset-only access
+	lastDate     time.Time          // date of the most recent Advance call
 }
 
 // advance pops snapshots and changelog entries up through forDate,
@@ -134,9 +136,27 @@ func NewIndexState(snapshots []IndexSnapshotEntry, changelog []IndexChangeEntry)
 	return &indexState{snapshots: ss, changelog: cc}
 }
 
+// reset rewinds the cursors so advance replays from the beginning. Used when
+// Advance receives a date earlier than the previous call (e.g. a new backtest
+// run reusing a shared provider).
+func (st *indexState) reset() {
+	st.snapIdx = 0
+	st.logIdx = 0
+	st.constituents = st.constituents[:0]
+	st.assets = st.assets[:0]
+}
+
 // Advance is the exported wrapper for advance. It returns both the asset-only
-// slice and the full constituent slice with weights.
+// slice and the full constituent slice with weights. When forDate is earlier
+// than the previous call's date, the state rewinds and replays from the
+// beginning so results stay correct for any call order.
 func (st *indexState) Advance(forDate time.Time) ([]asset.Asset, []IndexConstituent) {
+	if forDate.Before(st.lastDate) {
+		st.reset()
+	}
+
+	st.lastDate = forDate
 	st.advance(forDate)
+
 	return st.assets, st.constituents
 }

--- a/data/pvdata_index_members_test.go
+++ b/data/pvdata_index_members_test.go
@@ -165,6 +165,24 @@ var _ = Describe("IndexState", func() {
 		Expect(assets).To(ConsistOf(aapl))
 	})
 
+	It("rewinds and replays when Advance receives an earlier date", func() {
+		state := data.NewIndexState(
+			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{aaplIC}}},
+			[]data.IndexChangeEntry{
+				{Date: day2, Asset: goog, Action: "add", Weight: 0.3},
+				{Date: day3, Asset: msft, Action: "add", Weight: 0.2},
+			},
+		)
+		state.Advance(day3)
+
+		assets, constituents := state.Advance(day2)
+		Expect(assets).To(ConsistOf(aapl, goog))
+		Expect(constituents).To(HaveLen(2))
+
+		assets, _ = state.Advance(day3)
+		Expect(assets).To(ConsistOf(aapl, goog, msft))
+	})
+
 	It("preserves weight data through snapshots", func() {
 		state := data.NewIndexState(
 			[]data.IndexSnapshotEntry{{Date: day1, Members: []data.IndexConstituent{

--- a/data/pvdata_intraday.go
+++ b/data/pvdata_intraday.go
@@ -488,8 +488,6 @@ func (p *PVDataProvider) loadAdjustmentFactors(
 
 		for idx := len(events) - 1; idx >= 0; idx-- {
 			ev := events[idx]
-			priceCum[idx] = cumPrice
-			volumeCum[idx] = cumVolume
 
 			// Split factor S means an N-for-1 split: post-split shares
 			// are S times pre-split shares. So pre-split prices need
@@ -510,6 +508,12 @@ func (p *PVDataProvider) loadAdjustmentFactors(
 					cumPrice *= 1 - ev.divid/prevClose
 				}
 			}
+
+			// Store after applying this event's own adjustment: quotes
+			// strictly before event idx need idx's adjustment included,
+			// and lookupFactorAt selects this tier for exactly those quotes.
+			priceCum[idx] = cumPrice
+			volumeCum[idx] = cumVolume
 		}
 
 		priceMap := make(map[int64]float64, len(events))

--- a/data/pvdata_provider.go
+++ b/data/pvdata_provider.go
@@ -127,8 +127,12 @@ type pvdataConfig struct {
 // 1-minute bars are read directly from the pv-data ClickHouse instance
 // when configured.
 type PVDataProvider struct {
-	pool      *pgxpool.Pool
-	ownsPool  bool
+	pool     *pgxpool.Pool
+	ownsPool bool
+
+	// mu guards dimension and indexes. One provider instance may be shared
+	// across concurrently running backtests (e.g. study workers).
+	mu        sync.RWMutex
 	dimension string
 	indexes   map[string]*indexState
 
@@ -166,11 +170,17 @@ func WithConfigFile(path string) PVDataOption {
 // SetDimension updates the fundamental dimension filter at runtime.
 // Valid values: "ARQ", "ARY", "ART", "MRQ", "MRY", "MRT".
 func (p *PVDataProvider) SetDimension(dim string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	p.dimension = dim
 }
 
 // Dimension returns the current fundamental dimension filter.
 func (p *PVDataProvider) Dimension() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
 	return p.dimension
 }
 
@@ -903,7 +913,7 @@ func (p *PVDataProvider) fetchFundamentals(
 		strings.Join(cols, ", "),
 	)
 
-	rows, err := conn.Query(ctx, query, figis, start, end, p.dimension)
+	rows, err := conn.Query(ctx, query, figis, start, end, p.Dimension())
 	if err != nil {
 		return fmt.Errorf("pvdata: query fundamentals: %w", err)
 	}
@@ -968,12 +978,19 @@ func (p *PVDataProvider) RatedAssets(ctx context.Context, analyst string, filter
 	}
 	defer conn.Release()
 
+	// Pick each asset's most-recent rating on or before asOfDate, then keep
+	// only the assets whose current rating matches the filter.
 	rows, err := conn.Query(ctx,
 		`SELECT a.composite_figi, a.ticker, a.name, a.asset_type, a.primary_exchange,
 		        a.sector, a.industry, a.sic_code, a.cik, a.listed, a.delisted
-		 FROM ratings r
+		 FROM (
+		     SELECT DISTINCT ON (composite_figi) composite_figi, rating
+		     FROM ratings
+		     WHERE analyst = $1 AND event_date <= $2
+		     ORDER BY composite_figi, event_date DESC
+		 ) r
 		 JOIN assets a ON a.composite_figi = r.composite_figi
-		 WHERE r.analyst = $1 AND r.event_date = $2 AND r.rating = ANY($3)`,
+		 WHERE r.rating = ANY($3)`,
 		analyst, asOfDate, filter.Values,
 	)
 	if err != nil {
@@ -996,13 +1013,17 @@ func (p *PVDataProvider) RatedAssets(ctx context.Context, analyst string, filter
 }
 
 // IndexMembers returns the constituents of the named index at forDate. The
-// returned slice is borrowed -- it is only valid for the current engine step.
-// Callers that need data across steps must copy.
+// returned slices are copies owned by the caller.
 //
-// Dates must be monotonically increasing across calls for a given index.
 // The provider loads all snapshot and changelog data on the first call and
-// advances an internal cursor as time progresses.
+// advances an internal cursor as time progresses. Calls with an earlier date
+// than the previous call rewind the cursor and replay from the beginning, so
+// any call order is correct; monotonically increasing dates are merely the
+// fastest access pattern.
 func (p *PVDataProvider) IndexMembers(ctx context.Context, index string, forDate time.Time) ([]asset.Asset, []IndexConstituent, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.indexes == nil {
 		p.indexes = make(map[string]*indexState)
 	}
@@ -1021,7 +1042,15 @@ func (p *PVDataProvider) IndexMembers(ctx context.Context, index string, forDate
 
 	assets, constituents := state.Advance(forDate)
 
-	return assets, constituents, nil
+	// Copy before releasing the lock: the state mutates these slices in
+	// place on the next Advance, which may come from another goroutine.
+	assetsCopy := make([]asset.Asset, len(assets))
+	copy(assetsCopy, assets)
+
+	constituentsCopy := make([]IndexConstituent, len(constituents))
+	copy(constituentsCopy, constituents)
+
+	return assetsCopy, constituentsCopy, nil
 }
 
 func (p *PVDataProvider) loadIndexState(ctx context.Context, index string) (*indexState, error) {

--- a/data/snapshot_provider.go
+++ b/data/snapshot_provider.go
@@ -29,7 +29,8 @@ var (
 
 // SnapshotProvider replays data from a snapshot SQLite database.
 type SnapshotProvider struct {
-	db *sql.DB
+	db        *sql.DB
+	dimension string
 }
 
 // scanAssetRow scans 11 asset columns from any row/queryrow scanner.
@@ -98,12 +99,24 @@ func NewSnapshotProvider(path string) (*SnapshotProvider, error) {
 		return nil, fmt.Errorf("snapshot provider: set read-only: %w", err)
 	}
 
-	return &SnapshotProvider{db: db}, nil
+	return &SnapshotProvider{db: db, dimension: "ARQ"}, nil
 }
 
 // Close closes the database connection.
 func (p *SnapshotProvider) Close() error {
 	return p.db.Close()
+}
+
+// SetDimension updates the fundamental dimension filter used when replaying
+// fundamentals. The engine forwards the strategy's configured dimension here,
+// mirroring PVDataProvider.SetDimension.
+func (p *SnapshotProvider) SetDimension(dim string) {
+	p.dimension = dim
+}
+
+// Dimension returns the current fundamental dimension filter.
+func (p *SnapshotProvider) Dimension() string {
+	return p.dimension
 }
 
 // snapshotDateFormat is the canonical format for dates in snapshot databases.
@@ -553,12 +566,27 @@ func (p *SnapshotProvider) fetchFundamentals(
 	ensureCol func(string, Metric) map[int64]float64,
 	timeSet map[int64]time.Time,
 ) error {
+	// Build the list of SQL columns we need, skipping metadata metrics
+	// (date_key, report_period) which are always fetched by the fixed
+	// SELECT prefix. This mirrors PVDataProvider.fetchFundamentals.
 	var (
 		sqlCols     []string
 		metricOrder []Metric
 	)
 
+	wantDateKey := false
+	wantReportPeriod := false
+
 	for _, metric := range metrics {
+		switch metric {
+		case FundamentalsDateKey:
+			wantDateKey = true
+			continue
+		case FundamentalsReportPeriod:
+			wantReportPeriod = true
+			continue
+		}
+
 		col, ok := metricColumn[metric]
 		if !ok {
 			continue
@@ -568,13 +596,16 @@ func (p *SnapshotProvider) fetchFundamentals(
 		metricOrder = append(metricOrder, metric)
 	}
 
-	if len(sqlCols) == 0 {
+	if len(sqlCols) == 0 && !wantDateKey && !wantReportPeriod {
 		return nil
 	}
 
+	cols := []string{"composite_figi", "event_date", "date_key", "report_period"}
+	cols = append(cols, sqlCols...)
+
 	placeholders := make([]string, len(figis))
 
-	args := make([]any, len(figis)+2)
+	args := make([]any, len(figis)+3)
 	for idx, figi := range figis {
 		placeholders[idx] = "?"
 		args[idx] = figi
@@ -582,16 +613,14 @@ func (p *SnapshotProvider) fetchFundamentals(
 
 	args[len(figis)] = startStr
 	args[len(figis)+1] = endStr
-
-	// Add dimension filter -- the recorder stores "ARQ" as the default.
-	args = append(args, "ARQ")
+	args[len(figis)+2] = p.dimension
 
 	query := fmt.Sprintf(
-		`SELECT composite_figi, event_date, %s
+		`SELECT %s
 		 FROM fundamentals
 		 WHERE composite_figi IN (%s) AND substr(event_date, 1, 10) BETWEEN ? AND ? AND dimension = ?
 		 ORDER BY event_date`,
-		strings.Join(sqlCols, ", "),
+		strings.Join(cols, ", "),
 		strings.Join(placeholders, ","),
 	)
 
@@ -603,17 +632,21 @@ func (p *SnapshotProvider) fetchFundamentals(
 
 	for rows.Next() {
 		var (
-			figi    string
-			dateStr string
+			figi            string
+			dateStr         string
+			dateKeyStr      sql.NullString
+			reportPeriodStr sql.NullString
 		)
 
-		vals := make([]any, len(sqlCols)+2)
+		vals := make([]any, len(sqlCols)+4)
 		vals[0] = &figi
 		vals[1] = &dateStr
+		vals[2] = &dateKeyStr
+		vals[3] = &reportPeriodStr
 
 		floatVals := make([]sql.NullFloat64, len(sqlCols))
 		for idx := range sqlCols {
-			vals[idx+2] = &floatVals[idx]
+			vals[idx+4] = &floatVals[idx]
 		}
 
 		if err := rows.Scan(vals...); err != nil {
@@ -632,6 +665,24 @@ func (p *SnapshotProvider) fetchFundamentals(
 			if floatVals[idx].Valid {
 				ensureCol(figi, metric)[sec] = floatVals[idx].Float64
 			}
+		}
+
+		if wantDateKey && dateKeyStr.Valid {
+			parsed, parseErr := parseSnapshotDate(dateKeyStr.String)
+			if parseErr != nil {
+				return fmt.Errorf("snapshot provider: parse date_key %q: %w", dateKeyStr.String, parseErr)
+			}
+
+			ensureCol(figi, FundamentalsDateKey)[sec] = float64(parsed.Unix())
+		}
+
+		if wantReportPeriod && reportPeriodStr.Valid {
+			parsed, parseErr := parseSnapshotDate(reportPeriodStr.String)
+			if parseErr != nil {
+				return fmt.Errorf("snapshot provider: parse report_period %q: %w", reportPeriodStr.String, parseErr)
+			}
+
+			ensureCol(figi, FundamentalsReportPeriod)[sec] = float64(parsed.Unix())
 		}
 	}
 

--- a/data/snapshot_recorder.go
+++ b/data/snapshot_recorder.go
@@ -70,6 +70,27 @@ func (r *SnapshotRecorder) Close() error {
 	return r.db.Close()
 }
 
+// SetDimension forwards the fundamental dimension filter to the wrapped
+// batch provider so recorded fundamentals carry the strategy's configured
+// dimension instead of the default.
+func (r *SnapshotRecorder) SetDimension(dim string) {
+	if bp, ok := r.batchProvider.(interface{ SetDimension(string) }); ok {
+		bp.SetDimension(dim)
+	}
+}
+
+// Dimension reports the wrapped batch provider's fundamental dimension
+// filter, or "ARQ" when the provider does not expose one.
+func (r *SnapshotRecorder) Dimension() string {
+	if bp, ok := r.batchProvider.(interface{ Dimension() string }); ok {
+		if dim := bp.Dimension(); dim != "" {
+			return dim
+		}
+	}
+
+	return "ARQ"
+}
+
 // FetchMarketHolidays delegates to the underlying provider and records the
 // holidays in the snapshot database.
 func (r *SnapshotRecorder) FetchMarketHolidays(ctx context.Context) ([]tradecron.MarketHoliday, error) {

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/broker"
 	"github.com/penny-vault/pvbt/data"
 	"github.com/penny-vault/pvbt/portfolio"
 	"github.com/penny-vault/pvbt/tradecron"
@@ -159,13 +160,16 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 			return nil, fmt.Errorf("engine: child strategy %q did not set a schedule", child.name)
 		}
 
-		// Create child portfolio with simulated broker.
+		// Create child portfolio with simulated broker. The broker needs
+		// the child's own portfolio so housekeeping (dividends, delist
+		// sells, borrow fees) is generated from the child's holdings.
 		childBroker := NewSimulatedBroker()
 		child.broker = childBroker
 		child.account = portfolio.New(
 			portfolio.WithCash(100, start),
 			portfolio.WithBroker(childBroker),
 		)
+		childBroker.SetPortfolio(child.account)
 	}
 
 	// 5. Validate: error if schedule is nil.
@@ -407,7 +411,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 		}
 
 		// 13-14b. Housekeep parent account (dividends + fill draining).
-		if err := e.housekeepAccount(stepCtx, acct, date); err != nil {
+		if err := e.housekeepAccount(stepCtx, acct, e.broker, date); err != nil {
 			return nil, err
 		}
 
@@ -511,11 +515,16 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 
 		// Housekeep and update prices for all child portfolios at every step.
 		for _, child := range e.children {
+			// The child broker needs the current date and price provider
+			// even on non-firing days so dividends and delist sells are
+			// generated from the child's own holdings.
+			child.broker.SetPriceProvider(e, date)
+
 			if err := e.prefetchHousekeepingPrices(stepCtx, child.account, date, asset.Asset{}); err != nil {
 				return nil, fmt.Errorf("engine: child %q prefetch housekeeping on %v: %w", child.name, date, err)
 			}
 
-			if err := e.housekeepAccount(stepCtx, child.account, date); err != nil {
+			if err := e.housekeepAccount(stepCtx, child.account, child.broker, date); err != nil {
 				return nil, fmt.Errorf("engine: child %q housekeeping on %v: %w", child.name, date, err)
 			}
 
@@ -556,9 +565,12 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 }
 
 // housekeepAccount records dividends for held assets and drains broker fills
-// for the given account on date. Price prefetching, including the benchmark, is
-// handled separately by prefetchHousekeepingPrices.
-func (eng *Engine) housekeepAccount(ctx context.Context, acct portfolio.PortfolioManager, date time.Time) error {
+// for the given account on date. Transactions are fetched from brk, which
+// must be the broker attached to acct: syncing another account's broker
+// would credit this account with dividends sized by that account's holdings.
+// Price prefetching, including the benchmark, is handled separately by
+// prefetchHousekeepingPrices.
+func (eng *Engine) housekeepAccount(ctx context.Context, acct portfolio.PortfolioManager, brk broker.Broker, date time.Time) error {
 	// Drain fills from previous step (before syncing transactions).
 	if acct.HasBroker() {
 		if drainErr := acct.DrainFills(ctx); drainErr != nil {
@@ -567,7 +579,7 @@ func (eng *Engine) housekeepAccount(ctx context.Context, acct portfolio.Portfoli
 	}
 
 	// Sync broker-reported transactions (dividends, splits, borrow fees).
-	brokerTxns, txnErr := eng.broker.Transactions(ctx, date.Add(-24*time.Hour))
+	brokerTxns, txnErr := brk.Transactions(ctx, date.Add(-24*time.Hour))
 	if txnErr != nil {
 		return fmt.Errorf("engine: broker transactions on %v: %w", date, txnErr)
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -356,7 +356,7 @@ func (e *Engine) Fetch(ctx context.Context, assets []asset.Asset, lookback portf
 	}
 
 	rangeStart := periodToTime(e.currentDate, lookback)
-	rangeEnd := e.currentDate
+	rangeEnd := e.capDailyRangeEnd(e.currentDate)
 
 	tickers := make([]string, len(assets))
 
@@ -413,6 +413,8 @@ func (e *Engine) FetchAt(ctx context.Context, assets []asset.Asset, timestamp ti
 	if e.cache == nil {
 		e.cache = newDataCache(e.cacheMaxBytes)
 	}
+
+	timestamp = e.capDailyRangeEnd(timestamp)
 
 	result, err := e.fetchRange(ctx, assets, metrics, timestamp, timestamp)
 	if err != nil {
@@ -1022,6 +1024,28 @@ func (e *Engine) Prices(ctx context.Context, assets ...asset.Asset) (*data.DataF
 		data.MetricClose, data.MetricHigh, data.MetricLow,
 		data.Volume, data.Dividend, data.SplitFactor,
 	})
+}
+
+// capDailyRangeEnd caps the end of a daily data request during an
+// intra-day firing. The engine's currentDate is the day's close boundary,
+// but mid-session that close has not printed yet; serving it to the
+// strategy would be lookahead bias. Requests for the firing day are
+// shifted to the previous day (marks and fills stay anchored to the
+// firing moment via the intraday paths). Outside intra-day firings the
+// timestamp is returned unchanged.
+func (e *Engine) capDailyRangeEnd(ts time.Time) time.Time {
+	if !e.isIntradayFiring() {
+		return ts
+	}
+
+	local := ts.In(nyc)
+	cur := e.currentDate.In(nyc)
+
+	if local.Year() == cur.Year() && local.YearDay() == cur.YearDay() {
+		return ts.AddDate(0, 0, -1)
+	}
+
+	return ts
 }
 
 // isIntradayFiring reports whether the engine is currently inside a

--- a/engine/live.go
+++ b/engine/live.go
@@ -215,7 +215,11 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 			nextStrategy := e.schedule.Next(now)
 			nextDaily := dailySchedule.Next(now)
 
-			// Pick whichever fires sooner.
+			// Fire at whichever schedule comes sooner. An intraday strategy
+			// firing before the close runs at its scheduled time; the daily
+			// close firing still happens afterwards and records equity. When
+			// both schedules produce the same instant (e.g. a strategy
+			// scheduled at the close), a single firing serves both.
 			nextTime := nextDaily
 			isStrategy := false
 
@@ -224,15 +228,7 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 				isStrategy = true
 			}
 
-			// If both fall on the same calendar day, treat as a strategy day
-			// and use the later timestamp for equity recording.
-			if nextStrategy.Format("2006-01-02") == nextDaily.Format("2006-01-02") {
-				isStrategy = true
-
-				if nextDaily.After(nextStrategy) {
-					nextTime = nextDaily
-				}
-			}
+			isDaily := !nextDaily.After(nextTime)
 
 			wait := time.Until(nextTime)
 
@@ -328,66 +324,74 @@ func (e *Engine) RunLive(ctx context.Context) (<-chan portfolio.PortfolioManager
 				priceAssets = append(priceAssets, e.benchmark)
 			}
 
-			// Convert DGS3MO yield to cumulative risk-free value.
-			if e.riskFreeResolved {
-				rfDF, rfFetchErr := e.FetchAt(stepCtx, []asset.Asset{e.riskFreeAssetDGS}, e.currentDate, []data.Metric{data.MetricClose})
-				if rfFetchErr == nil {
-					yield := rfDF.Value(e.riskFreeAssetDGS, data.MetricClose)
-					if !math.IsNaN(yield) && yield > 0 {
-						e.riskFreeCumulative = portfolio.YieldToCumulative(yield, e.riskFreeCumulative)
-					} else if e.riskFreeCumulative == 0 {
-						e.riskFreeCumulative = 100.0
-					}
+			// Daily-close work: the risk-free series and equity marks are
+			// daily series keyed by date, so only the @close firing appends
+			// to them. Intraday strategy firings skip this section.
+			if isDaily {
+				// Convert DGS3MO yield to cumulative risk-free value.
+				if e.riskFreeResolved {
+					rfDF, rfFetchErr := e.FetchAt(stepCtx, []asset.Asset{e.riskFreeAssetDGS}, e.currentDate, []data.Metric{data.MetricClose})
+					if rfFetchErr == nil {
+						yield := rfDF.Value(e.riskFreeAssetDGS, data.MetricClose)
+						if !math.IsNaN(yield) && yield > 0 {
+							e.riskFreeCumulative = portfolio.YieldToCumulative(yield, e.riskFreeCumulative)
+						} else if e.riskFreeCumulative == 0 {
+							e.riskFreeCumulative = 100.0
+						}
 
-					// Append the raw yield for RiskAdjustedPct.
-					e.riskFreeTimes = append(e.riskFreeTimes, e.currentDate)
-					e.riskFreeValues = append(e.riskFreeValues, yield)
+						// Append the raw yield for RiskAdjustedPct. A NaN
+						// yield (data gap) must not enter the series.
+						if !math.IsNaN(yield) {
+							e.riskFreeTimes = append(e.riskFreeTimes, e.currentDate)
+							e.riskFreeValues = append(e.riskFreeValues, yield)
 
-					rfKey := time.Date(e.currentDate.Year(), e.currentDate.Month(), e.currentDate.Day(), 0, 0, 0, 0, time.UTC)
-					if e.riskFreeIndex == nil {
-						e.riskFreeIndex = make(map[time.Time]int)
-					}
+							rfKey := time.Date(e.currentDate.Year(), e.currentDate.Month(), e.currentDate.Day(), 0, 0, 0, 0, time.UTC)
+							if e.riskFreeIndex == nil {
+								e.riskFreeIndex = make(map[time.Time]int)
+							}
 
-					e.riskFreeIndex[rfKey] = len(e.riskFreeValues) - 1
-				}
-			}
-
-			acct.SetRiskFreeValue(e.riskFreeCumulative)
-
-			if len(priceAssets) > 0 {
-				var (
-					priceDF  *data.DataFrame
-					fetchErr error
-				)
-
-				for attempt := range 18 {
-					priceDF, fetchErr = e.FetchAt(stepCtx, priceAssets, e.currentDate, priceMetrics)
-					if fetchErr == nil {
-						break
-					}
-
-					zerolog.Ctx(stepCtx).Warn().
-						Err(fetchErr).
-						Int("attempt", attempt+1).
-						Msg("price fetch failed, retrying in 1 hour")
-
-					select {
-					case <-time.After(time.Hour):
-					case <-ctx.Done():
-						return
+							e.riskFreeIndex[rfKey] = len(e.riskFreeValues) - 1
+						}
 					}
 				}
 
-				if fetchErr != nil {
-					zerolog.Ctx(stepCtx).Error().Err(fetchErr).Msg("price fetch failed after retries")
+				acct.SetRiskFreeValue(e.riskFreeCumulative)
+
+				if len(priceAssets) > 0 {
+					var (
+						priceDF  *data.DataFrame
+						fetchErr error
+					)
+
+					for attempt := range 18 {
+						priceDF, fetchErr = e.FetchAt(stepCtx, priceAssets, e.currentDate, priceMetrics)
+						if fetchErr == nil {
+							break
+						}
+
+						zerolog.Ctx(stepCtx).Warn().
+							Err(fetchErr).
+							Int("attempt", attempt+1).
+							Msg("price fetch failed, retrying in 1 hour")
+
+						select {
+						case <-time.After(time.Hour):
+						case <-ctx.Done():
+							return
+						}
+					}
+
+					if fetchErr != nil {
+						zerolog.Ctx(stepCtx).Error().Err(fetchErr).Msg("price fetch failed after retries")
+					} else {
+						acct.UpdatePrices(priceDF)
+					}
 				} else {
-					acct.UpdatePrices(priceDF)
-				}
-			} else {
-				// No assets to price -- record cash-only portfolio value.
-				cashDF, cashErr := data.NewDataFrame([]time.Time{e.currentDate}, nil, nil, data.Daily, nil)
-				if cashErr == nil {
-					acct.UpdatePrices(cashDF)
+					// No assets to price -- record cash-only portfolio value.
+					cashDF, cashErr := data.NewDataFrame([]time.Time{e.currentDate}, nil, nil, data.Daily, nil)
+					if cashErr == nil {
+						acct.UpdatePrices(cashDF)
+					}
 				}
 			}
 

--- a/engine/middleware/risk/drawdown_circuit_breaker.go
+++ b/engine/middleware/risk/drawdown_circuit_breaker.go
@@ -36,15 +36,24 @@ func DrawdownCircuitBreaker(threshold float64) portfolio.Middleware {
 }
 
 func (m *drawdownCircuitBreaker) Process(_ context.Context, batch *portfolio.Batch) error {
-	// Get current drawdown from the portfolio's performance metrics.
-	dd, err := batch.Portfolio().PerformanceMetric(portfolio.MaxDrawdown).Value()
-	if err != nil {
+	// Get the current drawdown from the running peak: the last value of the
+	// drawdown series. Using the since-inception MaxDrawdown scalar instead
+	// would latch the breaker permanently after a single historical breach,
+	// even once the portfolio has recovered to a new peak.
+	ddSeries, err := batch.Portfolio().PerformanceMetric(portfolio.MaxDrawdown).Series()
+	if err != nil || ddSeries == nil || ddSeries.Len() == 0 {
 		// No performance data yet (early in backtest) -- no action.
 		return nil
 	}
 
-	// MaxDrawdown is typically negative (e.g., -0.15 for 15% drawdown).
-	if math.Abs(dd) < m.threshold {
+	ddCol := ddSeries.Column(ddSeries.AssetList()[0], ddSeries.MetricList()[0])
+	if len(ddCol) == 0 {
+		return nil
+	}
+
+	// Drawdown values are negative (e.g., -0.15 for 15% below peak).
+	dd := ddCol[len(ddCol)-1]
+	if math.IsNaN(dd) || math.Abs(dd) < m.threshold {
 		return nil
 	}
 
@@ -63,16 +72,10 @@ func (m *drawdownCircuitBreaker) Process(_ context.Context, batch *portfolio.Bat
 		}
 	}
 
-	// Keep only sell orders from the batch (remove any buy orders).
-	filtered := batch.Orders[:0]
-
-	for _, order := range batch.Orders {
-		if order.Side == broker.Sell {
-			filtered = append(filtered, order)
-		}
-	}
-
-	batch.Orders = append(filtered, sells...)
+	// Replace the strategy's orders with the liquidation sells. Keeping the
+	// strategy's own sell orders alongside the full-position sells would
+	// oversell held positions into unintended shorts.
+	batch.Orders = sells
 
 	batch.Annotate("risk:drawdown-circuit-breaker",
 		fmt.Sprintf("drawdown %.1f%% exceeds %.1f%% threshold, force-liquidating all positions",

--- a/engine/middleware/risk/max_position_count.go
+++ b/engine/middleware/risk/max_position_count.go
@@ -18,6 +18,7 @@ package risk
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/penny-vault/pvbt/asset"
@@ -58,12 +59,13 @@ func (m *maxPositionCount) Process(_ context.Context, batch *portfolio.Batch) er
 	for ast, weight := range weights {
 		positions = append(positions, positionEntry{
 			asset: ast,
-			value: weight * totalValue,
+			value: math.Abs(weight * totalValue),
 			qty:   holdings[ast],
 		})
 	}
 
-	// Sort ascending by dollar value so the smallest positions are first.
+	// Sort ascending by absolute dollar value so the smallest positions
+	// (long or short) are first.
 	sort.Slice(positions, func(i, j int) bool {
 		return positions[i].value < positions[j].value
 	})
@@ -73,10 +75,20 @@ func (m *maxPositionCount) Process(_ context.Context, batch *portfolio.Batch) er
 	for idx := 0; idx < dropCount; idx++ {
 		pos := positions[idx]
 
+		// Longs are closed with a sell; shorts are closed with a buy for
+		// the absolute quantity.
+		side := broker.Sell
+		qty := pos.qty
+
+		if qty < 0 {
+			side = broker.Buy
+			qty = -qty
+		}
+
 		batch.Orders = append(batch.Orders, broker.Order{
 			Asset:       pos.asset,
-			Side:        broker.Sell,
-			Qty:         pos.qty,
+			Side:        side,
+			Qty:         qty,
 			OrderType:   broker.Market,
 			TimeInForce: broker.Day,
 		})

--- a/engine/middleware/risk/volatility_scaler.go
+++ b/engine/middleware/risk/volatility_scaler.go
@@ -54,8 +54,11 @@ func (vs *volatilityScaler) Process(ctx context.Context, batch *portfolio.Batch)
 		assets = append(assets, ast)
 	}
 
-	// Fetch close prices for the lookback period.
-	lookbackPeriod := data.Days(vs.lookback)
+	// Fetch close prices for the lookback period. The lookback is in trading
+	// days but data.Days is calendar days, so widen the span (~7/5 for
+	// weekends, plus a small holiday buffer); computeAnnualizedVol trims to
+	// the last lookback rows so the extra span does not change the result.
+	lookbackPeriod := data.Days(vs.lookback*7/5 + 5)
 
 	priceFrame, err := vs.dataSource.Fetch(ctx, assets, lookbackPeriod, []data.Metric{data.MetricClose})
 	if err != nil {
@@ -75,7 +78,7 @@ func (vs *volatilityScaler) Process(ctx context.Context, batch *portfolio.Batch)
 	)
 
 	for ast, weight := range projectedWeights {
-		vol := computeAnnualizedVol(priceFrame, ast)
+		vol := computeAnnualizedVol(priceFrame, ast, vs.lookback)
 		if math.IsNaN(vol) || vol <= 0 {
 			withoutVolWeight += math.Abs(weight)
 			continue
@@ -146,14 +149,20 @@ func (vs *volatilityScaler) Process(ctx context.Context, batch *portfolio.Batch)
 }
 
 // computeAnnualizedVol computes annualized realized volatility from daily
-// close prices: stddev(daily log returns) * sqrt(252).
+// close prices: stddev(daily log returns) * sqrt(252). The price series is
+// trimmed to the last lookback+1 rows so vol covers exactly lookback trading
+// days even though the fetch window is wider (calendar days).
 // Returns NaN if insufficient data (need at least 2 prices).
-func computeAnnualizedVol(priceFrame *data.DataFrame, ast asset.Asset) float64 {
+func computeAnnualizedVol(priceFrame *data.DataFrame, ast asset.Asset, lookback int) float64 {
 	if priceFrame == nil {
 		return math.NaN()
 	}
 
 	prices := priceFrame.Column(ast, data.MetricClose)
+	if len(prices) > lookback+1 {
+		prices = prices[len(prices)-(lookback+1):]
+	}
+
 	if len(prices) < 2 {
 		return math.NaN()
 	}

--- a/engine/simulated_broker.go
+++ b/engine/simulated_broker.go
@@ -114,16 +114,45 @@ func (b *SimulatedBroker) Fills() <-chan broker.Fill {
 	return b.fills
 }
 
+// deliverFill places a fill on the fills channel without ever blocking.
+// In simulation, fills are produced (Submit/EvaluatePending) and consumed
+// (Account drain) on the same goroutine, so a batch with more orders than
+// the channel's capacity would deadlock on a blocking send. When the
+// channel is full it is replaced with one twice the size, preserving fill
+// order; consumers re-fetch the channel via Fills() on every drain.
+func (b *SimulatedBroker) deliverFill(fill broker.Fill) {
+	select {
+	case b.fills <- fill:
+		return
+	default:
+	}
+
+	grown := make(chan broker.Fill, 2*cap(b.fills)+1)
+
+	for {
+		select {
+		case queued := <-b.fills:
+			grown <- queued
+		default:
+			grown <- fill
+
+			b.fills = grown
+
+			return
+		}
+	}
+}
+
 // failOrder resolves an order as failed: it emits a fill carrying the reason
 // (Qty 0, no price) on the fills channel so the account records the failure
 // and the originating strategy can react to it, instead of the order silently
 // vanishing or the simulation aborting.
 func (b *SimulatedBroker) failOrder(order broker.Order, reason error) {
-	b.fills <- broker.Fill{
+	b.deliverFill(broker.Fill{
 		OrderID:  order.ID,
 		FilledAt: b.date,
 		Err:      reason,
-	}
+	})
 }
 
 func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error {
@@ -192,7 +221,8 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 		zerolog.Ctx(ctx).Warn().
 			Err(adjErr).
 			Str("asset", order.Asset.Ticker).
-			Msg("order skipped: fill adjuster error")
+			Msg("order failed: fill adjuster error")
+		b.failOrder(order, fmt.Errorf("fill adjuster error for %s: %w", order.Asset.Ticker, adjErr))
 
 		return nil
 	}
@@ -265,12 +295,12 @@ func (b *SimulatedBroker) Submit(ctx context.Context, order broker.Order) error 
 		}
 	}
 
-	b.fills <- broker.Fill{
+	b.deliverFill(broker.Fill{
 		OrderID:  order.ID,
 		Price:    result.Price,
 		Qty:      result.Quantity,
 		FilledAt: b.date,
-	}
+	})
 
 	// Handle partial fills: queue remainder for next bar.
 	if result.Partial {
@@ -470,12 +500,12 @@ func (b *SimulatedBroker) EvaluatePending() {
 		switch {
 		case stopTriggered:
 			// Stop loss wins (pessimistic) — even if TP also triggered.
-			b.fills <- broker.Fill{
+			b.deliverFill(broker.Fill{
 				OrderID:  stopOrder.ID,
 				Price:    stopFillPrice,
 				Qty:      stopOrder.Qty,
 				FilledAt: b.date,
-			}
+			})
 
 			delete(b.pending, stopOrder.ID)
 
@@ -486,12 +516,12 @@ func (b *SimulatedBroker) EvaluatePending() {
 			delete(b.groups, groupID)
 
 		case tpTriggered:
-			b.fills <- broker.Fill{
+			b.deliverFill(broker.Fill{
 				OrderID:  tpOrder.ID,
 				Price:    tpFillPrice,
 				Qty:      tpOrder.Qty,
 				FilledAt: b.date,
-			}
+			})
 
 			delete(b.pending, tpOrder.ID)
 
@@ -551,12 +581,12 @@ func (b *SimulatedBroker) evaluatePartialRemainders() {
 		}
 
 		if result.Quantity > 0 {
-			b.fills <- broker.Fill{
+			b.deliverFill(broker.Fill{
 				OrderID:  orderID,
 				Price:    result.Price,
 				Qty:      result.Quantity,
 				FilledAt: b.date,
-			}
+			})
 		}
 
 		if !result.Partial {

--- a/engine/warmup_test.go
+++ b/engine/warmup_test.go
@@ -89,8 +89,13 @@ var _ = Describe("walkBackTradingDays", func() {
 	})
 
 	It("walks back 5 trading days skipping weekends", func() {
-		// Monday 2024-02-12
-		from := time.Date(2024, 2, 12, 16, 0, 0, 0, time.UTC)
+		nyc, err := time.LoadLocation("America/New_York")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Monday 2024-02-12 at the close, market time. Times are evaluated
+		// in market time, so 16:00 UTC would be 11:00 ET -- before the
+		// close -- and Monday itself would not count.
+		from := time.Date(2024, 2, 12, 16, 0, 0, 0, nyc)
 		result, err := engine.WalkBackTradingDaysForTest(from, 5)
 		Expect(err).NotTo(HaveOccurred())
 		// 5 trading days back from Feb 12 (Mon): Feb 5 (Mon)

--- a/portfolio/absolute_window_test.go
+++ b/portfolio/absolute_window_test.go
@@ -59,6 +59,20 @@ var _ = Describe("AbsoluteWindow", func() {
 			Expect(windowedCAGR).NotTo(BeNumerically("~", fullCAGR, 1e-9))
 		})
 
+		It("measures drawdowns from peaks inside the window only", func() {
+			// Full history: peak of 115 on 01-05 makes 108 on 01-08 a -6.09%
+			// drawdown. The window [01-08, 01-10] covers a strictly rising
+			// segment (108, 120, 125), so no drawdown occurs within it.
+			start := time.Date(2024, 1, 8, 0, 0, 0, 0, time.UTC)
+			end := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
+
+			windowedDD, err := acct.PerformanceMetric(portfolio.MaxDrawdown).
+				AbsoluteWindow(start, end).
+				Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(windowedDD).To(BeNumerically("==", 0))
+		})
+
 		It("returns ErrInsufficientData when the window contains only one data point", func() {
 			// A single day produces one data point: insufficient for CAGR.
 			start := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)

--- a/portfolio/account.go
+++ b/portfolio/account.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"time"
 
 	"github.com/penny-vault/pvbt/asset"
@@ -235,7 +236,7 @@ func (a *Account) RebalanceTo(ctx context.Context, allocs ...Allocation) error {
 				OrderType:   broker.Market,
 				TimeInForce: broker.Day,
 			}
-			if err := a.submitAndRecord(ctx, sellOrder.asset, Sell, order, alloc.Justification); err != nil {
+			if err := a.submitAndRecord(ctx, sellOrder.asset, order, alloc.Justification); err != nil {
 				return fmt.Errorf("RebalanceTo: sell %s: %w", sellOrder.asset.Ticker, err)
 			}
 		}
@@ -249,7 +250,7 @@ func (a *Account) RebalanceTo(ctx context.Context, allocs ...Allocation) error {
 				OrderType:   broker.Market,
 				TimeInForce: broker.Day,
 			}
-			if err := a.submitAndRecord(ctx, coverOrder.asset, Buy, order, alloc.Justification); err != nil {
+			if err := a.submitAndRecord(ctx, coverOrder.asset, order, alloc.Justification); err != nil {
 				return fmt.Errorf("RebalanceTo: cover %s: %w", coverOrder.asset.Ticker, err)
 			}
 		}
@@ -278,7 +279,7 @@ func (a *Account) RebalanceTo(ctx context.Context, allocs ...Allocation) error {
 				OrderType:   broker.Market,
 				TimeInForce: broker.Day,
 			}
-			if err := a.submitAndRecord(ctx, buyOrder.asset, Buy, order, alloc.Justification); err != nil {
+			if err := a.submitAndRecord(ctx, buyOrder.asset, order, alloc.Justification); err != nil {
 				return fmt.Errorf("RebalanceTo: buy %s: %w", buyOrder.asset.Ticker, err)
 			}
 		}
@@ -351,53 +352,34 @@ func (a *Account) Order(ctx context.Context, ast asset.Asset, side Side, qty flo
 		order.OrderType = broker.Stop
 	}
 
-	return a.submitAndRecord(ctx, ast, side, order, justification)
+	return a.submitAndRecord(ctx, ast, order, justification)
 }
 
-// submitAndRecord sends an order to the broker and records each fill
-// as a transaction. Used by both Order and RebalanceTo.
+// submitAndRecord sends an order to the broker and records resulting fills
+// as transactions. Used by both Order and RebalanceTo.
 //
-// After Submit returns, any fills already in the broker's channel are
-// drained immediately (non-blocking). This is a temporary bridge until
-// Task 4 introduces the full DrainFills/ExecuteBatch infrastructure.
-func (a *Account) submitAndRecord(ctx context.Context, ast asset.Asset, side Side, order broker.Order, justification string) error {
+// The order is registered in pendingOrders and fills are drained through the
+// shared fill machinery: each fill is matched to its order by ID, failed
+// fills surface without recording a transaction, and fills belonging to
+// other still-pending orders (e.g. an earlier GTC order) are recorded
+// against those orders rather than misattributed to this one.
+func (a *Account) submitAndRecord(ctx context.Context, ast asset.Asset, order broker.Order, justification string) error {
+	if order.ID == "" {
+		order.ID = fmt.Sprintf("order-%s-%d", ast.CompositeFigi, len(a.transactions))
+	}
+
+	order.Justification = justification
+	a.pendingOrders[order.ID] = order
+
 	if err := a.broker.Submit(ctx, order); err != nil {
+		delete(a.pendingOrders, order.ID)
+
 		return fmt.Errorf("order %s (qty=%.2f, amount=%.2f): %w", ast.Ticker, order.Qty, order.Amount, err)
 	}
 
-	fillCh := a.broker.Fills()
+	a.drainFillsFromChannel()
 
-	for {
-		select {
-		case fill := <-fillCh:
-			var (
-				txType asset.TransactionType
-				amount float64
-			)
-
-			switch side {
-			case Buy:
-				txType = asset.BuyTransaction
-				amount = -(fill.Price * fill.Qty)
-			case Sell:
-				txType = asset.SellTransaction
-				amount = fill.Price * fill.Qty
-			}
-
-			a.Record(Transaction{
-				Date:          fill.FilledAt,
-				Asset:         ast,
-				Type:          txType,
-				Qty:           fill.Qty,
-				Price:         fill.Price,
-				Amount:        amount,
-				Justification: justification,
-				LotSelection:  LotSelection(order.LotSelection),
-			})
-		default:
-			return nil
-		}
-	}
+	return nil
 }
 
 // Cash returns the current cash balance.
@@ -541,74 +523,96 @@ func (a *Account) Summary() (Summary, error) {
 	return summary, errors.Join(errs...)
 }
 
+// metricQuerier is the minimal surface the shared metric aggregators need:
+// both *Account (full history) and *viewedPortfolio (windowed) provide it.
+type metricQuerier interface {
+	PerformanceMetric(pm PerformanceMetric) PerformanceMetricQuery
+}
+
 func (a *Account) RiskMetrics() (RiskMetrics, error) {
+	return riskMetricsFrom(a)
+}
+
+func (a *Account) TaxMetrics() (TaxMetrics, error) {
+	return taxMetricsFrom(a)
+}
+
+func (a *Account) TradeMetrics() (TradeMetrics, error) {
+	return tradeMetricsFrom(a)
+}
+
+func (a *Account) WithdrawalMetrics() (WithdrawalMetrics, error) {
+	return withdrawalMetricsFrom(a)
+}
+
+func riskMetricsFrom(src metricQuerier) (RiskMetrics, error) {
 	var errs []error
 
 	risk := RiskMetrics{}
 
 	var err error
 
-	risk.Beta, err = a.PerformanceMetric(Beta).Value()
+	risk.Beta, err = src.PerformanceMetric(Beta).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.Alpha, err = a.PerformanceMetric(Alpha).Value()
+	risk.Alpha, err = src.PerformanceMetric(Alpha).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.TrackingError, err = a.PerformanceMetric(TrackingError).Value()
+	risk.TrackingError, err = src.PerformanceMetric(TrackingError).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.DownsideDeviation, err = a.PerformanceMetric(DownsideDeviation).Value()
+	risk.DownsideDeviation, err = src.PerformanceMetric(DownsideDeviation).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.InformationRatio, err = a.PerformanceMetric(InformationRatio).Value()
+	risk.InformationRatio, err = src.PerformanceMetric(InformationRatio).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.Treynor, err = a.PerformanceMetric(Treynor).Value()
+	risk.Treynor, err = src.PerformanceMetric(Treynor).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.UlcerIndex, err = a.PerformanceMetric(UlcerIndex).Value()
+	risk.UlcerIndex, err = src.PerformanceMetric(UlcerIndex).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.ExcessKurtosis, err = a.PerformanceMetric(ExcessKurtosis).Value()
+	risk.ExcessKurtosis, err = src.PerformanceMetric(ExcessKurtosis).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.Skewness, err = a.PerformanceMetric(Skewness).Value()
+	risk.Skewness, err = src.PerformanceMetric(Skewness).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.RSquared, err = a.PerformanceMetric(RSquared).Value()
+	risk.RSquared, err = src.PerformanceMetric(RSquared).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.ValueAtRisk, err = a.PerformanceMetric(ValueAtRisk).Value()
+	risk.ValueAtRisk, err = src.PerformanceMetric(ValueAtRisk).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.UpsideCaptureRatio, err = a.PerformanceMetric(UpsideCaptureRatio).Value()
+	risk.UpsideCaptureRatio, err = src.PerformanceMetric(UpsideCaptureRatio).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	risk.DownsideCaptureRatio, err = a.PerformanceMetric(DownsideCaptureRatio).Value()
+	risk.DownsideCaptureRatio, err = src.PerformanceMetric(DownsideCaptureRatio).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -616,49 +620,49 @@ func (a *Account) RiskMetrics() (RiskMetrics, error) {
 	return risk, errors.Join(errs...)
 }
 
-func (a *Account) TaxMetrics() (TaxMetrics, error) {
+func taxMetricsFrom(src metricQuerier) (TaxMetrics, error) {
 	var errs []error
 
 	taxMetrics := TaxMetrics{}
 
 	var err error
 
-	taxMetrics.LTCG, err = a.PerformanceMetric(LTCGMetric).Value()
+	taxMetrics.LTCG, err = src.PerformanceMetric(LTCGMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.STCG, err = a.PerformanceMetric(STCGMetric).Value()
+	taxMetrics.STCG, err = src.PerformanceMetric(STCGMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.UnrealizedLTCG, err = a.PerformanceMetric(UnrealizedLTCGMetric).Value()
+	taxMetrics.UnrealizedLTCG, err = src.PerformanceMetric(UnrealizedLTCGMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.UnrealizedSTCG, err = a.PerformanceMetric(UnrealizedSTCGMetric).Value()
+	taxMetrics.UnrealizedSTCG, err = src.PerformanceMetric(UnrealizedSTCGMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.QualifiedDividends, err = a.PerformanceMetric(QualifiedDividendsMetric).Value()
+	taxMetrics.QualifiedDividends, err = src.PerformanceMetric(QualifiedDividendsMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.NonQualifiedIncome, err = a.PerformanceMetric(NonQualifiedIncomeMetric).Value()
+	taxMetrics.NonQualifiedIncome, err = src.PerformanceMetric(NonQualifiedIncomeMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.TaxCostRatio, err = a.PerformanceMetric(TaxCostRatioMetric).Value()
+	taxMetrics.TaxCostRatio, err = src.PerformanceMetric(TaxCostRatioMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	taxMetrics.TaxDrag, err = a.PerformanceMetric(TaxDragMetric).Value()
+	taxMetrics.TaxDrag, err = src.PerformanceMetric(TaxDragMetric).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -666,99 +670,99 @@ func (a *Account) TaxMetrics() (TaxMetrics, error) {
 	return taxMetrics, errors.Join(errs...)
 }
 
-func (a *Account) TradeMetrics() (TradeMetrics, error) {
+func tradeMetricsFrom(src metricQuerier) (TradeMetrics, error) {
 	var errs []error
 
 	tradeMetrics := TradeMetrics{}
 
 	var err error
 
-	tradeMetrics.WinRate, err = a.PerformanceMetric(WinRate).Value()
+	tradeMetrics.WinRate, err = src.PerformanceMetric(WinRate).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.AverageWin, err = a.PerformanceMetric(AverageWin).Value()
+	tradeMetrics.AverageWin, err = src.PerformanceMetric(AverageWin).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.AverageLoss, err = a.PerformanceMetric(AverageLoss).Value()
+	tradeMetrics.AverageLoss, err = src.PerformanceMetric(AverageLoss).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.ProfitFactor, err = a.PerformanceMetric(ProfitFactor).Value()
+	tradeMetrics.ProfitFactor, err = src.PerformanceMetric(ProfitFactor).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.AverageHoldingPeriod, err = a.PerformanceMetric(AverageHoldingPeriod).Value()
+	tradeMetrics.AverageHoldingPeriod, err = src.PerformanceMetric(AverageHoldingPeriod).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.Turnover, err = a.PerformanceMetric(Turnover).Value()
+	tradeMetrics.Turnover, err = src.PerformanceMetric(Turnover).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.NPositivePeriods, err = a.PerformanceMetric(NPositivePeriods).Value()
+	tradeMetrics.NPositivePeriods, err = src.PerformanceMetric(NPositivePeriods).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.GainLossRatio, err = a.PerformanceMetric(TradeGainLossRatio).Value()
+	tradeMetrics.GainLossRatio, err = src.PerformanceMetric(TradeGainLossRatio).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.AverageMFE, err = a.PerformanceMetric(AverageMFE).Value()
+	tradeMetrics.AverageMFE, err = src.PerformanceMetric(AverageMFE).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.AverageMAE, err = a.PerformanceMetric(AverageMAE).Value()
+	tradeMetrics.AverageMAE, err = src.PerformanceMetric(AverageMAE).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.MedianMFE, err = a.PerformanceMetric(MedianMFE).Value()
+	tradeMetrics.MedianMFE, err = src.PerformanceMetric(MedianMFE).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.MedianMAE, err = a.PerformanceMetric(MedianMAE).Value()
+	tradeMetrics.MedianMAE, err = src.PerformanceMetric(MedianMAE).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.EdgeRatio, err = a.PerformanceMetric(EdgeRatio).Value()
+	tradeMetrics.EdgeRatio, err = src.PerformanceMetric(EdgeRatio).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.TradeCaptureRatio, err = a.PerformanceMetric(TradeCaptureRatio).Value()
+	tradeMetrics.TradeCaptureRatio, err = src.PerformanceMetric(TradeCaptureRatio).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.LongWinRate, err = a.PerformanceMetric(LongWinRate).Value()
+	tradeMetrics.LongWinRate, err = src.PerformanceMetric(LongWinRate).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.ShortWinRate, err = a.PerformanceMetric(ShortWinRate).Value()
+	tradeMetrics.ShortWinRate, err = src.PerformanceMetric(ShortWinRate).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.LongProfitFactor, err = a.PerformanceMetric(LongProfitFactor).Value()
+	tradeMetrics.LongProfitFactor, err = src.PerformanceMetric(LongProfitFactor).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	tradeMetrics.ShortProfitFactor, err = a.PerformanceMetric(ShortProfitFactor).Value()
+	tradeMetrics.ShortProfitFactor, err = src.PerformanceMetric(ShortProfitFactor).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -766,24 +770,24 @@ func (a *Account) TradeMetrics() (TradeMetrics, error) {
 	return tradeMetrics, errors.Join(errs...)
 }
 
-func (a *Account) WithdrawalMetrics() (WithdrawalMetrics, error) {
+func withdrawalMetricsFrom(src metricQuerier) (WithdrawalMetrics, error) {
 	var errs []error
 
 	withdrawal := WithdrawalMetrics{}
 
 	var err error
 
-	withdrawal.SafeWithdrawalRate, err = a.PerformanceMetric(SafeWithdrawalRate).Value()
+	withdrawal.SafeWithdrawalRate, err = src.PerformanceMetric(SafeWithdrawalRate).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	withdrawal.PerpetualWithdrawalRate, err = a.PerformanceMetric(PerpetualWithdrawalRate).Value()
+	withdrawal.PerpetualWithdrawalRate, err = src.PerformanceMetric(PerpetualWithdrawalRate).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
 
-	withdrawal.DynamicWithdrawalRate, err = a.PerformanceMetric(DynamicWithdrawalRate).Value()
+	withdrawal.DynamicWithdrawalRate, err = src.PerformanceMetric(DynamicWithdrawalRate).Value()
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -877,7 +881,9 @@ func (a *Account) Record(txn Transaction) {
 
 				tdRemaining := coverQty
 
-				tdLots := shortLots
+				// Walk lots in the same order consumeShortLots will
+				// consume them so entry price/date match the real lots.
+				tdLots := lotsInConsumptionOrder(shortLots, method)
 				for tdLotIdx := 0; tdLotIdx < len(tdLots) && tdRemaining > 0; tdLotIdx++ {
 					matched := tdLots[tdLotIdx].Qty
 					if matched > tdRemaining {
@@ -937,12 +943,17 @@ func (a *Account) Record(txn Transaction) {
 			}
 
 			a.taxLots[txn.Asset] = append(a.taxLots[txn.Asset], newLot)
-			a.checkWashSaleOnBuy(txn.Asset, txn.Date, longQty, lotID)
-			a.recentBuys[txn.Asset] = append(a.recentBuys[txn.Asset], recentBuy{
-				date:  txn.Date,
-				lotID: lotID,
-				qty:   longQty,
-			})
+
+			// Only the portion of the lot that did not absorb a disallowed
+			// loss remains a replacement-share candidate for future sales.
+			remainingLotID, remainingQty := a.checkWashSaleOnBuy(txn.Asset, txn.Date, longQty, lotID)
+			if remainingQty > 0 {
+				a.recentBuys[txn.Asset] = append(a.recentBuys[txn.Asset], recentBuy{
+					date:  txn.Date,
+					lotID: remainingLotID,
+					qty:   remainingQty,
+				})
+			}
 
 			if _, exists := a.excursions[txn.Asset]; !exists {
 				a.excursions[txn.Asset] = ExcursionRecord{
@@ -989,7 +1000,9 @@ func (a *Account) Record(txn Transaction) {
 
 				tdRemaining := closeLongQty
 
-				tdLots := longLots
+				// Walk lots in the same order consumeLots will consume
+				// them so entry price/date match the real lots.
+				tdLots := lotsInConsumptionOrder(longLots, method)
 				for tdLotIdx := 0; tdLotIdx < len(tdLots) && tdRemaining > 0; tdLotIdx++ {
 					matched := tdLots[tdLotIdx].Qty
 					if matched > tdRemaining {
@@ -1230,14 +1243,19 @@ func (a *Account) pruneWashSaleTracking(asOf time.Time) {
 
 // checkWashSaleOnBuy checks if there are recent loss sales within 30 days
 // of this buy. If so, it disallows the loss by adding it to the new lot's
-// cost basis.
-func (a *Account) checkWashSaleOnBuy(ast asset.Asset, buyDate time.Time, buyQty float64, lotID string) {
+// cost basis. When only part of the new lot matches a loss sale, the lot
+// is split so that only the matched shares receive the basis adjustment.
+// It returns the lot ID and share count of the portion of the new lot
+// that did not absorb a disallowed loss (and so remains a replacement-share
+// candidate for future loss sales); remainingQty is 0 when the entire lot
+// was matched.
+func (a *Account) checkWashSaleOnBuy(ast asset.Asset, buyDate time.Time, buyQty float64, lotID string) (remainingLotID string, remainingQty float64) {
+	remaining := buyQty
+
 	sales := a.recentLossSales[ast]
 	if len(sales) == 0 {
-		return
+		return lotID, remaining
 	}
-
-	remaining := buyQty
 
 	for idx := 0; idx < len(sales) && remaining > 0; idx++ {
 		daysDiff := buyDate.Sub(sales[idx].date).Hours() / 24
@@ -1253,8 +1271,18 @@ func (a *Account) checkWashSaleOnBuy(ast asset.Asset, buyDate time.Time, buyQty 
 
 		disallowedLoss := matchQty * sales[idx].lossPerShare
 
-		// Adjust the new lot's cost basis.
-		a.adjustLotBasis(ast, lotID, sales[idx].lossPerShare)
+		// When only part of the current lot matches, split it so the
+		// basis adjustment lands on the matched shares only. The tail
+		// keeps its original basis and is matched on later iterations.
+		adjustedLotID := lotID
+		if matchQty < remaining {
+			headID, tailID := a.splitLot(ast, lotID, matchQty)
+			adjustedLotID = headID
+			lotID = tailID
+		}
+
+		// Adjust the matched portion's cost basis.
+		a.adjustLotBasis(ast, adjustedLotID, sales[idx].lossPerShare)
 
 		// Record the wash sale.
 		a.washSales = append(a.washSales, WashSaleRecord{
@@ -1262,7 +1290,7 @@ func (a *Account) checkWashSaleOnBuy(ast asset.Asset, buyDate time.Time, buyQty 
 			SellDate:       sales[idx].date,
 			RebuyDate:      buyDate,
 			DisallowedLoss: disallowedLoss,
-			AdjustedLotID:  lotID,
+			AdjustedLotID:  adjustedLotID,
 		})
 
 		// Consume from the loss sale entry.
@@ -1283,6 +1311,8 @@ func (a *Account) checkWashSaleOnBuy(ast asset.Asset, buyDate time.Time, buyQty 
 	} else {
 		a.recentLossSales[ast] = pruned
 	}
+
+	return lotID, remaining
 }
 
 // checkWashSaleOnSell checks if there are recent buys within 30 days of
@@ -1423,7 +1453,9 @@ func (a *Account) splitLot(ast asset.Asset, lotID string, headQty float64) (head
 			Price: original.Price,
 		}
 
-		a.taxLots[ast] = append(lots, tail)
+		// Insert the tail immediately after the head so the slice keeps
+		// its date-ascending order, which FIFO consumption relies on.
+		a.taxLots[ast] = slices.Insert(lots, idx+1, tail)
 
 		return headID, tailID
 	}
@@ -2119,6 +2151,16 @@ func (a *Account) ExecuteBatch(ctx context.Context, batch *Batch) error {
 						return fmt.Errorf("execute batch: submit %s: %w", ord.Asset.Ticker, err)
 					}
 				}
+
+				// Register the group so cancelOCOSiblings can cancel the
+				// surviving leg when one fills; without this the OCO pair
+				// degrades to two independent orders.
+				group := &broker.OrderGroup{ID: spec.GroupID, Type: broker.GroupOCO}
+				for _, ord := range orders {
+					group.OrderIDs = append(group.OrderIDs, ord.ID)
+				}
+
+				a.pendingGroups[spec.GroupID] = group
 			}
 
 		case broker.GroupBracket:
@@ -2251,7 +2293,15 @@ func (a *Account) drainFillsFromChannel() {
 				BatchID:       order.BatchID,
 			})
 
-			delete(a.pendingOrders, fill.OrderID)
+			// Partial fill: keep the order pending with the remaining
+			// quantity so later fills for the same order ID are still
+			// recognized rather than dropped as unknown.
+			if order.Qty-fill.Qty > 1e-9 {
+				order.Qty -= fill.Qty
+				a.pendingOrders[fill.OrderID] = order
+			} else {
+				delete(a.pendingOrders, fill.OrderID)
+			}
 
 			// Group handling for the filled order.
 			if order.GroupID != "" {
@@ -2545,6 +2595,20 @@ func (acct *Account) Clone() PortfolioManager {
 		seenTxns[id] = struct{}{}
 	}
 
+	positionMV := make(map[asset.Asset][]float64, len(acct.positionMV))
+	for held, series := range acct.positionMV {
+		seriesCopy := make([]float64, len(series))
+		copy(seriesCopy, series)
+		positionMV[held] = seriesCopy
+	}
+
+	positionQty := make(map[asset.Asset][]float64, len(acct.positionQty))
+	for held, series := range acct.positionQty {
+		seriesCopy := make([]float64, len(series))
+		copy(seriesCopy, series)
+		positionQty[held] = seriesCopy
+	}
+
 	clone := &Account{
 		cash:              acct.cash,
 		holdings:          holdings,
@@ -2574,6 +2638,16 @@ func (acct *Account) Clone() PortfolioManager {
 		seenTransactions:  seenTxns,
 		batches:           batches,
 		currentBatchID:    currentBatchID,
+		positionMV:        positionMV,
+		positionQty:       positionQty,
+
+		// Margin configuration: prediction runs must see the same
+		// leverage limits and borrow costs as the real account.
+		initialMargin:            acct.initialMargin,
+		maintenanceMargin:        acct.maintenanceMargin,
+		maxLeverage:              acct.maxLeverage,
+		grossMaintenanceLeverage: acct.grossMaintenanceLeverage,
+		borrowRate:               acct.borrowRate,
 	}
 
 	if acct.perfData != nil {

--- a/portfolio/active_return.go
+++ b/portfolio/active_return.go
@@ -55,7 +55,10 @@ func (activeReturn) Compute(ctx context.Context, stats PortfolioStats, window *P
 		return 0, nil
 	}
 
-	portReturn := (eqCol[len(eqCol)-1] / eqCol[0]) - 1
+	// The portfolio return is flow-adjusted so external deposits and
+	// withdrawals are not counted as return. The benchmark is a price
+	// curve with no external flows, so a naive end/start ratio is correct.
+	portReturn := flowAdjustedGrowth(ctx, stats, eqCol, df.Times()) - 1
 	benchReturn := (benchCol[len(benchCol)-1] / benchCol[0]) - 1
 
 	return portReturn - benchReturn, nil
@@ -104,9 +107,12 @@ func (activeReturn) ComputeSeries(ctx context.Context, stats PortfolioStats, win
 		series[idx] = (cumPort - 1) - (cumBench - 1)
 	}
 
+	// Returns correspond to the end of each period: the first return is
+	// stamped with the second timestamp, and NaN-padded leading returns
+	// were removed above, so keep the trailing count timestamps.
 	times := rdf.Times()
 	if len(times) > count {
-		times = times[:count]
+		times = times[len(times)-count:]
 	}
 
 	return data.NewDataFrame(

--- a/portfolio/after_tax_equity.go
+++ b/portfolio/after_tax_equity.go
@@ -17,32 +17,25 @@ package portfolio
 
 import (
 	"time"
-
-	"github.com/penny-vault/pvbt/asset"
 )
 
 // afterTaxEquity returns a copy of equity adjusted for cumulative realized
 // capital-gains taxes within the inclusive [start, end] window. The
 // returned slice is parallel to times.
 //
-// FIFO lot matching replays the full transaction log so that buys before
-// start still build up cost basis for sells inside the window. Realized
-// gains from in-window sells are taxed at rates.STCG (held <= 365 days)
-// or rates.LTCG (held > 365 days) and accumulated. The cumulative tax at
-// or before each timestamp is subtracted from the matching equity point.
+// FIFO lot matching (replayGainEvents) replays the full transaction log so
+// that opens before start still build up cost basis for closes inside the
+// window. Realized gains from in-window closes are taxed at rates.STCG
+// (held <= 365 days, and all short-sale gains) or rates.LTCG (held > 365
+// days) and accumulated. The cumulative tax at or before each timestamp is
+// subtracted from the matching equity point.
 //
-// Buys, sells outside the window, and dividends contribute zero tax: this
-// mirrors TaxDrag, which explicitly excludes dividend taxation. A zero
-// start or end disables the bound on that side.
+// Opens, closes outside the window, and dividends contribute zero tax:
+// this mirrors TaxDrag, which explicitly excludes dividend taxation. A
+// zero start or end disables the bound on that side.
 func afterTaxEquity(equity []float64, times []time.Time, txns []Transaction, start, end time.Time, rates taxRates) []float64 {
 	if len(equity) == 0 || len(times) != len(equity) {
 		return nil
-	}
-
-	type lot struct {
-		date  time.Time
-		qty   float64
-		price float64
 	}
 
 	type taxEvent struct {
@@ -50,87 +43,22 @@ func afterTaxEquity(equity []float64, times []time.Time, txns []Transaction, sta
 		amount float64
 	}
 
-	inRange := func(date time.Time) bool {
-		if !start.IsZero() && date.Before(start) {
-			return false
+	gains, _, _ := replayGainEvents(txns, start, end)
+
+	events := make([]taxEvent, 0, len(gains))
+
+	for _, gain := range gains {
+		tax := 0.0
+		if gain.stcg > 0 {
+			tax += rates.STCG * gain.stcg
 		}
 
-		if !end.IsZero() && date.After(end) {
-			return false
+		if gain.ltcg > 0 {
+			tax += rates.LTCG * gain.ltcg
 		}
 
-		return true
-	}
-
-	lots := make(map[string][]lot)
-
-	var events []taxEvent
-
-	for _, txn := range txns {
-		key := txn.Asset.CompositeFigi
-
-		switch txn.Type {
-		case asset.BuyTransaction:
-			lots[key] = append(lots[key], lot{
-				date:  txn.Date,
-				qty:   txn.Qty,
-				price: txn.Price,
-			})
-		case asset.SellTransaction:
-			remaining := txn.Qty
-			lotList := lots[key]
-			attribute := inRange(txn.Date)
-
-			var (
-				ltcg float64
-				stcg float64
-			)
-
-			lotIdx := 0
-			for lotIdx < len(lotList) && remaining > 0 {
-				matched := lotList[lotIdx].qty
-				if matched > remaining {
-					matched = remaining
-				}
-
-				if attribute {
-					gain := (txn.Price - lotList[lotIdx].price) * matched
-
-					holdingDays := txn.Date.Sub(lotList[lotIdx].date).Hours() / 24
-					if holdingDays > 365 {
-						ltcg += gain
-					} else {
-						stcg += gain
-					}
-				}
-
-				if lotList[lotIdx].qty <= remaining {
-					remaining -= lotList[lotIdx].qty
-					lotIdx++
-				} else {
-					lotList[lotIdx].qty -= remaining
-					remaining = 0
-				}
-			}
-
-			lots[key] = lotList[lotIdx:]
-
-			if !attribute {
-				continue
-			}
-
-			tax := 0.0
-			if stcg > 0 {
-				tax += rates.STCG * stcg
-			}
-
-			if ltcg > 0 {
-				tax += rates.LTCG * ltcg
-			}
-
-			if tax > 0 {
-				events = append(events, taxEvent{date: txn.Date, amount: tax})
-			}
+		if tax > 0 {
+			events = append(events, taxEvent{date: gain.date, amount: tax})
 		}
 	}
 

--- a/portfolio/batch.go
+++ b/portfolio/batch.go
@@ -409,7 +409,9 @@ func (b *Batch) RebalanceTo(_ context.Context, allocs ...Allocation) error {
 
 		// Liquidate all positions not in the target allocation.
 		// Long positions are sold; short positions are covered (bought back).
-		for ast, qty := range b.portfolio.Holdings() {
+		// Projected holdings (not actual) so positions already sold by
+		// earlier orders in this batch are not sold a second time.
+		for ast, qty := range b.ProjectedHoldings() {
 			if _, ok := alloc.Members[ast]; !ok && qty != 0 {
 				if qty > 0 {
 					sells = append(sells, pendingOrder{asset: ast, side: Sell, qty: qty})

--- a/portfolio/benchmark_view.go
+++ b/portfolio/benchmark_view.go
@@ -16,6 +16,7 @@
 package portfolio
 
 import (
+	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/data"
 )
 
@@ -67,6 +68,22 @@ func (a *Account) benchmarkView() (*Account, error) {
 	view := *a
 	view.perfData = newPerfData
 	view.dfCache = nil
+
+	// The benchmark price curve has no external cash flows, so hide the
+	// portfolio's deposits and withdrawals from the view. Otherwise
+	// flow-adjusted metrics (TWRR, CAGR, MWRR, etc.) would subtract the
+	// portfolio's flows from the benchmark curve.
+	flowFree := make([]Transaction, 0, len(a.transactions))
+
+	for _, txn := range a.transactions {
+		if txn.Type == asset.DepositTransaction || txn.Type == asset.WithdrawalTransaction {
+			continue
+		}
+
+		flowFree = append(flowFree, txn)
+	}
+
+	view.transactions = flowFree
 
 	return &view, nil
 }

--- a/portfolio/benchmark_view_test.go
+++ b/portfolio/benchmark_view_test.go
@@ -1,9 +1,12 @@
 package portfolio_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/data"
 	"github.com/penny-vault/pvbt/portfolio"
 )
@@ -50,6 +53,41 @@ var _ = Describe("Benchmark targeting", func() {
 
 			// Both should be equal because the portfolio IS the benchmark.
 			Expect(portfolioTWRR).To(BeNumerically("~", benchmarkTWRR, 1e-9))
+		})
+
+		It("ignores portfolio deposits when computing benchmark metrics", func() {
+			// The benchmark price curve has no external cash flows, so a
+			// deposit into the portfolio must not be subtracted from the
+			// benchmark's sub-period returns.
+			spy := asset.Asset{CompositeFigi: "SPY", Ticker: "SPY"}
+			dates := daySeq(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), 3)
+			prices := []float64{100, 110, 121}
+
+			acct := portfolio.New(
+				portfolio.WithCash(10_000, time.Time{}),
+				portfolio.WithBenchmark(spy),
+			)
+
+			for idx, dd := range dates {
+				if idx == 1 {
+					acct.Record(portfolio.Transaction{
+						Date:   dd,
+						Type:   asset.DepositTransaction,
+						Amount: 5_000,
+					})
+				}
+
+				acct.UpdatePrices(buildDF(dd,
+					[]asset.Asset{spy},
+					[]float64{prices[idx]},
+					[]float64{prices[idx]},
+				))
+			}
+
+			// Benchmark returns 10% then 10%: TWRR = 1.1*1.1 - 1 = 0.21.
+			benchmarkTWRR, err := acct.PerformanceMetric(portfolio.TWRR).Benchmark().Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(benchmarkTWRR).To(BeNumerically("~", 0.21, 1e-9))
 		})
 	})
 

--- a/portfolio/calmar.go
+++ b/portfolio/calmar.go
@@ -48,7 +48,14 @@ func (calmar) Compute(ctx context.Context, stats PortfolioStats, window *Period)
 		return 0, nil
 	}
 
-	annualizedReturn := math.Pow(eqCol[len(eqCol)-1]/eqCol[0], 1.0/years) - 1
+	// Flow-adjust the return so external deposits and withdrawals are not
+	// counted as return, matching CAGR.
+	growth := flowAdjustedGrowth(ctx, stats, eqCol, eqTimes)
+	if growth <= 0 {
+		return 0, nil
+	}
+
+	annualizedReturn := math.Pow(growth, 1.0/years) - 1
 
 	ddDF := stats.Drawdown(ctx, window)
 	if ddDF == nil {

--- a/portfolio/excursion_test.go
+++ b/portfolio/excursion_test.go
@@ -553,6 +553,49 @@ var _ = Describe("ExcursionRecord", func() {
 		})
 	})
 
+	Describe("TradeCaptureRatio with short trades", func() {
+		It("uses direction-adjusted realized returns for shorts", func() {
+			acme := asset.Asset{CompositeFigi: "ACME", Ticker: "ACME"}
+			acct := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+
+			// Short 10 @ 100, price falls to 80, cover at 80.
+			acct.Record(portfolio.Transaction{
+				Date:   time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  acme,
+				Type:   asset.SellTransaction,
+				Qty:    10,
+				Price:  100.0,
+				Amount: 1_000.0,
+			})
+
+			df, err := data.NewDataFrame(
+				[]time.Time{time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)},
+				[]asset.Asset{acme},
+				[]data.Metric{data.MetricClose, data.AdjClose, data.MetricHigh, data.MetricLow},
+				data.Daily, [][]float64{{80.0}, {80.0}, {100.0}, {80.0}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			acct.UpdateExcursions(df)
+
+			acct.Record(portfolio.Transaction{
+				Date:   time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  acme,
+				Type:   asset.BuyTransaction,
+				Qty:    10,
+				Price:  80.0,
+				Amount: -800.0,
+			})
+
+			// Short MFE = (entry - low) / entry = (100-80)/100 = 0.20.
+			// Realized short return = (entry - exit) / entry = 0.20.
+			// TradeCaptureRatio = 0.20 / 0.20 = 1.0 (not -1.0, which the
+			// long-only formula would produce).
+			val, err := acct.PerformanceMetric(portfolio.TradeCaptureRatio).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(BeNumerically("~", 1.0, 1e-9))
+		})
+	})
+
 	Describe("with no trades", func() {
 		It("returns zero for averages and medians", func() {
 			emptyAcct := portfolio.New(portfolio.WithCash(10_000, time.Time{}))

--- a/portfolio/k_ratio.go
+++ b/portfolio/k_ratio.go
@@ -88,7 +88,9 @@ func (kRatio) Compute(ctx context.Context, stats PortfolioStats, window *Period)
 		return 0, nil
 	}
 
-	return slope / stderr, nil
+	// 2003 Kestner revision: normalize the regression t-stat by the number
+	// of observations so the ratio is comparable across window lengths.
+	return slope / (stderr * numPeriods), nil
 }
 
 func (kRatio) ComputeSeries(_ context.Context, _ PortfolioStats, _ *Period) (*data.DataFrame, error) {

--- a/portfolio/keller_ratio.go
+++ b/portfolio/keller_ratio.go
@@ -41,7 +41,9 @@ func (kellerRatio) Compute(ctx context.Context, stats PortfolioStats, window *Pe
 		return 0, nil
 	}
 
-	totalReturn := (eqCol[len(eqCol)-1] / eqCol[0]) - 1
+	// Flow-adjust the return so external deposits and withdrawals are not
+	// counted as return, matching CAGR.
+	totalReturn := flowAdjustedGrowth(ctx, stats, eqCol, eqDF.Times()) - 1
 
 	ddDF := stats.Drawdown(ctx, window)
 	if ddDF == nil {

--- a/portfolio/lot_selection.go
+++ b/portfolio/lot_selection.go
@@ -45,3 +45,25 @@ func sortLotsByPriceDesc(lots []TaxLot) {
 		return lots[i].Price > lots[j].Price
 	})
 }
+
+// lotsInConsumptionOrder returns a copy of lots ordered the way the given
+// lot-selection method consumes them: FIFO front-first, LIFO back-first,
+// HighestCost by descending price. Callers use it to attribute per-lot
+// details (entry price/date, PnL, holding period) to the same lots that
+// consumeLots/consumeShortLots actually remove.
+func lotsInConsumptionOrder(lots []TaxLot, method LotSelection) []TaxLot {
+	ordered := make([]TaxLot, len(lots))
+	copy(ordered, lots)
+
+	switch method {
+	case LotLIFO:
+		for ii, jj := 0, len(ordered)-1; ii < jj; ii, jj = ii+1, jj-1 {
+			ordered[ii], ordered[jj] = ordered[jj], ordered[ii]
+		}
+	case LotHighestCost:
+		sortLotsByPriceDesc(ordered)
+	default: // LotFIFO: already in date-ascending order.
+	}
+
+	return ordered
+}

--- a/portfolio/lot_selection_account_test.go
+++ b/portfolio/lot_selection_account_test.go
@@ -128,6 +128,47 @@ var _ = Describe("Account lot selection", func() {
 		})
 	})
 
+	Describe("trade detail lot attribution", func() {
+		It("attributes LIFO sells to the most recently acquired lot", func() {
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, time.Time{}),
+				portfolio.WithDefaultLotSelection(portfolio.LotLIFO),
+			)
+
+			buyLot(acct, spy, day1, 50.0, 10)  // lot 1: $50, old
+			buyLot(acct, spy, day2, 150.0, 10) // lot 2: $150, recent
+
+			sellLot(acct, spy, day3, 100.0, 10)
+
+			details := acct.TradeDetails()
+			Expect(details).To(HaveLen(1))
+			// LIFO consumes the $150 lot: a $50/share loss, held from day2.
+			Expect(details[0].EntryPrice).To(Equal(150.0))
+			Expect(details[0].EntryDate).To(Equal(day2))
+			Expect(details[0].PnL).To(Equal(-500.0))
+		})
+
+		It("attributes HighestCost sells to the highest-cost lot", func() {
+			acct := portfolio.New(
+				portfolio.WithCash(100_000, time.Time{}),
+				portfolio.WithDefaultLotSelection(portfolio.LotHighestCost),
+			)
+
+			buyLot(acct, spy, day1, 100.0, 10) // lot 1: $100
+			buyLot(acct, spy, day2, 300.0, 10) // lot 2: $300
+			buyLot(acct, spy, day3, 200.0, 10) // lot 3: $200
+
+			sellLot(acct, spy, day4, 250.0, 10)
+
+			details := acct.TradeDetails()
+			Expect(details).To(HaveLen(1))
+			// HighestCost consumes the $300 lot: a $50/share loss.
+			Expect(details[0].EntryPrice).To(Equal(300.0))
+			Expect(details[0].EntryDate).To(Equal(day2))
+			Expect(details[0].PnL).To(Equal(-500.0))
+		})
+	})
+
 	Describe("per-transaction LotSelection override", func() {
 		It("overrides the account default when set on the transaction", func() {
 			// Account default is FIFO, but transaction override is LIFO.

--- a/portfolio/margin_option.go
+++ b/portfolio/margin_option.go
@@ -44,8 +44,8 @@ func WithBorrowRate(rate float64) Option {
 // (LongMarketValue + ShortMarketValue) / Equity, at order-submission
 // time. Orders that would push the account above this ratio are
 // rejected; closing trades are always allowed through. The default is
-// 1.0, which models a cash account; set to 2.0 for Reg T-style 2x
-// initial leverage. Values <= 0 are clamped to the default.
+// 2.0 (Reg T-style 2x initial leverage); set to 1.0 to model a cash
+// account. Values <= 0 are clamped to the default.
 //
 // MaxLeverage is an entry-time gate only. Adverse price moves that
 // drift gross leverage above the cap do not force liquidation;

--- a/portfolio/metric_helpers.go
+++ b/portfolio/metric_helpers.go
@@ -233,6 +233,22 @@ func roundTrips(details []TradeDetail, txns []Transaction) ([]roundTrip, float64
 	return trips, totalSellValue
 }
 
+// flowAdjustedGrowth compounds flow-adjusted sub-period returns over the
+// equity curve, isolating market-driven growth from external deposits and
+// withdrawals (a naive end/start ratio would count a deposit as return).
+// The returned value is the total growth factor, product(1 + r_i).
+func flowAdjustedGrowth(ctx context.Context, stats PortfolioStats, equity []float64, times []time.Time) float64 {
+	flows := buildFlowMap(stats.TransactionsView(ctx), times[0], times[len(times)-1])
+	returns := subPeriodReturns(equity, times, flows)
+
+	growth := 1.0
+	for _, ri := range returns {
+		growth *= 1 + ri
+	}
+
+	return growth
+}
+
 // realizedGains replays the transaction log with FIFO lot matching to
 // compute realized long-term capital gains, short-term capital gains,
 // qualified dividend income, and non-qualified dividend income across
@@ -241,13 +257,28 @@ func realizedGains(txns []Transaction) (ltcg, stcg, qualDiv, nonQualDiv float64)
 	return realizedGainsInRange(txns, time.Time{}, time.Time{})
 }
 
-// realizedGainsInRange replays the full transaction log with FIFO lot
-// matching but only attributes realized gains and dividends whose
-// transaction date falls inside the inclusive [start, end] window.
-// Buys outside the window still build up tax lots so that in-window
-// sells consume the correct cost basis. A zero-value start/end disables
-// the bound on that side; a zero range on both sides covers all history.
-func realizedGainsInRange(txns []Transaction, start, end time.Time) (ltcg, stcg, qualDiv, nonQualDiv float64) {
+// gainEvent records the realized capital gains from a single closing
+// transaction: a sell closing long lots or a buy covering short lots.
+type gainEvent struct {
+	date time.Time
+	ltcg float64
+	stcg float64
+}
+
+// replayGainEvents replays the full transaction log with FIFO lot matching
+// and returns one gainEvent per closing transaction whose date falls inside
+// the inclusive [start, end] window, along with in-window qualified and
+// non-qualified dividend income. Transactions outside the window still build
+// up and consume lots so that in-window events use the correct cost basis.
+// A zero-value start/end disables the bound on that side.
+//
+// The replay mirrors Account.Record's two-phase handling: a Sell first
+// closes long lots and any excess opens short lots; a Buy first covers open
+// short lots -- realizing entry-minus-cover gains that are always short-term
+// per IRS short-sale rules -- and any excess opens long lots. It also
+// mirrors Account.ApplySplit: a SplitTransaction rescales open lot
+// quantities and prices by the split factor recorded in txn.Price.
+func replayGainEvents(txns []Transaction, start, end time.Time) (events []gainEvent, qualDiv, nonQualDiv float64) {
 	type lot struct {
 		date  time.Time
 		qty   float64
@@ -266,50 +297,102 @@ func realizedGainsInRange(txns []Transaction, start, end time.Time) (ltcg, stcg,
 		return true
 	}
 
-	lots := make(map[string][]lot) // keyed by CompositeFigi
+	// consume matches qty against the FIFO lot list, invoking onMatch for
+	// each matched piece, and returns the trimmed list plus any unmatched
+	// remainder.
+	consume := func(lotList []lot, qty float64, onMatch func(matched lot, matchedQty float64)) ([]lot, float64) {
+		lotIdx := 0
+		for lotIdx < len(lotList) && qty > 0 {
+			matchedQty := lotList[lotIdx].qty
+			if matchedQty > qty {
+				matchedQty = qty
+			}
+
+			onMatch(lotList[lotIdx], matchedQty)
+
+			if lotList[lotIdx].qty <= qty {
+				qty -= lotList[lotIdx].qty
+				lotIdx++
+			} else {
+				lotList[lotIdx].qty -= qty
+				qty = 0
+			}
+		}
+
+		return lotList[lotIdx:], qty
+	}
+
+	// Long and short lots keyed by CompositeFigi.
+	longLots := make(map[string][]lot)
+	shortLots := make(map[string][]lot)
 
 	for _, txn := range txns {
 		key := txn.Asset.CompositeFigi
 		switch txn.Type {
 		case asset.BuyTransaction:
-			lots[key] = append(lots[key], lot{
-				date:  txn.Date,
-				qty:   txn.Qty,
-				price: txn.Price,
-			})
-		case asset.SellTransaction:
-			remaining := txn.Qty
-			lotList := lots[key]
 			attribute := inRange(txn.Date)
+			event := gainEvent{date: txn.Date}
 
-			lotIdx := 0
-			for lotIdx < len(lotList) && remaining > 0 {
-				matched := lotList[lotIdx].qty
-				if matched > remaining {
-					matched = remaining
-				}
-
+			// Phase 1: cover open short lots. Gains on short sales are
+			// short-term regardless of how long the short was open.
+			remaining := txn.Qty
+			shortLots[key], remaining = consume(shortLots[key], remaining, func(matched lot, matchedQty float64) {
 				if attribute {
-					gain := (txn.Price - lotList[lotIdx].price) * matched
-
-					holdingDays := txn.Date.Sub(lotList[lotIdx].date).Hours() / 24
-					if holdingDays > 365 {
-						ltcg += gain
-					} else {
-						stcg += gain
-					}
+					event.stcg += (matched.price - txn.Price) * matchedQty
 				}
+			})
 
-				if lotList[lotIdx].qty <= remaining {
-					remaining -= lotList[lotIdx].qty
-					lotIdx++
-				} else {
-					lotList[lotIdx].qty -= remaining
-					remaining = 0
-				}
+			// Phase 2: open a long lot for the remainder.
+			if remaining > 0 {
+				longLots[key] = append(longLots[key], lot{date: txn.Date, qty: remaining, price: txn.Price})
 			}
 
-			lots[key] = lotList[lotIdx:]
+			if attribute && (event.ltcg != 0 || event.stcg != 0) {
+				events = append(events, event)
+			}
+		case asset.SellTransaction:
+			attribute := inRange(txn.Date)
+			event := gainEvent{date: txn.Date}
+
+			// Phase 1: close long lots.
+			remaining := txn.Qty
+			longLots[key], remaining = consume(longLots[key], remaining, func(matched lot, matchedQty float64) {
+				if !attribute {
+					return
+				}
+
+				gain := (txn.Price - matched.price) * matchedQty
+
+				holdingDays := txn.Date.Sub(matched.date).Hours() / 24
+				if holdingDays > 365 {
+					event.ltcg += gain
+				} else {
+					event.stcg += gain
+				}
+			})
+
+			// Phase 2: open short lots for the remainder.
+			if remaining > 0 {
+				shortLots[key] = append(shortLots[key], lot{date: txn.Date, qty: remaining, price: txn.Price})
+			}
+
+			if attribute && (event.ltcg != 0 || event.stcg != 0) {
+				events = append(events, event)
+			}
+		case asset.SplitTransaction:
+			if txn.Price == 0 {
+				continue
+			}
+
+			for idx := range longLots[key] {
+				longLots[key][idx].qty *= txn.Price
+				longLots[key][idx].price /= txn.Price
+			}
+
+			for idx := range shortLots[key] {
+				shortLots[key][idx].qty *= txn.Price
+				shortLots[key][idx].price /= txn.Price
+			}
 		case asset.DividendTransaction:
 			if !inRange(txn.Date) {
 				continue
@@ -323,5 +406,23 @@ func realizedGainsInRange(txns []Transaction, start, end time.Time) (ltcg, stcg,
 		}
 	}
 
-	return
+	return events, qualDiv, nonQualDiv
+}
+
+// realizedGainsInRange replays the full transaction log with FIFO lot
+// matching but only attributes realized gains and dividends whose
+// transaction date falls inside the inclusive [start, end] window.
+// Transactions outside the window still build up tax lots so that
+// in-window closes consume the correct cost basis. A zero-value start/end
+// disables the bound on that side; a zero range on both sides covers all
+// history.
+func realizedGainsInRange(txns []Transaction, start, end time.Time) (ltcg, stcg, qualDiv, nonQualDiv float64) {
+	events, qualDiv, nonQualDiv := replayGainEvents(txns, start, end)
+
+	for _, event := range events {
+		ltcg += event.ltcg
+		stcg += event.stcg
+	}
+
+	return ltcg, stcg, qualDiv, nonQualDiv
 }

--- a/portfolio/mwrr.go
+++ b/portfolio/mwrr.go
@@ -56,41 +56,33 @@ func (mwrr) Compute(ctx context.Context, stats PortfolioStats, window *Period) (
 		amount float64
 	}
 
-	var flows []cashFlow
-
 	startDate := times[0]
+	endDate := times[len(times)-1]
+
+	// The starting equity acts as the investor's initial investment: a
+	// synthetic outflow at the first observation. External flows dated at
+	// or before times[0] (including zero-date flows) are already reflected
+	// in equity[0], so only flows inside (times[0], times[len-1]] are
+	// added. This windows MWRR the same way buildFlowMap windows TWRR.
+	flows := []cashFlow{{date: startDate, amount: -equity[0]}}
 
 	for _, txn := range stats.TransactionsView(ctx) {
 		switch txn.Type {
-		case asset.DepositTransaction:
-			// From investor perspective, deposits are outflows (negative).
-			txnDate := txn.Date
-			if txnDate.IsZero() {
-				txnDate = startDate
+		case asset.DepositTransaction, asset.WithdrawalTransaction:
+			if !txn.Date.After(startDate) || txn.Date.After(endDate) {
+				continue
 			}
 
-			flows = append(flows, cashFlow{date: txnDate, amount: -txn.Amount})
-		case asset.WithdrawalTransaction:
-			// Withdrawals have negative Amount in the tx log; from investor
-			// perspective they are inflows (positive), so negate again.
-			txnDate := txn.Date
-			if txnDate.IsZero() {
-				txnDate = startDate
-			}
-
-			flows = append(flows, cashFlow{date: txnDate, amount: -txn.Amount})
+			// From the investor's perspective deposits are outflows
+			// (negative) and withdrawals are inflows (positive). Withdrawal
+			// amounts are already negative in the transaction log, so both
+			// cases negate Amount.
+			flows = append(flows, cashFlow{date: txn.Date, amount: -txn.Amount})
 		}
-	}
-
-	// If there are zero external flows, use a synthetic initial outflow
-	// equal to the first equity value.
-	if len(flows) == 0 {
-		flows = append(flows, cashFlow{date: startDate, amount: -equity[0]})
 	}
 
 	// Terminal cash flow: ending portfolio value (positive, investor could
 	// liquidate).
-	endDate := times[len(times)-1]
 	endValue := equity[len(equity)-1]
 	flows = append(flows, cashFlow{date: endDate, amount: endValue})
 

--- a/portfolio/order_test.go
+++ b/portfolio/order_test.go
@@ -86,14 +86,22 @@ func (m *mockBroker) Submit(_ context.Context, order broker.Order) error {
 	if m.submitFn != nil {
 		return m.submitFn(order)
 	}
+	// Real brokers echo the submitted order's ID on each fill; stamp it on
+	// configured fills that don't set one explicitly.
 	if fills, ok := m.fillsByAsset[order.Asset]; ok {
 		for _, fill := range fills {
+			if fill.OrderID == "" {
+				fill.OrderID = order.ID
+			}
 			m.fillCh <- fill
 		}
 		return nil
 	}
 	if m.callIdx < len(m.fills) {
 		for _, fill := range m.fills[m.callIdx] {
+			if fill.OrderID == "" {
+				fill.OrderID = order.ID
+			}
 			m.fillCh <- fill
 		}
 		m.callIdx++

--- a/portfolio/portfolio.go
+++ b/portfolio/portfolio.go
@@ -150,12 +150,14 @@ type Portfolio interface {
 	GrossLeverage() float64
 
 	// MaxLeverage returns the configured gross-leverage cap. The default is
-	// 1.0 (cash account). See WithMaxLeverage.
+	// 2.0 (Reg T initial margin); use WithMaxLeverage(1.0) to model a cash
+	// account.
 	MaxLeverage() float64
 
 	// GrossMaintenanceLeverage returns the configured gross-leverage
-	// liquidation threshold, or 0 when none is set (in which case
-	// only short-side maintenance margin can force liquidation).
+	// liquidation threshold. The default is 4.0 (Reg T maintenance);
+	// pass math.Inf(1) to WithGrossMaintenanceLeverage so that only
+	// short-side maintenance margin can force liquidation.
 	GrossMaintenanceLeverage() float64
 
 	// LeverageHeadroom returns the additional notional (in dollars) that can

--- a/portfolio/probabilistic_sharpe.go
+++ b/portfolio/probabilistic_sharpe.go
@@ -78,11 +78,13 @@ func (probabilisticSharpe) Compute(ctx context.Context, stats PortfolioStats, wi
 	skew := (sum3 / numPeriods) / (stdDev * stdDev * stdDev)
 	kurt := (sum4/numPeriods)/(stdDev*stdDev*stdDev*stdDev) - 3
 
-	// Standard error of the Sharpe ratio (Lo, 2002 / Bailey & Lopez de Prado).
-	// se(SR) = sqrt((1 - skew*SR + (kurt/4)*SR^2) / (n - 1))
+	// Standard error of the Sharpe ratio (Bailey & Lopez de Prado, 2012):
+	// se(SR) = sqrt((1 - skew*SR + ((kurtosis-1)/4)*SR^2) / (n - 1))
+	// where kurtosis is the raw (non-excess) fourth moment ratio. kurt above
+	// holds EXCESS kurtosis, so kurtosis-1 = kurt+2.
 	sr2 := sharpeRatio * sharpeRatio
 
-	inner := (1 - skew*sharpeRatio + (kurt/4)*sr2) / (numPeriods - 1)
+	inner := (1 - skew*sharpeRatio + ((kurt+2)/4)*sr2) / (numPeriods - 1)
 	if inner <= 0 {
 		return 0, nil
 	}

--- a/portfolio/recovery_factor.go
+++ b/portfolio/recovery_factor.go
@@ -41,7 +41,9 @@ func (recoveryFactor) Compute(ctx context.Context, stats PortfolioStats, window 
 		return 0, nil
 	}
 
-	totalReturn := eqCol[len(eqCol)-1]/eqCol[0] - 1
+	// Flow-adjust the return so external deposits and withdrawals are not
+	// counted as return, matching CAGR.
+	totalReturn := flowAdjustedGrowth(ctx, stats, eqCol, eqDF.Times()) - 1
 
 	ddDF := stats.Drawdown(ctx, window)
 	if ddDF == nil {

--- a/portfolio/return_metrics_test.go
+++ b/portfolio/return_metrics_test.go
@@ -564,6 +564,47 @@ var _ = Describe("Return Metrics", func() {
 			Expect(result).To(BeNumerically("~", expected, 1e-9))
 			Expect(result).To(BeNumerically("<", 0.0))
 		})
+
+		It("measures only the window when computed over an absolute window", func() {
+			// Equity: 10000 -> 11000 -> 12100 via dividends (organic growth).
+			// The full-history initial deposit must not leak into a window
+			// that starts later: the window's starting equity is the
+			// synthetic initial outflow.
+			dates := []time.Time{
+				time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
+				time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+				time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+			}
+
+			a := portfolio.New(portfolio.WithCash(10_000, time.Time{}))
+			df0 := buildDF(dates[0], []asset.Asset{spy}, []float64{100}, []float64{100})
+			a.UpdatePrices(df0)
+
+			a.Record(portfolio.Transaction{
+				Date:   dates[1],
+				Type:   asset.DividendTransaction,
+				Amount: 1000,
+			})
+			df1 := buildDF(dates[1], []asset.Asset{spy}, []float64{100}, []float64{100})
+			a.UpdatePrices(df1)
+
+			a.Record(portfolio.Transaction{
+				Date:   dates[2],
+				Type:   asset.DividendTransaction,
+				Amount: 1100,
+			})
+			df2 := buildDF(dates[2], []asset.Asset{spy}, []float64{100}, []float64{100})
+			a.UpdatePrices(df2)
+
+			// Window covers [dates[1], dates[2]]: equity [11000, 12100] over
+			// 365 days with no external flows inside the window.
+			// XIRR solves: -11000 + 12100/(1+r)^(365/365) = 0 -> r = 0.10.
+			result, err := a.PerformanceMetric(portfolio.MWRR).
+				AbsoluteWindow(dates[1], dates[2]).
+				Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNumerically("~", 0.10, 1e-9))
+		})
 	})
 
 	// recordBuy is a helper that records a buy transaction on the account.
@@ -960,7 +1001,9 @@ var _ = Describe("Return Metrics", func() {
 
 	Describe("ActiveReturn", func() {
 		// buildAccountWithBenchmark creates an account with both a portfolio equity
-		// curve and benchmark prices.
+		// curve and benchmark prices. The equity curve is shaped with dividend/fee
+		// transactions so it reflects organic growth rather than external cash
+		// flows, which are excluded from flow-adjusted returns.
 		buildAccountWithBenchmark := func(
 			dates []time.Time,
 			equity []float64,
@@ -976,13 +1019,13 @@ var _ = Describe("Return Metrics", func() {
 					if diff > 0 {
 						a.Record(portfolio.Transaction{
 							Date:   d,
-							Type:   asset.DepositTransaction,
+							Type:   asset.DividendTransaction,
 							Amount: diff,
 						})
 					} else if diff < 0 {
 						a.Record(portfolio.Transaction{
 							Date:   d,
-							Type:   asset.WithdrawalTransaction,
+							Type:   asset.FeeTransaction,
 							Amount: diff,
 						})
 					}

--- a/portfolio/risk_adjusted_metrics_test.go
+++ b/portfolio/risk_adjusted_metrics_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Risk-Adjusted Metrics", func() {
 			Expect(val).To(BeNumerically("~", 1.3629, 1e-3))
 		})
 
-		It("returns the return series from ComputeSeries", func() {
+		It("returns an expanding annualized standard deviation series from ComputeSeries", func() {
 			acct := buildAccount(
 				[]float64{100, 105, 98, 103, 97, 110},
 				[]float64{100, 100.01, 100.02, 100.03, 100.04, 100.05},
@@ -125,10 +125,17 @@ var _ = Describe("Risk-Adjusted Metrics", func() {
 
 			df, err := acct.PerformanceMetric(portfolio.StdDev).Series()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(df.Len()).To(Equal(5))
+			// 5 returns -> 4 expanding points (at least 2 returns needed).
+			Expect(df.Len()).To(Equal(4))
 			series := df.Column(perfAsset, data.PortfolioEquity)
-			Expect(series[0]).To(BeNumerically("~", 0.05, 1e-10))
-			Expect(series[1]).To(BeNumerically("~", -0.06667, 1e-4))
+			// First point: stddev([0.05, -0.066667]) = 0.0824958 annualized
+			// over the first 3 timestamps (Jan 2 - Jan 6, af = 2/(4/365.25)):
+			// 0.0824958 * sqrt(182.625) = 1.11484
+			Expect(series[0]).To(BeNumerically("~", 1.11484, 1e-4))
+			// Final point matches the scalar StdDev value.
+			val, err := acct.PerformanceMetric(portfolio.StdDev).Value()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(series[3]).To(BeNumerically("~", val, 1e-12))
 		})
 	})
 

--- a/portfolio/specialized_metrics_test.go
+++ b/portfolio/specialized_metrics_test.go
@@ -2,50 +2,18 @@ package portfolio_test
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/portfolio"
 )
 
 var _ = Describe("Specialized Metrics", func() {
-	spy := asset.Asset{CompositeFigi: "SPY", Ticker: "SPY"}
-
-	// buildAccountFromEquity creates an Account whose equity curve matches the
-	// given values exactly. Since we hold no securities, total value = cash,
-	// so we use deposit/withdrawal transactions to move cash to the desired
-	// level before each UpdatePrices call.
-	buildAccountFromEquity := func(equityValues []float64) *portfolio.Account {
-		a := portfolio.New(portfolio.WithCash(equityValues[0], time.Time{}))
-		start := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
-		dates := daySeq(start, len(equityValues))
-
-		for i, v := range equityValues {
-			if i > 0 {
-				diff := v - equityValues[i-1]
-				if diff > 0 {
-					a.Record(portfolio.Transaction{
-						Date:   dates[i],
-						Type:   asset.DepositTransaction,
-						Amount: diff,
-					})
-				} else if diff < 0 {
-					a.Record(portfolio.Transaction{
-						Date:   dates[i],
-						Type:   asset.WithdrawalTransaction,
-						Amount: diff,
-					})
-				}
-			}
-			df := buildDF(dates[i], []asset.Asset{spy}, []float64{450}, []float64{448})
-			a.UpdatePrices(df)
-		}
-
-		return a
-	}
+	// These specs use the shared buildAccountFromEquity from
+	// testutil_test.go, which shapes the equity curve via dividend/fee
+	// transactions. Deposits/withdrawals must not be used here: they are
+	// external cash flows and are excluded from flow-adjusted returns.
 
 	// -----------------------------------------------------------------------
 	// Shared equity curve: [100, 110, 105, 115, 108, 120, 125]
@@ -181,12 +149,12 @@ var _ = Describe("Specialized Metrics", func() {
 		It("computes correctly for the base curve", func() {
 			// logVAMI = ln(1000 * cumProd(1+r_i)) for i in [0..5]
 			// OLS regression of logVAMI on x=[0,1,2,3,4,5]
-			// slope = 0.027913, stderr = 0.010989
-			// KRatio = slope / stderr = 0.027913 / 0.010989 = 2.53999 (2003 Kestner revision)
+			// slope = 0.027913, stderr = 0.010989, n = 6
+			// KRatio = slope / (stderr * n) = 2.53999 / 6 = 0.42333 (2003 Kestner revision)
 			a := buildAccountFromEquity([]float64{100, 110, 105, 115, 108, 120, 125})
 			result, err := a.PerformanceMetric(portfolio.KRatio).Value()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(BeNumerically("~", 2.5399944051723757, 1e-9))
+			Expect(result).To(BeNumerically("~", 2.5399944051723757/6.0, 1e-9))
 		})
 
 		It("returns zero with fewer than 3 returns (3 equity points)", func() {
@@ -518,11 +486,11 @@ var _ = Describe("Specialized Metrics", func() {
 				// logVAMI oscillates heavily around the trend line, producing
 				// a large standard error that reduces the K-Ratio.
 				// OLS on logVAMI: slope=0.04918, stderr=0.08882
-				// KRatio = slope / stderr = 0.04918 / 0.08882 = 0.45738 (2003 Kestner revision)
+				// KRatio = slope / (stderr * n) = 0.45738 / 7 = 0.06534 (2003 Kestner revision)
 				a := buildAccountFromEquity([]float64{100, 130, 95, 140, 90, 145, 100, 150})
 				result, err := a.PerformanceMetric(portfolio.KRatio).Value()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(BeNumerically("~", 0.45737915846086635, 1e-9))
+				Expect(result).To(BeNumerically("~", 0.45737915846086635/7.0, 1e-9))
 				// Positive but much smaller than the steady-growth case
 				Expect(result).To(BeNumerically(">", 0))
 				Expect(result).To(BeNumerically("<", 1.0))
@@ -533,11 +501,11 @@ var _ = Describe("Specialized Metrics", func() {
 				// 6 returns that decrease slightly (5/100, 5/105, 5/110, ...),
 				// producing near-linear logVAMI with tiny residuals.
 				// slope = 0.042684, stderr = 0.000666
-				// KRatio = 0.042684 / 0.000666 = 64.113 (2003 Kestner revision)
+				// KRatio = slope / (stderr * n) = 64.113 / 6 = 10.685 (2003 Kestner revision)
 				a := buildAccountFromEquity([]float64{100, 105, 110, 115, 120, 125, 130})
 				result, err := a.PerformanceMetric(portfolio.KRatio).Value()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(BeNumerically("~", 64.11253704211674, 1e-6))
+				Expect(result).To(BeNumerically("~", 64.11253704211674/6.0, 1e-6))
 				// Orders of magnitude larger than the volatile case
 				Expect(result).To(BeNumerically(">", 10))
 			})
@@ -548,11 +516,11 @@ var _ = Describe("Specialized Metrics", func() {
 				//   r0=-0.20, r1=-0.3125, r2=-0.36364, r3=-0.42857, r4=-0.50
 				// logVAMI has a steep negative slope.
 				// slope = -0.14936, stderr = 0.01053
-				// KRatio = -0.14936 / 0.01053 = -14.176 (2003 Kestner revision)
+				// KRatio = slope / (stderr * n) = -14.176 / 5 = -2.835 (2003 Kestner revision)
 				a := buildAccountFromEquity([]float64{100, 80, 55, 35, 20, 10})
 				result, err := a.PerformanceMetric(portfolio.KRatio).Value()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(result).To(BeNumerically("~", -14.175542222575912, 1e-6))
+				Expect(result).To(BeNumerically("~", -14.175542222575912/5.0, 1e-6))
 				Expect(result).To(BeNumerically("<", -2))
 			})
 		})

--- a/portfolio/sqlite.go
+++ b/portfolio/sqlite.go
@@ -17,13 +17,17 @@ package portfolio
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"io/fs"
 	"math"
+	"os"
 	"sort"
 	"strconv"
 	"time"
 
 	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/broker"
 	"github.com/penny-vault/pvbt/data"
 	_ "modernc.org/sqlite"
 )
@@ -172,6 +176,12 @@ func stringToTransactionType(str string) (asset.TransactionType, error) {
 // The database is created fresh; if a file already exists at path it is
 // overwritten.
 func (a *Account) ToSQLite(path string) error {
+	// sql.Open does not truncate an existing database; without the remove,
+	// a second write to the same path fails at CREATE TABLE.
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("remove existing sqlite file: %w", err)
+	}
+
 	database, err := sql.Open("sqlite", path)
 	if err != nil {
 		return fmt.Errorf("open sqlite: %w", err)
@@ -590,10 +600,24 @@ func FromSQLite(path string) (*Account, error) {
 		return nil, fmt.Errorf("ping sqlite: %w", err)
 	}
 
+	// Initialize every map that New() initializes: a restored account is
+	// documented as resumable, so mutating methods (Record, UpdatePrices)
+	// must not panic on nil maps.
 	acct := &Account{
-		holdings: make(map[asset.Asset]float64),
-		taxLots:  make(map[asset.Asset][]TaxLot),
-		metadata: make(map[string]string),
+		holdings:         make(map[asset.Asset]float64),
+		taxLots:          make(map[asset.Asset][]TaxLot),
+		shortLots:        make(map[asset.Asset][]TaxLot),
+		recentLossSales:  make(map[asset.Asset][]recentLossSale),
+		recentBuys:       make(map[asset.Asset][]recentBuy),
+		metadata:         make(map[string]string),
+		pendingOrders:    make(map[string]broker.Order),
+		pendingGroups:    make(map[string]*broker.OrderGroup),
+		deferredExits:    make(map[string]OrderGroupSpec),
+		substitutions:    make(map[asset.Asset]Substitution),
+		excursions:       make(map[asset.Asset]ExcursionRecord),
+		seenTransactions: make(map[string]struct{}),
+		positionMV:       make(map[asset.Asset][]float64),
+		positionQty:      make(map[asset.Asset][]float64),
 	}
 
 	// Read metadata.
@@ -749,7 +773,14 @@ func (a *Account) readPerfData(db *sql.DB) error {
 	// Fixed metric order.
 	metrics := []data.Metric{data.PortfolioEquity, data.PortfolioBenchmark, data.PortfolioRiskFree}
 	assets := []asset.Asset{portfolioAsset}
+
+	// NaN entries are skipped at write time, so any (date, metric) pair
+	// absent from the table must round-trip back to NaN -- zero-filling
+	// would fabricate a value (e.g. a benchmark gap reloading as 0.0).
 	vals := make([]float64, len(times)*len(metrics))
+	for idx := range vals {
+		vals[idx] = math.NaN()
+	}
 
 	metricIndex := make(map[data.Metric]int, len(metrics))
 	for i, m := range metrics {

--- a/portfolio/std_dev.go
+++ b/portfolio/std_dev.go
@@ -18,6 +18,7 @@ package portfolio
 import (
 	"context"
 	"math"
+	"time"
 
 	"github.com/penny-vault/pvbt/asset"
 	"github.com/penny-vault/pvbt/data"
@@ -53,26 +54,61 @@ func (stdDev) Compute(ctx context.Context, stats PortfolioStats, window *Period)
 	return stdDev * math.Sqrt(af), nil
 }
 
+// ComputeSeries returns an expanding-window annualized standard deviation:
+// each point is the sample standard deviation of all returns observed up to
+// and including that timestamp, annualized with the observation frequency.
+// The final point matches the scalar Compute value. Timestamps stay aligned
+// with the return each point incorporates, skipping NaN returns.
 func (stdDev) ComputeSeries(ctx context.Context, stats PortfolioStats, window *Period) (*data.DataFrame, error) {
 	df := stats.Returns(ctx, window)
 	if df == nil {
 		return nil, nil
 	}
 
-	col := removeNaN(df.Column(portfolioAsset, data.PortfolioEquity))
-	if len(col) == 0 {
+	col := df.Column(portfolioAsset, data.PortfolioEquity)
+	times := df.Times()
+
+	if len(col) == 0 || len(times) != len(col) {
 		return nil, nil
 	}
 
-	times := df.Times()
-	seriesTimes := times[1:]
+	seriesTimes := make([]time.Time, 0, len(col))
+	values := make([]float64, 0, len(col))
+
+	// Welford's online algorithm for a numerically stable running variance.
+	count := 0
+	mean := 0.0
+	m2 := 0.0
+
+	for idx, ret := range col {
+		if math.IsNaN(ret) {
+			continue
+		}
+
+		count++
+		delta := ret - mean
+		mean += delta / float64(count)
+		m2 += delta * (ret - mean)
+
+		if count < 2 {
+			continue
+		}
+
+		af := annualizationFactor(times[:idx+1])
+		values = append(values, math.Sqrt(m2/float64(count-1))*math.Sqrt(af))
+		seriesTimes = append(seriesTimes, times[idx])
+	}
+
+	if len(values) == 0 {
+		return nil, nil
+	}
 
 	return data.NewDataFrame(
 		seriesTimes,
 		[]asset.Asset{portfolioAsset},
 		[]data.Metric{data.PortfolioEquity},
 		df.Frequency(),
-		[][]float64{col},
+		[][]float64{values},
 	)
 }
 

--- a/portfolio/tax_metrics_test.go
+++ b/portfolio/tax_metrics_test.go
@@ -143,6 +143,118 @@ var _ = Describe("TaxMetrics", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tm.STCG).To(Equal(-2_000.0))
 		})
+
+		It("attributes short-sale gains as STCG regardless of holding period", func() {
+			a := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+
+			// Short 100 shares at $100 (no long lots exist).
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.SellTransaction,
+				Qty:    100,
+				Price:  100.0,
+				Amount: 10_000.0,
+			})
+
+			// Cover at $80 more than a year later: gain = 100 * (100 - 80)
+			// = 2000, short-term per IRS short-sale rules.
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    100,
+				Price:  80.0,
+				Amount: -8_000.0,
+			})
+
+			tm, err := a.TaxMetrics()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tm.STCG).To(Equal(2_000.0))
+			Expect(tm.LTCG).To(Equal(0.0))
+		})
+
+		It("does not create phantom long lots from short covers", func() {
+			a := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+
+			// Short 100 @ $100, cover 100 @ $80: STCG = 2000.
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.SellTransaction,
+				Qty:    100,
+				Price:  100.0,
+				Amount: 10_000.0,
+			})
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    100,
+				Price:  80.0,
+				Amount: -8_000.0,
+			})
+
+			// Separate long round trip: buy 100 @ $90, sell 100 @ $110.
+			// STCG = 100 * (110 - 90) = 2000. If the cover above had opened
+			// a phantom $80 long lot, this sell would incorrectly match it
+			// and report 3000.
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    100,
+				Price:  90.0,
+				Amount: -9_000.0,
+			})
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.SellTransaction,
+				Qty:    100,
+				Price:  110.0,
+				Amount: 11_000.0,
+			})
+
+			tm, err := a.TaxMetrics()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tm.STCG).To(Equal(4_000.0))
+			Expect(tm.LTCG).To(Equal(0.0))
+		})
+
+		It("adjusts replayed tax lots for stock splits", func() {
+			a := portfolio.New(portfolio.WithCash(50_000, time.Time{}))
+
+			// Buy 100 shares at $100.
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.BuyTransaction,
+				Qty:    100,
+				Price:  100.0,
+				Amount: -10_000.0,
+			})
+
+			// 2-for-1 split: 200 shares with a $50 basis.
+			Expect(a.ApplySplit(spy, time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC), 2.0)).To(Succeed())
+
+			// Sell 200 at $60: STCG = 200 * (60 - 50) = 2000. Without split
+			// handling the replay would match only 100 pre-split shares at a
+			// $100 basis and report a 4000 loss.
+			a.Record(portfolio.Transaction{
+				Date:   time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC),
+				Asset:  spy,
+				Type:   asset.SellTransaction,
+				Qty:    200,
+				Price:  60.0,
+				Amount: 12_000.0,
+			})
+
+			tm, err := a.TaxMetrics()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tm.STCG).To(Equal(2_000.0))
+			Expect(tm.LTCG).To(Equal(0.0))
+		})
 	})
 
 	Describe("dividends", func() {

--- a/portfolio/trade_capture_ratio.go
+++ b/portfolio/trade_capture_ratio.go
@@ -41,7 +41,13 @@ func (tradeCaptureRatio) Compute(ctx context.Context, stats PortfolioStats, _ *P
 	var sumReturnPct, sumMFE float64
 
 	for _, trade := range trades {
+		// For shorts the trade profits when price falls, mirroring the
+		// direction-adjusted MFE recorded for short covers.
 		returnPct := (trade.ExitPrice - trade.EntryPrice) / trade.EntryPrice
+		if trade.Direction == TradeShort {
+			returnPct = (trade.EntryPrice - trade.ExitPrice) / trade.EntryPrice
+		}
+
 		sumReturnPct += returnPct
 		sumMFE += trade.MFE
 	}

--- a/portfolio/treynor.go
+++ b/portfolio/treynor.go
@@ -63,8 +63,15 @@ func (treynor) Compute(ctx context.Context, stats PortfolioStats, window *Period
 
 	years := calendarDays / 365.25
 
-	// Annualize returns using CAGR.
-	cagrPortfolio := math.Pow(eqCol[len(eqCol)-1]/eqCol[0], 1/years) - 1
+	// Annualize returns using CAGR. The portfolio return is flow-adjusted
+	// so external deposits and withdrawals are not counted as return; the
+	// risk-free curve has no external flows.
+	growth := flowAdjustedGrowth(ctx, stats, eqCol, times)
+	if growth <= 0 {
+		return 0, nil
+	}
+
+	cagrPortfolio := math.Pow(growth, 1/years) - 1
 	cagrRiskFree := math.Pow(rfWinCol[len(rfWinCol)-1]/rfWinCol[0], 1/years) - 1
 
 	betaValue, err := Beta.Compute(ctx, stats, window)

--- a/portfolio/viewed_portfolio.go
+++ b/portfolio/viewed_portfolio.go
@@ -94,56 +94,24 @@ func (vp *viewedPortfolio) Summary() (Summary, error) {
 	return summary, errors.Join(errs...)
 }
 
+// RiskMetrics, TaxMetrics, TradeMetrics, and WithdrawalMetrics use the shared
+// aggregators with the view as the metric source, so every field is computed
+// over the view's [start, end] range -- vp.PerformanceMetric pre-applies
+// AbsoluteWindow.
 func (vp *viewedPortfolio) RiskMetrics() (RiskMetrics, error) {
-	var errs []error
-
-	risk := RiskMetrics{}
-
-	var err error
-
-	risk.Beta, err = vp.PerformanceMetric(Beta).Value()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	risk.Alpha, err = vp.PerformanceMetric(Alpha).Value()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	risk.TrackingError, err = vp.PerformanceMetric(TrackingError).Value()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	risk.DownsideDeviation, err = vp.PerformanceMetric(DownsideDeviation).Value()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	risk.InformationRatio, err = vp.PerformanceMetric(InformationRatio).Value()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	risk.Treynor, err = vp.PerformanceMetric(Treynor).Value()
-	if err != nil {
-		errs = append(errs, err)
-	}
-
-	return risk, errors.Join(errs...)
+	return riskMetricsFrom(vp)
 }
 
 func (vp *viewedPortfolio) TaxMetrics() (TaxMetrics, error) {
-	return vp.acct.TaxMetrics()
+	return taxMetricsFrom(vp)
 }
 
 func (vp *viewedPortfolio) TradeMetrics() (TradeMetrics, error) {
-	return vp.acct.TradeMetrics()
+	return tradeMetricsFrom(vp)
 }
 
 func (vp *viewedPortfolio) WithdrawalMetrics() (WithdrawalMetrics, error) {
-	return vp.acct.WithdrawalMetrics()
+	return withdrawalMetricsFrom(vp)
 }
 
 func (vp *viewedPortfolio) FactorAnalysis(factors *data.DataFrame) (*FactorRegression, error) {

--- a/portfolio/windowed_stats.go
+++ b/portfolio/windowed_stats.go
@@ -64,13 +64,20 @@ func (ws *windowedStats) ExcessReturns(ctx context.Context, window *Period) *dat
 	return df.Between(ws.start, ws.end)
 }
 
+// Drawdown computes running-peak drawdowns from the equity curve restricted
+// to [start, end], so peaks that occurred before the window do not leak in.
+// This matches Account.Drawdown, which windows equity first and then
+// computes running peaks within the window.
 func (ws *windowedStats) Drawdown(ctx context.Context, window *Period) *data.DataFrame {
-	df := ws.inner.Drawdown(ctx, window)
-	if df == nil {
+	equityDF := ws.EquitySeries(ctx, window)
+	if equityDF == nil {
 		return nil
 	}
 
-	return df.Between(ws.start, ws.end)
+	equity := equityDF.Metrics(data.PortfolioEquity)
+	peak := equity.CumMax()
+
+	return equity.Sub(peak).Div(peak)
 }
 
 func (ws *windowedStats) BenchmarkReturns(ctx context.Context, window *Period) *data.DataFrame {

--- a/signal/atr.go
+++ b/signal/atr.go
@@ -30,10 +30,16 @@ import (
 const ATRSignal data.Metric = "ATR"
 
 // ATR computes the Average True Range for each asset in the universe using
-// Wilder's smoothing method. It always uses High, Low, and Close metrics.
-// Returns a single-row DataFrame with ATRSignal.
+// Wilder's smoothing method: the seed average covers the first period.N true
+// ranges and Wilder's smoothing runs over the remaining fetched history.
+// Extra warm-up bars are fetched (over-fetching calendar days to cover
+// weekends and holidays) so the smoothing has data to run on. It always uses
+// High, Low, and Close metrics. Returns a single-row DataFrame with ATRSignal.
 func ATR(ctx context.Context, assetUniverse universe.Universe, period portfolio.Period) *data.DataFrame {
-	df, err := assetUniverse.Window(ctx, period, data.MetricHigh, data.MetricLow, data.MetricClose)
+	// Fetch two extra periods (plus the +1 bar needed for the first true
+	// range) of warm-up history so Wilder's smoothing converges past its
+	// SMA seed.
+	df, baseBars, err := extendedWindow(ctx, assetUniverse, period, 2*period.N+1, data.MetricHigh, data.MetricLow, data.MetricClose)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("ATR: %w", err))
 	}
@@ -43,7 +49,12 @@ func ATR(ctx context.Context, assetUniverse universe.Universe, period portfolio.
 		return data.WithErr(fmt.Errorf("ATR: need at least 2 data points, got %d", numRows))
 	}
 
-	atrPeriod := numRows - 1
+	// Clamp the smoothing period when history is shorter than requested.
+	atrPeriod := min(baseBars, numRows-1)
+	if atrPeriod < 1 {
+		return data.WithErr(fmt.Errorf("ATR: period must cover at least 1 bar, got %d", atrPeriod))
+	}
+
 	assets := df.AssetList()
 	times := df.Times()
 	lastTime := []time.Time{times[len(times)-1]}

--- a/signal/bollinger.go
+++ b/signal/bollinger.go
@@ -55,7 +55,10 @@ func BollingerBands(ctx context.Context, assetUniverse universe.Universe, period
 	windowSize := df.Len()
 
 	middle := df.Rolling(windowSize).Mean().Last().RenameMetric(metric, BollingerMiddleSignal)
-	stdDev := df.Rolling(windowSize).Std().Last().RenameMetric(metric, BollingerMiddleSignal)
+
+	// Bollinger Bands use the population (N denominator) standard deviation,
+	// not the sample (N-1) standard deviation.
+	stdDev := df.Reduce(populationStd).RenameMetric(metric, BollingerMiddleSignal)
 
 	upper := middle.Add(stdDev.MulScalar(numStdDev)).RenameMetric(BollingerMiddleSignal, BollingerUpperSignal)
 	lower := middle.Sub(stdDev.MulScalar(numStdDev)).RenameMetric(BollingerMiddleSignal, BollingerLowerSignal)

--- a/signal/bollinger_test.go
+++ b/signal/bollinger_test.go
@@ -33,8 +33,8 @@ var _ = Describe("BollingerBands", func() {
 
 	It("computes correct upper, middle, and lower bands", func() {
 		// AAPL prices: [10, 20, 30, 40, 50], mean=30
-		// sample std = sqrt(sum((x-30)^2)/4) = sqrt((400+100+0+100+400)/4) = sqrt(250) ~= 15.8114
-		// GOOG prices: [100, 200, 300, 400, 500], mean=300, std=sqrt(25000) ~= 158.114
+		// population std = sqrt(sum((x-30)^2)/5) = sqrt((400+100+0+100+400)/5) = sqrt(200) ~= 14.1421
+		// GOOG prices: [100, 200, 300, 400, 500], mean=300, std=sqrt(20000) ~= 141.421
 		times := make([]time.Time, 5)
 		for ii := range times {
 			times[ii] = now.AddDate(0, 0, ii-4)
@@ -58,12 +58,12 @@ var _ = Describe("BollingerBands", func() {
 			signal.BollingerLowerSignal,
 		))
 
-		aaplStd := math.Sqrt(250.0)
+		aaplStd := math.Sqrt(200.0)
 		Expect(result.Value(aapl, signal.BollingerMiddleSignal)).To(BeNumerically("~", 30.0, 1e-10))
 		Expect(result.Value(aapl, signal.BollingerUpperSignal)).To(BeNumerically("~", 30.0+2*aaplStd, 1e-10))
 		Expect(result.Value(aapl, signal.BollingerLowerSignal)).To(BeNumerically("~", 30.0-2*aaplStd, 1e-10))
 
-		googStd := math.Sqrt(25000.0)
+		googStd := math.Sqrt(20000.0)
 		Expect(result.Value(goog, signal.BollingerMiddleSignal)).To(BeNumerically("~", 300.0, 1e-10))
 		Expect(result.Value(goog, signal.BollingerUpperSignal)).To(BeNumerically("~", 300.0+2*googStd, 1e-10))
 		Expect(result.Value(goog, signal.BollingerLowerSignal)).To(BeNumerically("~", 300.0-2*googStd, 1e-10))

--- a/signal/calendar_regression_test.go
+++ b/signal/calendar_regression_test.go
@@ -1,0 +1,557 @@
+package signal_test
+
+import (
+	"context"
+	"math"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/penny-vault/pvbt/asset"
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/portfolio"
+	"github.com/penny-vault/pvbt/signal"
+	"github.com/penny-vault/pvbt/universe"
+)
+
+// calendarDataSource emulates a real data provider: Fetch honors the
+// requested lookback period against the current date and only returns the
+// rows of the backing frame that fall inside [currentDate - lookback,
+// currentDate]. Because the backing frame only has rows on trading days,
+// a calendar-day lookback returns fewer bars than calendar days -- the
+// behavior that hid the indicator lookback bugs behind period-ignoring mocks.
+type calendarDataSource struct {
+	currentDate time.Time
+	frame       *data.DataFrame
+}
+
+func (c *calendarDataSource) Fetch(_ context.Context, _ []asset.Asset, lookback portfolio.Period, _ []data.Metric) (*data.DataFrame, error) {
+	start := lookback.Before(c.currentDate)
+	return c.frame.Between(start, c.currentDate), nil
+}
+
+func (c *calendarDataSource) FetchAt(_ context.Context, _ []asset.Asset, t time.Time, _ []data.Metric) (*data.DataFrame, error) {
+	return c.frame.Between(t, t), nil
+}
+
+func (c *calendarDataSource) CurrentDate() time.Time { return c.currentDate }
+
+// Compile-time check.
+var _ data.DataSource = (*calendarDataSource)(nil)
+
+// tradingTimes returns count timestamps on consecutive trading days
+// (skipping Saturdays and Sundays) ending at end, in ascending order.
+func tradingTimes(end time.Time, count int) []time.Time {
+	times := make([]time.Time, count)
+	tt := end
+
+	for ii := count - 1; ii >= 0; ii-- {
+		for tt.Weekday() == time.Saturday || tt.Weekday() == time.Sunday {
+			tt = tt.AddDate(0, 0, -1)
+		}
+
+		times[ii] = tt
+		tt = tt.AddDate(0, 0, -1)
+	}
+
+	return times
+}
+
+var _ = Describe("Indicators with weekend-skipping trading calendars", func() {
+	var (
+		ctx  context.Context
+		aapl asset.Asset
+		now  time.Time
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		aapl = asset.Asset{CompositeFigi: "FIGI-AAPL", Ticker: "AAPL"}
+		// A Friday, so any multi-day window spans at least one weekend.
+		now = time.Date(2025, 6, 13, 16, 0, 0, 0, time.UTC)
+	})
+
+	Describe("StochasticFast", func() {
+		It("computes over the requested trading bars despite weekends", func() {
+			// 15 trading days spanning three weekends. The last 7 bars are the
+			// hand-calculated series; the 8 earlier bars carry extreme values
+			// that would corrupt the result if they leaked into the window.
+			count := 15
+			highs := make([]float64, count)
+			lows := make([]float64, count)
+			closes := make([]float64, count)
+
+			for ii := range count - 7 {
+				highs[ii] = 30
+				lows[ii] = 1
+				closes[ii] = 2
+			}
+
+			copy(highs[count-7:], []float64{12, 11, 13, 14, 12, 15, 13})
+			copy(lows[count-7:], []float64{9, 8, 10, 11, 9, 10, 11})
+			copy(closes[count-7:], []float64{10, 10, 12, 13, 11, 14, 12})
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricHigh, data.MetricLow, data.MetricClose},
+				data.Daily, [][]float64{highs, lows, closes})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			// With the old calendar-day fetch, Days(5) fetched 7 calendar days
+			// spanning a weekend (5 trading bars) and always errored.
+			result := signal.StochasticFast(ctx, uu, portfolio.Days(5))
+			Expect(result.Err()).NotTo(HaveOccurred())
+			Expect(result.Value(aapl, signal.StochasticKSignal)).To(BeNumerically("~", 50.0, 1e-10))
+			Expect(result.Value(aapl, signal.StochasticDSignal)).To(BeNumerically("~", (50.0+600.0/7.0+50.0)/3.0, 1e-10))
+		})
+	})
+
+	Describe("StochasticSlow", func() {
+		It("computes over the requested trading bars despite weekends", func() {
+			// Last 7 bars are the tail of the hand-calculated series from the
+			// StochasticSlow unit test; earlier bars are extreme values.
+			count := 15
+			highs := make([]float64, count)
+			lows := make([]float64, count)
+			closes := make([]float64, count)
+
+			for ii := range count - 7 {
+				highs[ii] = 30
+				lows[ii] = 1
+				closes[ii] = 2
+			}
+
+			copy(highs[count-7:], []float64{13, 14, 12, 15, 13, 16, 14})
+			copy(lows[count-7:], []float64{10, 11, 9, 10, 11, 12, 10})
+			copy(closes[count-7:], []float64{12, 13, 11, 14, 12, 15, 13})
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricHigh, data.MetricLow, data.MetricClose},
+				data.Daily, [][]float64{highs, lows, closes})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			result := signal.StochasticSlow(ctx, uu, portfolio.Days(3), portfolio.Days(3))
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			expectedSlowK := (50.0 + 250.0/3.0 + 50.0) / 3.0
+			Expect(result.Value(aapl, signal.StochasticSlowKSignal)).To(BeNumerically("~", expectedSlowK, 1e-6))
+
+			slowK2 := (40.0 + 250.0/3.0 + 50.0) / 3.0
+			slowK3 := (250.0/3.0 + 50.0 + 250.0/3.0) / 3.0
+			expectedSlowD := (slowK2 + slowK3 + expectedSlowK) / 3.0
+			Expect(result.Value(aapl, signal.StochasticSlowDSignal)).To(BeNumerically("~", expectedSlowD, 1e-6))
+		})
+	})
+
+	Describe("MACD", func() {
+		It("produces non-NaN values when the slow window spans weekends", func() {
+			// 40 trading bars; a Days(26) calendar fetch only returns ~18
+			// trading bars, so the old code emptied the frame and errored.
+			count := 40
+			prices := make([]float64, count)
+			for ii := range prices {
+				prices[ii] = 100 + float64(ii)*1.5
+			}
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricClose}, data.Daily, [][]float64{prices})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			result := signal.MACD(ctx, uu, portfolio.Days(12), portfolio.Days(26), portfolio.Days(9))
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			macdLine := result.Value(aapl, signal.MACDLineSignal)
+			signalLine := result.Value(aapl, signal.MACDSignalLineSignal)
+			histogram := result.Value(aapl, signal.MACDHistogramSignal)
+
+			Expect(math.IsNaN(macdLine)).To(BeFalse())
+			Expect(math.IsNaN(signalLine)).To(BeFalse())
+			Expect(macdLine).To(BeNumerically(">", 0))
+			Expect(histogram).To(BeNumerically("~", macdLine-signalLine, 1e-10))
+		})
+	})
+
+	Describe("MFI", func() {
+		buildOHLCV := func(count int) (highs, lows, closes, volumes []float64) {
+			highs = make([]float64, count)
+			lows = make([]float64, count)
+			closes = make([]float64, count)
+			volumes = make([]float64, count)
+
+			for ii := range count {
+				base := 100 + math.Sin(float64(ii)*0.7)*10
+				highs[ii] = base + 2
+				lows[ii] = base - 2
+				closes[ii] = base + math.Cos(float64(ii))*1.5
+				volumes[ii] = 1000 + float64(ii%7)*100
+			}
+
+			return highs, lows, closes, volumes
+		}
+
+		expectedMFI := func(highs, lows, closes, volumes []float64, startIdx int) float64 {
+			tp := make([]float64, len(highs))
+			for ii := range tp {
+				tp[ii] = (highs[ii] + lows[ii] + closes[ii]) / 3.0
+			}
+
+			posFlow := 0.0
+			negFlow := 0.0
+
+			for ii := startIdx; ii < len(tp); ii++ {
+				mf := tp[ii] * volumes[ii]
+				if tp[ii] > tp[ii-1] {
+					posFlow += mf
+				} else if tp[ii] < tp[ii-1] {
+					negFlow += mf
+				}
+			}
+
+			return 100.0 - 100.0/(1.0+posFlow/negFlow)
+		}
+
+		It("uses period.N trading bars of money flow despite weekends", func() {
+			count := 30
+			highs, lows, closes, volumes := buildOHLCV(count)
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricHigh, data.MetricLow, data.MetricClose, data.Volume},
+				data.Daily, [][]float64{highs, lows, closes, volumes})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			result := signal.MFI(ctx, uu, portfolio.Days(14))
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			// Exactly the last 14 money flows (bars count-14 .. count-1
+			// against their prior bar) should participate.
+			expected := expectedMFI(highs, lows, closes, volumes, count-14)
+			Expect(result.Value(aapl, signal.MFISignal)).To(BeNumerically("~", expected, 1e-10))
+		})
+
+		It("preserves month-unit periods instead of coercing to days", func() {
+			// 60 trading days ending 2025-06-13 reach back to mid-March, so
+			// they fully cover the Months(2) window starting 2025-05-01.
+			count := 60
+			highs, lows, closes, volumes := buildOHLCV(count)
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricHigh, data.MetricLow, data.MetricClose, data.Volume},
+				data.Daily, [][]float64{highs, lows, closes, volumes})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			result := signal.MFI(ctx, uu, portfolio.Months(2))
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			// Months(2) at 2025-06-13 covers bars from 2025-05-01 onward,
+			// with one extra bar before the window as the TP baseline.
+			windowStart := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+			startIdx := 0
+
+			for ii, tt := range times {
+				if !tt.Before(windowStart) {
+					startIdx = ii
+					break
+				}
+			}
+
+			expected := expectedMFI(highs, lows, closes, volumes, startIdx)
+			Expect(result.Value(aapl, signal.MFISignal)).To(BeNumerically("~", expected, 1e-10))
+		})
+	})
+
+	Describe("RSI", func() {
+		It("runs Wilder smoothing over history beyond the seed period", func() {
+			count := 20
+			prices := make([]float64, count)
+			for ii := range prices {
+				prices[ii] = 50 + math.Sin(float64(ii)*0.9)*5
+			}
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricClose}, data.Daily, [][]float64{prices})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			result := signal.RSI(ctx, uu, portfolio.Days(14))
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			// Reference implementation: SMA seed over the first 14 changes,
+			// then Wilder smoothing over the remaining 5 changes.
+			rsiPeriod := 14
+			gains := make([]float64, 0, count-1)
+			losses := make([]float64, 0, count-1)
+
+			for ii := 1; ii < count; ii++ {
+				change := prices[ii] - prices[ii-1]
+				if change > 0 {
+					gains = append(gains, change)
+					losses = append(losses, 0)
+				} else {
+					gains = append(gains, 0)
+					losses = append(losses, -change)
+				}
+			}
+
+			avgGain := 0.0
+			avgLoss := 0.0
+
+			for ii := range rsiPeriod {
+				avgGain += gains[ii]
+				avgLoss += losses[ii]
+			}
+
+			avgGain /= float64(rsiPeriod)
+			avgLoss /= float64(rsiPeriod)
+
+			for ii := rsiPeriod; ii < len(gains); ii++ {
+				avgGain = (avgGain*float64(rsiPeriod-1) + gains[ii]) / float64(rsiPeriod)
+				avgLoss = (avgLoss*float64(rsiPeriod-1) + losses[ii]) / float64(rsiPeriod)
+			}
+
+			expected := 100 - 100/(1+avgGain/avgLoss)
+			Expect(result.Value(aapl, signal.RSISignal)).To(BeNumerically("~", expected, 1e-10))
+		})
+	})
+
+	Describe("ATR", func() {
+		It("runs Wilder smoothing over history beyond the seed period", func() {
+			count := 12
+			highs := make([]float64, count)
+			lows := make([]float64, count)
+			closes := make([]float64, count)
+
+			for ii := range count {
+				base := 100 + math.Sin(float64(ii)*0.8)*6
+				highs[ii] = base + 1 + float64(ii%3)
+				lows[ii] = base - 1 - float64(ii%2)
+				closes[ii] = base + 0.5
+			}
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricHigh, data.MetricLow, data.MetricClose},
+				data.Daily, [][]float64{highs, lows, closes})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			atrPeriod := 4
+			result := signal.ATR(ctx, uu, portfolio.Days(atrPeriod))
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			// Reference implementation: SMA seed over the first 4 true
+			// ranges, Wilder smoothing over the remaining 7.
+			trValues := make([]float64, count-1)
+			for ii := 1; ii < count; ii++ {
+				highLow := highs[ii] - lows[ii]
+				highPrevClose := math.Abs(highs[ii] - closes[ii-1])
+				lowPrevClose := math.Abs(lows[ii] - closes[ii-1])
+				trValues[ii-1] = math.Max(highLow, math.Max(highPrevClose, lowPrevClose))
+			}
+
+			avgTR := 0.0
+			for ii := range atrPeriod {
+				avgTR += trValues[ii]
+			}
+
+			avgTR /= float64(atrPeriod)
+
+			for ii := atrPeriod; ii < len(trValues); ii++ {
+				avgTR = (avgTR*float64(atrPeriod-1) + trValues[ii]) / float64(atrPeriod)
+			}
+
+			Expect(result.Value(aapl, signal.ATRSignal)).To(BeNumerically("~", avgTR, 1e-10))
+		})
+	})
+
+	Describe("KeltnerChannels", func() {
+		It("uses a true EMA center line and Wilder ATR with warm-up history", func() {
+			count := 12
+			highs := make([]float64, count)
+			lows := make([]float64, count)
+			closes := make([]float64, count)
+
+			for ii := range count {
+				base := 100 + math.Sin(float64(ii)*0.8)*6
+				highs[ii] = base + 1 + float64(ii%3)
+				lows[ii] = base - 1 - float64(ii%2)
+				closes[ii] = base + 0.5
+			}
+
+			times := tradingTimes(now, count)
+			df, err := data.NewDataFrame(times, []asset.Asset{aapl},
+				[]data.Metric{data.MetricHigh, data.MetricLow, data.MetricClose},
+				data.Daily, [][]float64{highs, lows, closes})
+			Expect(err).NotTo(HaveOccurred())
+
+			ds := &calendarDataSource{currentDate: now, frame: df}
+			uu := universe.NewStaticWithSource([]asset.Asset{aapl}, ds)
+
+			period := 4
+			result := signal.KeltnerChannels(ctx, uu, portfolio.Days(period), 2.0)
+			Expect(result.Err()).NotTo(HaveOccurred())
+
+			// Reference EMA(4): SMA seed over the first 4 closes, then
+			// exponential smoothing over the remaining 8.
+			alpha := 2.0 / float64(period+1)
+			ema := 0.0
+
+			for ii := range period {
+				ema += closes[ii]
+			}
+
+			ema /= float64(period)
+
+			for ii := period; ii < count; ii++ {
+				ema = alpha*closes[ii] + (1-alpha)*ema
+			}
+
+			// Reference Wilder ATR(4) over the 11 true ranges.
+			trValues := make([]float64, count-1)
+			for ii := 1; ii < count; ii++ {
+				highLow := highs[ii] - lows[ii]
+				highPrevClose := math.Abs(highs[ii] - closes[ii-1])
+				lowPrevClose := math.Abs(lows[ii] - closes[ii-1])
+				trValues[ii-1] = math.Max(highLow, math.Max(highPrevClose, lowPrevClose))
+			}
+
+			avgTR := 0.0
+			for ii := range period {
+				avgTR += trValues[ii]
+			}
+
+			avgTR /= float64(period)
+
+			for ii := period; ii < len(trValues); ii++ {
+				avgTR = (avgTR*float64(period-1) + trValues[ii]) / float64(period)
+			}
+
+			Expect(result.Value(aapl, signal.KeltnerMiddleSignal)).To(BeNumerically("~", ema, 1e-10))
+			Expect(result.Value(aapl, signal.KeltnerUpperSignal)).To(BeNumerically("~", ema+2*avgTR, 1e-10))
+			Expect(result.Value(aapl, signal.KeltnerLowerSignal)).To(BeNumerically("~", ema-2*avgTR, 1e-10))
+		})
+	})
+})
+
+var _ = Describe("Pairs signals with mismatched histories", func() {
+	var (
+		ctx  context.Context
+		aapl asset.Asset
+		spy  asset.Asset
+		now  time.Time
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		aapl = asset.Asset{CompositeFigi: "FIGI-AAPL", Ticker: "AAPL"}
+		spy = asset.Asset{CompositeFigi: "FIGI-SPY", Ticker: "SPY"}
+		now = time.Date(2025, 6, 13, 16, 0, 0, 0, time.UTC)
+	})
+
+	buildFrames := func(primaryLen, refLen int) (*data.DataFrame, *data.DataFrame) {
+		times := tradingTimes(now, primaryLen)
+
+		primaryPrices := make([]float64, primaryLen)
+		for ii := range primaryPrices {
+			primaryPrices[ii] = 150 + float64(ii)*0.75 + math.Sin(float64(ii))*2
+		}
+
+		refPrices := make([]float64, refLen)
+		for ii := range refPrices {
+			refPrices[ii] = 100 + float64(ii)*0.5
+		}
+
+		primaryDF, err := data.NewDataFrame(times, []asset.Asset{aapl},
+			[]data.Metric{data.MetricClose}, data.Daily, [][]float64{primaryPrices})
+		Expect(err).NotTo(HaveOccurred())
+
+		refDF, err := data.NewDataFrame(times[primaryLen-refLen:], []asset.Asset{spy},
+			[]data.Metric{data.MetricClose}, data.Daily, [][]float64{refPrices})
+		Expect(err).NotTo(HaveOccurred())
+
+		return primaryDF, refDF
+	}
+
+	It("PairsRatio aligns on common timestamps instead of panicking", func() {
+		primaryDF, refDF := buildFrames(20, 12)
+
+		primaryU := universe.NewStaticWithSource([]asset.Asset{aapl}, &mockDataSource{currentDate: now, fetchResult: primaryDF})
+		refU := universe.NewStaticWithSource([]asset.Asset{spy}, &mockDataSource{currentDate: now, fetchResult: refDF})
+
+		result := signal.PairsRatio(ctx, primaryU, portfolio.Days(19), refU)
+		Expect(result.Err()).NotTo(HaveOccurred())
+		Expect(result.Len()).To(Equal(1))
+
+		zz := result.Value(aapl, "PairsRatio_SPY")
+		Expect(math.IsNaN(zz)).To(BeFalse())
+		Expect(math.IsInf(zz, 0)).To(BeFalse())
+	})
+
+	It("PairsResidual aligns on common timestamps instead of panicking", func() {
+		primaryDF, refDF := buildFrames(20, 12)
+
+		primaryU := universe.NewStaticWithSource([]asset.Asset{aapl}, &mockDataSource{currentDate: now, fetchResult: primaryDF})
+		refU := universe.NewStaticWithSource([]asset.Asset{spy}, &mockDataSource{currentDate: now, fetchResult: refDF})
+
+		result := signal.PairsResidual(ctx, primaryU, portfolio.Days(19), refU)
+		Expect(result.Err()).NotTo(HaveOccurred())
+		Expect(result.Len()).To(Equal(1))
+
+		zz := result.Value(aapl, "PairsResidual_SPY")
+		Expect(math.IsNaN(zz)).To(BeFalse())
+		Expect(math.IsInf(zz, 0)).To(BeFalse())
+	})
+
+	It("returns an error when the frames share no timestamps", func() {
+		times := tradingTimes(now, 10)
+		oldTimes := tradingTimes(now.AddDate(-2, 0, 0), 10)
+
+		prices := make([]float64, 10)
+		for ii := range prices {
+			prices[ii] = 100 + float64(ii)
+		}
+
+		primaryDF, err := data.NewDataFrame(times, []asset.Asset{aapl},
+			[]data.Metric{data.MetricClose}, data.Daily, [][]float64{prices})
+		Expect(err).NotTo(HaveOccurred())
+
+		refDF, err := data.NewDataFrame(oldTimes, []asset.Asset{spy},
+			[]data.Metric{data.MetricClose}, data.Daily, [][]float64{prices})
+		Expect(err).NotTo(HaveOccurred())
+
+		primaryU := universe.NewStaticWithSource([]asset.Asset{aapl}, &mockDataSource{currentDate: now, fetchResult: primaryDF})
+		refU := universe.NewStaticWithSource([]asset.Asset{spy}, &mockDataSource{currentDate: now, fetchResult: refDF})
+
+		ratio := signal.PairsRatio(ctx, primaryU, portfolio.Days(9), refU)
+		Expect(ratio.Err()).To(HaveOccurred())
+		Expect(ratio.Err().Error()).To(ContainSubstring("overlapping"))
+
+		residual := signal.PairsResidual(ctx, primaryU, portfolio.Days(9), refU)
+		Expect(residual.Err()).To(HaveOccurred())
+		Expect(residual.Err().Error()).To(ContainSubstring("overlapping"))
+	})
+})

--- a/signal/helpers.go
+++ b/signal/helpers.go
@@ -16,9 +16,188 @@
 package signal
 
 import (
+	"context"
 	"fmt"
 	"math"
+	"sort"
+	"time"
+
+	"github.com/penny-vault/pvbt/data"
+	"github.com/penny-vault/pvbt/portfolio"
+	"github.com/penny-vault/pvbt/universe"
 )
+
+// barsToCalendarDays converts a required trading-bar count into a calendar-day
+// lookback long enough to contain at least that many trading bars: the 7/5
+// factor covers weekends, bars/20 covers regular market holidays, and the
+// constant absorbs holiday clusters and rounding.
+func barsToCalendarDays(bars int) int {
+	return bars*7/5 + bars/20 + 10
+}
+
+// extendedWindow fetches the caller's period plus extraBars additional trading
+// bars of warm-up history from the universe.
+//
+// Day-unit periods are interpreted as trading-bar counts: the fetch is
+// inflated to enough calendar days to cover weekends and market holidays and
+// the result is trimmed to the last period.N + extraBars bars. Calendar-unit
+// periods (months, years, to-date) keep their span and gain extraBars bars of
+// history before the window start. Intraday periods extend N directly because
+// their bars already count trading time.
+//
+// It returns the trimmed frame together with the number of bars that
+// correspond to the caller's original period, clamped to the rows actually
+// available.
+func extendedWindow(ctx context.Context, assetUniverse universe.Universe, period portfolio.Period, extraBars int, metrics ...data.Metric) (*data.DataFrame, int, error) {
+	ref := assetUniverse.CurrentDate()
+
+	var fetchPeriod portfolio.Period
+
+	switch period.Unit {
+	case portfolio.UnitDay:
+		fetchPeriod = portfolio.Days(barsToCalendarDays(period.N + extraBars))
+	case portfolio.UnitMinuteBar, portfolio.UnitDailyAtTime:
+		fetchPeriod = portfolio.Period{N: period.N + extraBars, Unit: period.Unit, TimeOfDay: period.TimeOfDay}
+	default:
+		spanDays := int(math.Ceil(ref.Sub(period.Before(ref)).Hours() / 24))
+		fetchPeriod = portfolio.Days(spanDays + barsToCalendarDays(extraBars))
+	}
+
+	df, err := assetUniverse.Window(ctx, fetchPeriod, metrics...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	switch period.Unit {
+	case portfolio.UnitDay:
+		df = tailBars(df, period.N+extraBars)
+		return df, min(period.N, df.Len()), nil
+	case portfolio.UnitMinuteBar, portfolio.UnitDailyAtTime:
+		return df, min(period.N, df.Len()), nil
+	default:
+		start := period.Before(ref)
+		startDate := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
+		times := df.Times()
+
+		idx := sort.Search(len(times), func(ii int) bool {
+			return !times[ii].Before(startDate)
+		})
+
+		baseBars := len(times) - idx
+
+		trimIdx := idx - extraBars
+		if trimIdx < 0 {
+			trimIdx = 0
+		}
+
+		if trimIdx > 0 {
+			df = df.Between(times[trimIdx], times[len(times)-1])
+		}
+
+		return df, baseBars, nil
+	}
+}
+
+// tailBars returns df trimmed to at most the last barCount rows.
+func tailBars(df *data.DataFrame, barCount int) *data.DataFrame {
+	if barCount <= 0 || df.Len() <= barCount {
+		return df
+	}
+
+	times := df.Times()
+
+	return df.Between(times[len(times)-barCount], times[len(times)-1])
+}
+
+// alignFrames trims two DataFrames to their common timestamps so that row ii
+// of each frame refers to the same bar. Daily-or-coarser frames are matched
+// on calendar date, finer frames on the exact timestamp. Returns an error
+// when the frames share no timestamps or contain duplicates that prevent a
+// one-to-one alignment.
+func alignFrames(dfA, dfB *data.DataFrame) (*data.DataFrame, *data.DataFrame, error) {
+	daily := dfA.Frequency() >= data.Daily && dfB.Frequency() >= data.Daily
+
+	keyOf := func(tt time.Time) int64 {
+		if daily {
+			return int64(tt.Year())*10000 + int64(tt.Month())*100 + int64(tt.Day())
+		}
+
+		return tt.UnixNano()
+	}
+
+	timesA := dfA.Times()
+	timesB := dfB.Times()
+
+	if len(timesA) == len(timesB) {
+		same := true
+
+		for ii := range timesA {
+			if keyOf(timesA[ii]) != keyOf(timesB[ii]) {
+				same = false
+				break
+			}
+		}
+
+		if same {
+			return dfA, dfB, nil
+		}
+	}
+
+	keysA := make(map[int64]struct{}, len(timesA))
+	for _, tt := range timesA {
+		keysA[keyOf(tt)] = struct{}{}
+	}
+
+	keysB := make(map[int64]struct{}, len(timesB))
+	for _, tt := range timesB {
+		keysB[keyOf(tt)] = struct{}{}
+	}
+
+	alignedA := dfA.Filter(func(tt time.Time, _ *data.DataFrame) bool {
+		_, ok := keysB[keyOf(tt)]
+		return ok
+	})
+
+	alignedB := dfB.Filter(func(tt time.Time, _ *data.DataFrame) bool {
+		_, ok := keysA[keyOf(tt)]
+		return ok
+	})
+
+	if alignedA.Len() == 0 || alignedB.Len() == 0 {
+		return nil, nil, fmt.Errorf("no overlapping timestamps between the two data sets")
+	}
+
+	if alignedA.Len() != alignedB.Len() {
+		return nil, nil, fmt.Errorf("cannot align data sets: duplicate timestamps (%d vs %d overlapping rows)", alignedA.Len(), alignedB.Len())
+	}
+
+	return alignedA, alignedB, nil
+}
+
+// populationStd computes the population (N denominator) standard deviation of
+// values. Returns NaN for an empty slice.
+func populationStd(values []float64) float64 {
+	nn := len(values)
+	if nn == 0 {
+		return math.NaN()
+	}
+
+	sum := 0.0
+	for _, vv := range values {
+		sum += vv
+	}
+
+	mean := sum / float64(nn)
+
+	sumSq := 0.0
+
+	for _, vv := range values {
+		diff := vv - mean
+		sumSq += diff * diff
+	}
+
+	return math.Sqrt(sumSq / float64(nn))
+}
 
 // zScore computes the z-score of the last element in values relative to the
 // mean and standard deviation of the full slice. Returns an error if the

--- a/signal/keltner.go
+++ b/signal/keltner.go
@@ -36,10 +36,12 @@ const (
 )
 
 // KeltnerChannels computes the Keltner Channels (upper, middle, lower) for
-// each asset in the universe over the given period. The center line is an EMA
-// of the price metric (defaults to Close). Bands are placed at +/- atrMultiplier
-// times the ATR. Returns a single-row DataFrame with KeltnerUpperSignal,
-// KeltnerMiddleSignal, KeltnerLowerSignal.
+// each asset in the universe over the given period. The center line is a
+// period.N-bar EMA of the price metric (defaults to Close). Bands are placed
+// at +/- atrMultiplier times the period.N-bar Wilder ATR. Extra warm-up bars
+// are fetched (over-fetching calendar days to cover weekends and holidays) so
+// the EMA and Wilder smoothing run past their SMA seeds. Returns a single-row
+// DataFrame with KeltnerUpperSignal, KeltnerMiddleSignal, KeltnerLowerSignal.
 func KeltnerChannels(ctx context.Context, assetUniverse universe.Universe, period portfolio.Period, atrMultiplier float64, metrics ...data.Metric) *data.DataFrame {
 	metric := data.MetricClose
 	if len(metrics) > 0 {
@@ -52,7 +54,10 @@ func KeltnerChannels(ctx context.Context, assetUniverse universe.Universe, perio
 		fetchMetrics = append(fetchMetrics, metric)
 	}
 
-	df, err := assetUniverse.Window(ctx, period, fetchMetrics...)
+	// Fetch two extra periods (plus the +1 bar needed for the first true
+	// range) of warm-up history so the EMA and Wilder smoothing converge
+	// past their SMA seeds.
+	df, baseBars, err := extendedWindow(ctx, assetUniverse, period, 2*period.N+1, fetchMetrics...)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("KeltnerChannels: %w", err))
 	}
@@ -62,14 +67,20 @@ func KeltnerChannels(ctx context.Context, assetUniverse universe.Universe, perio
 		return data.WithErr(fmt.Errorf("KeltnerChannels: need at least 2 data points, got %d", numRows))
 	}
 
+	// Clamp the windows when history is shorter than requested.
+	emaWindow := min(baseBars, numRows)
+
+	atrPeriod := min(baseBars, numRows-1)
+	if atrPeriod < 1 {
+		return data.WithErr(fmt.Errorf("KeltnerChannels: period must cover at least 1 bar, got %d", atrPeriod))
+	}
+
 	// Compute EMA of the price metric for the center line.
 	// Filter to only the price metric before EMA to avoid extra High/Low columns.
-	windowSize := numRows
-	emaDF := df.Metrics(metric).Rolling(windowSize).EMA()
+	emaDF := df.Metrics(metric).Rolling(emaWindow).EMA()
 	centerLine := emaDF.Last().RenameMetric(metric, KeltnerMiddleSignal)
 
 	// Compute ATR inline (same logic as signal.ATR to avoid redundant data fetch).
-	atrPeriod := numRows - 1
 	assets := df.AssetList()
 	times := df.Times()
 	lastTime := []time.Time{times[len(times)-1]}
@@ -95,6 +106,11 @@ func KeltnerChannels(ctx context.Context, assetUniverse universe.Universe, perio
 		}
 
 		avgTR /= float64(atrPeriod)
+
+		// Apply Wilder's smoothing for additional rows.
+		for kk := atrPeriod; kk < len(trValues); kk++ {
+			avgTR = (avgTR*float64(atrPeriod-1) + trValues[kk]) / float64(atrPeriod)
+		}
 
 		atrCols[ii] = []float64{avgTR}
 	}

--- a/signal/keltner_test.go
+++ b/signal/keltner_test.go
@@ -31,17 +31,19 @@ var _ = Describe("KeltnerChannels", func() {
 	})
 
 	It("computes hand-calculated Keltner Channels for multiple assets", func() {
+		// period=4 with 5 bars available: EMA window = 4, atrPeriod = 4.
+		//
 		// AAPL: Close=[100,102,101,104,103], High=[101,103,102,105,104], Low=[99,101,100,103,102]
-		//   EMA(5) of Close: seed = SMA = (100+102+101+104+103)/5 = 102.0
-		//   Only 5 points so EMA = 102.0
+		//   EMA(4) of Close (alpha=2/5): seed = SMA(100,102,101,104) = 101.75
+		//   idx 4: 0.4*103 + 0.6*101.75 = 102.25
 		//   TR from row 1: [3, 2, 4, 2], atrPeriod=4, ATR = (3+2+4+2)/4 = 2.75
-		//   Upper = 102.0 + 2*2.75 = 107.5, Lower = 102.0 - 2*2.75 = 96.5
+		//   Upper = 102.25 + 2*2.75 = 107.75, Lower = 102.25 - 2*2.75 = 96.75
 		//
 		// GOOG: Close=[200,204,202,208,206], High=[202,206,204,210,208], Low=[198,202,200,206,204]
-		//   EMA(5) of Close: seed = SMA = (200+204+202+208+206)/5 = 204.0
-		//   Only 5 points so EMA = 204.0
+		//   EMA(4) of Close (alpha=2/5): seed = SMA(200,204,202,208) = 203.5
+		//   idx 4: 0.4*206 + 0.6*203.5 = 204.5
 		//   TR from row 1: [6, 4, 8, 4], atrPeriod=4, ATR = (6+4+8+4)/4 = 5.5
-		//   Upper = 204.0 + 2*5.5 = 215.0, Lower = 204.0 - 2*5.5 = 193.0
+		//   Upper = 204.5 + 2*5.5 = 215.5, Lower = 204.5 - 2*5.5 = 193.5
 		times := make([]time.Time, 5)
 		for ii := range times {
 			times[ii] = now.AddDate(0, 0, ii-4)
@@ -71,21 +73,21 @@ var _ = Describe("KeltnerChannels", func() {
 			signal.KeltnerLowerSignal,
 		))
 
-		Expect(result.Value(aapl, signal.KeltnerMiddleSignal)).To(BeNumerically("~", 102.0, 1e-10))
-		Expect(result.Value(aapl, signal.KeltnerUpperSignal)).To(BeNumerically("~", 107.5, 1e-10))
-		Expect(result.Value(aapl, signal.KeltnerLowerSignal)).To(BeNumerically("~", 96.5, 1e-10))
+		Expect(result.Value(aapl, signal.KeltnerMiddleSignal)).To(BeNumerically("~", 102.25, 1e-10))
+		Expect(result.Value(aapl, signal.KeltnerUpperSignal)).To(BeNumerically("~", 107.75, 1e-10))
+		Expect(result.Value(aapl, signal.KeltnerLowerSignal)).To(BeNumerically("~", 96.75, 1e-10))
 
-		Expect(result.Value(goog, signal.KeltnerMiddleSignal)).To(BeNumerically("~", 204.0, 1e-10))
-		Expect(result.Value(goog, signal.KeltnerUpperSignal)).To(BeNumerically("~", 215.0, 1e-10))
-		Expect(result.Value(goog, signal.KeltnerLowerSignal)).To(BeNumerically("~", 193.0, 1e-10))
+		Expect(result.Value(goog, signal.KeltnerMiddleSignal)).To(BeNumerically("~", 204.5, 1e-10))
+		Expect(result.Value(goog, signal.KeltnerUpperSignal)).To(BeNumerically("~", 215.5, 1e-10))
+		Expect(result.Value(goog, signal.KeltnerLowerSignal)).To(BeNumerically("~", 193.5, 1e-10))
 	})
 
 	It("uses custom metric for center line when provided", func() {
 		// Use AdjClose instead of Close for the EMA center line.
 		// ATR still uses High/Low/Close.
 		// AdjClose=[90,92,91,94,93] differs from Close=[100,102,101,104,103].
-		// EMA(5) of AdjClose: SMA seed = (90+92+91+94+93)/5 = 92.0.
-		// Only 5 points so EMA = 92.0.
+		// EMA(4) of AdjClose (alpha=2/5): seed = SMA(90,92,91,94) = 91.75.
+		// idx 4: 0.4*93 + 0.6*91.75 = 92.25.
 		adjCloses := []float64{90, 92, 91, 94, 93}
 		closes := []float64{100, 102, 101, 104, 103}
 		highs := []float64{101, 103, 102, 105, 104}
@@ -106,8 +108,8 @@ var _ = Describe("KeltnerChannels", func() {
 
 		result := signal.KeltnerChannels(ctx, uu, portfolio.Days(4), 2.0, data.AdjClose)
 		Expect(result.Err()).NotTo(HaveOccurred())
-		// Center line must reflect AdjClose EMA (92.0), not Close EMA (102.0).
-		Expect(result.Value(aapl, signal.KeltnerMiddleSignal)).To(BeNumerically("~", 92.0, 1e-10))
+		// Center line must reflect AdjClose EMA (92.25), not Close EMA (102.25).
+		Expect(result.Value(aapl, signal.KeltnerMiddleSignal)).To(BeNumerically("~", 92.25, 1e-10))
 	})
 
 	It("returns error on degenerate window (fewer than 2 rows)", func() {

--- a/signal/macd.go
+++ b/signal/macd.go
@@ -35,16 +35,23 @@ const (
 )
 
 // MACD computes the Moving Average Convergence/Divergence indicator for each
-// asset in the universe. It returns a single-row DataFrame with three metrics:
-// MACDLineSignal (fast EMA - slow EMA), MACDSignalLineSignal (EMA of MACD
-// line), and MACDHistogramSignal (MACD line - signal line).
+// asset in the universe. It fetches slow.N + signalPeriod.N - 1 trading bars
+// (over-fetching calendar days to cover weekends and holidays) so the slow
+// EMA warm-up leaves enough MACD points to seed the signal line. It returns
+// a single-row DataFrame with three metrics: MACDLineSignal (fast EMA - slow
+// EMA), MACDSignalLineSignal (EMA of MACD line), and MACDHistogramSignal
+// (MACD line - signal line).
 func MACD(ctx context.Context, assetUniverse universe.Universe, fast, slow, signalPeriod portfolio.Period, metrics ...data.Metric) *data.DataFrame {
 	metric := data.MetricClose
 	if len(metrics) > 0 {
 		metric = metrics[0]
 	}
 
-	df, err := assetUniverse.Window(ctx, slow, metric)
+	if fast.N < 1 || slow.N < 1 || signalPeriod.N < 1 {
+		return data.WithErr(fmt.Errorf("MACD: fast, slow, and signal periods must each cover at least 1 bar"))
+	}
+
+	df, _, err := extendedWindow(ctx, assetUniverse, slow, signalPeriod.N-1, metric)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("MACD: %w", err))
 	}
@@ -53,15 +60,16 @@ func MACD(ctx context.Context, assetUniverse universe.Universe, fast, slow, sign
 		return data.WithErr(fmt.Errorf("MACD: need at least 2 data points, got %d", df.Len()))
 	}
 
-	fastWindow := fast.N
-	slowWindow := slow.N
-	sigWindow := signalPeriod.N
+	// Clamp windows when the available history is shorter than requested.
+	fastWindow := min(fast.N, df.Len())
+	slowWindow := min(slow.N, df.Len())
 
 	fastEMA := df.Rolling(fastWindow).EMA()
 	slowEMA := df.Rolling(slowWindow).EMA()
 
 	// Drop NaN rows so the signal line EMA gets a clean seed.
 	macdLine := fastEMA.Sub(slowEMA).Drop(math.NaN())
+	sigWindow := min(signalPeriod.N, macdLine.Len())
 	signalLine := macdLine.Rolling(sigWindow).EMA()
 	histogram := macdLine.Sub(signalLine)
 

--- a/signal/mfi.go
+++ b/signal/mfi.go
@@ -33,13 +33,13 @@ const MFISignal data.Metric = "MFI"
 // MFI computes the Money Flow Index for each asset in the universe over the
 // given period. It compares positive and negative money flow (typical price
 // times volume) to produce a momentum oscillator. One extra bar is fetched to
-// establish the initial typical price for comparison. Returns a single-row
-// DataFrame with [MFISignal].
+// establish the initial typical price for comparison; the period's unit is
+// preserved, so day-unit periods count trading bars and calendar-unit periods
+// (months, years) keep their span. Returns a single-row DataFrame with
+// [MFISignal].
 func MFI(ctx context.Context, assetUniverse universe.Universe, period portfolio.Period) *data.DataFrame {
 	// Fetch one extra bar so bar 0 serves as the TP baseline for comparison.
-	adjustedPeriod := portfolio.Days(period.N + 1)
-
-	df, err := assetUniverse.Window(ctx, adjustedPeriod, data.MetricHigh, data.MetricLow, data.MetricClose, data.Volume)
+	df, _, err := extendedWindow(ctx, assetUniverse, period, 1, data.MetricHigh, data.MetricLow, data.MetricClose, data.Volume)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("MFI: %w", err))
 	}

--- a/signal/pairs_ratio.go
+++ b/signal/pairs_ratio.go
@@ -48,6 +48,14 @@ func PairsRatio(ctx context.Context, assetUniverse universe.Universe, period por
 		return data.WithErr(fmt.Errorf("PairsRatio: reference fetch: %w", err))
 	}
 
+	// The primary and reference universes may have different histories;
+	// align both frames on their common timestamps so ratios compare prices
+	// from the same bar.
+	primaryDF, refDF, err = alignFrames(primaryDF, refDF)
+	if err != nil {
+		return data.WithErr(fmt.Errorf("PairsRatio: %w", err))
+	}
+
 	numRows := primaryDF.Len()
 	if numRows < 2 {
 		return data.WithErr(fmt.Errorf("PairsRatio: need at least 2 data points, got %d", numRows))

--- a/signal/pairs_residual.go
+++ b/signal/pairs_residual.go
@@ -48,6 +48,14 @@ func PairsResidual(ctx context.Context, assetUniverse universe.Universe, period 
 		return data.WithErr(fmt.Errorf("PairsResidual: reference fetch: %w", err))
 	}
 
+	// The primary and reference universes may have different histories;
+	// align both frames on their common timestamps so the regression pairs
+	// returns from the same bar.
+	primaryDF, refDF, err = alignFrames(primaryDF, refDF)
+	if err != nil {
+		return data.WithErr(fmt.Errorf("PairsResidual: %w", err))
+	}
+
 	numRows := primaryDF.Len()
 	if numRows < 3 {
 		return data.WithErr(fmt.Errorf("PairsResidual: need at least 3 data points, got %d", numRows))

--- a/signal/rsi.go
+++ b/signal/rsi.go
@@ -29,16 +29,21 @@ import (
 const RSISignal data.Metric = "RSI"
 
 // RSI computes the Relative Strength Index for each asset in the universe
-// using Wilder's smoothing method. The period controls the lookback window;
-// rsiPeriod = period.N - 1 price changes are used. Returns a single-row
-// DataFrame with RSISignal metric.
+// using Wilder's smoothing method. The period controls the smoothing length:
+// the seed average covers the first period.N price changes and Wilder's
+// smoothing runs over the remaining fetched history. Extra warm-up bars are
+// fetched (over-fetching calendar days to cover weekends and holidays) so the
+// smoothing has data to run on. Returns a single-row DataFrame with RSISignal
+// metric.
 func RSI(ctx context.Context, assetUniverse universe.Universe, period portfolio.Period, metrics ...data.Metric) *data.DataFrame {
 	metric := data.MetricClose
 	if len(metrics) > 0 {
 		metric = metrics[0]
 	}
 
-	df, err := assetUniverse.Window(ctx, period, metric)
+	// Fetch two extra periods (plus the +1 bar needed for the first change)
+	// of warm-up history so Wilder's smoothing converges past its SMA seed.
+	df, baseBars, err := extendedWindow(ctx, assetUniverse, period, 2*period.N+1, metric)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("RSI: %w", err))
 	}
@@ -47,7 +52,11 @@ func RSI(ctx context.Context, assetUniverse universe.Universe, period portfolio.
 		return data.WithErr(fmt.Errorf("RSI: need at least 3 data points, got %d", df.Len()))
 	}
 
-	rsiPeriod := df.Len() - 1
+	// Clamp the smoothing period when history is shorter than requested.
+	rsiPeriod := min(baseBars, df.Len()-1)
+	if rsiPeriod < 1 {
+		return data.WithErr(fmt.Errorf("RSI: period must cover at least 1 bar, got %d", rsiPeriod))
+	}
 
 	result := df.Diff().Apply(func(changes []float64) []float64 {
 		out := make([]float64, len(changes))
@@ -68,10 +77,6 @@ func RSI(ctx context.Context, assetUniverse universe.Universe, period portfolio.
 				gains = append(gains, 0)
 				losses = append(losses, -changes[ii])
 			}
-		}
-
-		if len(gains) < rsiPeriod {
-			return out
 		}
 
 		// Initial average gain/loss: SMA of first rsiPeriod values.

--- a/signal/stochastic.go
+++ b/signal/stochastic.go
@@ -50,23 +50,32 @@ const stochasticDPeriod = 3
 // StochasticFast computes the Fast Stochastic Oscillator for each asset in
 // the universe. %K measures where the close sits relative to the high-low
 // range over the period; %D is a 3-period SMA of %K. The function fetches
-// period.N + 2 total bars to compute the %D smoothing. Returns a single-row
+// period.N + 2 total trading bars (over-fetching calendar days to cover
+// weekends and holidays) to compute the %D smoothing. Returns a single-row
 // DataFrame with [StochasticKSignal] and [StochasticDSignal].
 func StochasticFast(ctx context.Context, assetUniverse universe.Universe, period portfolio.Period) *data.DataFrame {
 	// Need period.N + 2 total bars: period.N bars per %K window, sliding
 	// 3 times to get 3 %K values for the %D SMA.
-	adjustedPeriod := portfolio.Days(period.N + stochasticDPeriod - 1)
-
-	df, err := assetUniverse.Window(ctx, adjustedPeriod, data.MetricHigh, data.MetricLow, data.MetricClose)
+	df, kWindow, err := extendedWindow(ctx, assetUniverse, period, stochasticDPeriod-1, data.MetricHigh, data.MetricLow, data.MetricClose)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("StochasticFast: %w", err))
 	}
 
 	numRows := df.Len()
 
-	minRows := period.N + stochasticDPeriod - 1
+	minRows := stochasticDPeriod + 1
 	if numRows < minRows {
 		return data.WithErr(fmt.Errorf("StochasticFast: need at least %d data points, got %d", minRows, numRows))
+	}
+
+	// Clamp the %K window so 3 %K values remain for the %D SMA when the
+	// available history is shorter than requested.
+	if maxK := numRows - stochasticDPeriod + 1; kWindow > maxK {
+		kWindow = maxK
+	}
+
+	if kWindow < 1 {
+		return data.WithErr(fmt.Errorf("StochasticFast: period must cover at least 1 bar, got %d", kWindow))
 	}
 
 	assets := df.AssetList()
@@ -81,7 +90,7 @@ func StochasticFast(ctx context.Context, assetUniverse universe.Universe, period
 		lows := df.Column(aa, data.MetricLow)
 		closes := df.Column(aa, data.MetricClose)
 
-		kValues := stochasticKSeries(highs, lows, closes, period.N)
+		kValues := stochasticKSeries(highs, lows, closes, kWindow)
 
 		lastK := kValues[len(kValues)-1]
 
@@ -131,24 +140,34 @@ func StochasticFast(ctx context.Context, assetUniverse universe.Universe, period
 // StochasticSlow computes the Slow Stochastic Oscillator for each asset in
 // the universe. Slow %K is an SMA of the raw %K over the smoothing period;
 // Slow %D is a 3-period SMA of Slow %K. The function fetches
-// period.N + smoothing.N + 1 bars to compute the required values. Returns a
+// period.N + smoothing.N + 1 total trading bars (over-fetching calendar days
+// to cover weekends and holidays) to compute the required values. Returns a
 // single-row DataFrame with [StochasticSlowKSignal] and [StochasticSlowDSignal].
 func StochasticSlow(ctx context.Context, assetUniverse universe.Universe, period, smoothing portfolio.Period) *data.DataFrame {
 	// Need enough bars for: period.N per raw %K window, smoothing.N raw %K
 	// values for each Slow %K, and 3 Slow %K values for %D.
-	adjustedN := period.N + smoothing.N + stochasticDPeriod - 2
-	adjustedPeriod := portfolio.Days(adjustedN)
+	warmupBars := smoothing.N + stochasticDPeriod - 2
 
-	df, err := assetUniverse.Window(ctx, adjustedPeriod, data.MetricHigh, data.MetricLow, data.MetricClose)
+	df, kWindow, err := extendedWindow(ctx, assetUniverse, period, warmupBars, data.MetricHigh, data.MetricLow, data.MetricClose)
 	if err != nil {
 		return data.WithErr(fmt.Errorf("StochasticSlow: %w", err))
 	}
 
 	numRows := df.Len()
 
-	minRows := period.N + smoothing.N + stochasticDPeriod - 2
+	minRows := warmupBars + 2
 	if numRows < minRows {
 		return data.WithErr(fmt.Errorf("StochasticSlow: need at least %d data points, got %d", minRows, numRows))
+	}
+
+	// Clamp the %K window so enough raw %K values remain for the Slow %K
+	// smoothing and the %D SMA when history is shorter than requested.
+	if maxK := numRows - warmupBars; kWindow > maxK {
+		kWindow = maxK
+	}
+
+	if kWindow < 1 {
+		return data.WithErr(fmt.Errorf("StochasticSlow: period must cover at least 1 bar, got %d", kWindow))
 	}
 
 	assets := df.AssetList()
@@ -163,7 +182,7 @@ func StochasticSlow(ctx context.Context, assetUniverse universe.Universe, period
 		lows := df.Column(aa, data.MetricLow)
 		closes := df.Column(aa, data.MetricClose)
 
-		rawK := stochasticKSeries(highs, lows, closes, period.N)
+		rawK := stochasticKSeries(highs, lows, closes, kWindow)
 
 		// Slow %K = SMA of raw %K over smoothing window.
 		numSlowK := len(rawK) - smoothing.N + 1

--- a/study/bayesian.go
+++ b/study/bayesian.go
@@ -178,18 +178,27 @@ func (bs *bayesianStrategy) generateRandomBatch(count int) []RunConfig {
 func (bs *bayesianStrategy) generateGuidedSamples(scores []CombinationScore) ([]RunConfig, error) {
 	dims := len(bs.sweeps)
 
-	// Encode observed points into normalized [0,1] space.
-	xTrain := make([][]float64, len(scores))
-	yTrain := make([]float64, len(scores))
+	// Encode observed points into normalized [0,1] space. NaN scores (failed
+	// runs or undefined metrics) must be excluded or they poison the GP fit.
+	xTrain := make([][]float64, 0, len(scores))
+	yTrain := make([]float64, 0, len(scores))
 	bestScore := math.Inf(-1)
 
-	for ii, sc := range scores {
-		xTrain[ii] = bs.encode(sc)
-		yTrain[ii] = sc.Score
+	for _, sc := range scores {
+		if math.IsNaN(sc.Score) {
+			continue
+		}
+
+		xTrain = append(xTrain, bs.encode(sc))
+		yTrain = append(yTrain, sc.Score)
 
 		if sc.Score > bestScore {
 			bestScore = sc.Score
 		}
+	}
+
+	if len(xTrain) == 0 {
+		return nil, fmt.Errorf("bayesian guided samples: no valid (non-NaN) scores to fit GP")
 	}
 
 	// Fit GP surrogate model.

--- a/study/runner.go
+++ b/study/runner.go
@@ -230,7 +230,9 @@ func (runner *Runner) runSearch(ctx context.Context, baseConfigs []RunConfig, wo
 			allResults = append(allResults, batchResults...)
 
 			// Score each combination by grouping results by _combination_id.
-			scores = runner.scoreBatch(combos, batchResults, origins, combinationID-len(combos))
+			// Accumulate across batches: SearchStrategy.Next expects all
+			// previously scored combinations, not just the latest batch.
+			scores = append(scores, runner.scoreBatch(combos, batchResults, origins, combinationID-len(combos))...)
 
 			batchIdx++
 

--- a/study/split.go
+++ b/study/split.go
@@ -161,6 +161,13 @@ func KFold(start, end time.Time, folds int) ([]Split, error) {
 // step and expands the training window accordingly. It returns an error if
 // minTrain+testLen exceeds end-start.
 func WalkForward(start, end time.Time, minTrain, testLen, step time.Duration) ([]Split, error) {
+	if minTrain <= 0 || testLen <= 0 || step <= 0 {
+		return nil, fmt.Errorf(
+			"walk-forward: minTrain (%v), testLen (%v), and step (%v) must all be positive",
+			minTrain, testLen, step,
+		)
+	}
+
 	totalDur := end.Sub(start)
 	if minTrain+testLen > totalDur {
 		return nil, fmt.Errorf(

--- a/study/stress/analyze.go
+++ b/study/stress/analyze.go
@@ -208,6 +208,13 @@ func buildRankings(analyses []runAnalysis) []scenarioRanking {
 
 	for _, analysis := range analyses {
 		for _, scenarioResult := range analysis.scenarios {
+			// Skip scenarios the equity curve doesn't cover: their zero-value
+			// metrics would masquerade as real flat results. Errored runs are
+			// kept so the failure stays visible in the rankings.
+			if !scenarioResult.hasData && analysis.errMsg == "" {
+				continue
+			}
+
 			rankings = append(rankings, scenarioRanking{
 				RunName:      analysis.runName,
 				ScenarioName: scenarioResult.scenarioName,

--- a/study/sweep.go
+++ b/study/sweep.go
@@ -55,9 +55,24 @@ func (ps ParamSweep) Max() string { return ps.max }
 func SweepRange[T Numeric](field string, min, max, step T) ParamSweep {
 	var values []string
 
+	if step <= 0 {
+		// A non-positive step would loop forever; degrade to the single min value.
+		if min <= max {
+			values = append(values, fmt.Sprintf("%v", min))
+		}
+
+		return ParamSweep{field: field, values: values, min: fmt.Sprintf("%v", min), max: fmt.Sprintf("%v", max)}
+	}
+
 	for ii := 0; ; ii++ {
 		val := min + T(ii)*step
 		if val > max {
+			// Include max when floating-point rounding pushes the final grid
+			// point slightly past it (e.g. 3*0.1 > 0.3).
+			if float64(val)-float64(max) < float64(step)*1e-9 {
+				values = append(values, fmt.Sprintf("%v", max))
+			}
+
 			break
 		}
 
@@ -70,6 +85,16 @@ func SweepRange[T Numeric](field string, min, max, step T) ParamSweep {
 // SweepDuration generates duration values from min to max with the given step.
 func SweepDuration(field string, min, max, step time.Duration) ParamSweep {
 	var values []string
+
+	if step <= 0 {
+		// A non-positive step would loop forever; degrade to the single min value.
+		if min <= max {
+			values = append(values, min.String())
+		}
+
+		return ParamSweep{field: field, values: values, min: min.String(), max: max.String()}
+	}
+
 	for val := min; val <= max; val += step {
 		values = append(values, val.String())
 	}

--- a/tradecron/market_status.go
+++ b/tradecron/market_status.go
@@ -83,6 +83,8 @@ func (ms *MarketStatus) EarlyClose(checkTime time.Time) int {
 
 	requireHolidays()
 
+	checkTime = checkTime.In(ms.tz)
+
 	d := time.Date(checkTime.Year(), checkTime.Month(), checkTime.Day(), 0, 0, 0, 0, ms.tz)
 	if marketClose, ok := holidays[d.Unix()]; ok {
 		return marketClose
@@ -98,6 +100,8 @@ func (ms *MarketStatus) IsMarketHoliday(checkTime time.Time) bool {
 
 	requireHolidays()
 
+	checkTime = checkTime.In(ms.tz)
+
 	d := time.Date(checkTime.Year(), checkTime.Month(), checkTime.Day(), 0, 0, 0, 0, ms.tz)
 
 	marketHoliday, isHoliday := holidays[d.Unix()]
@@ -110,8 +114,11 @@ func (ms *MarketStatus) IsMarketHoliday(checkTime time.Time) bool {
 }
 
 // IsMarketOpen returns true if the specified time is during market hours
-// (i.e. not a market holiday or weekend)
+// (i.e. not a market holiday or weekend). The time is evaluated in the
+// market's timezone regardless of the input's location.
 func (ms *MarketStatus) IsMarketOpen(checkTime time.Time) bool {
+	checkTime = checkTime.In(ms.tz)
+
 	if !ms.IsMarketDay(checkTime) {
 		return false
 	}
@@ -135,8 +142,11 @@ func (ms *MarketStatus) IsMarketOpen(checkTime time.Time) bool {
 }
 
 // IsMarketDay returns true if the specified date is a valid trading day
-// (i.e. not a market holiday or weekend)
+// (i.e. not a market holiday or weekend). The date is evaluated in the
+// market's timezone regardless of the input's location.
 func (ms *MarketStatus) IsMarketDay(checkTime time.Time) bool {
+	checkTime = checkTime.In(ms.tz)
+
 	if checkTime.Weekday() == time.Saturday || checkTime.Weekday() == time.Sunday {
 		return false
 	}

--- a/tradecron/tradecron.go
+++ b/tradecron/tradecron.go
@@ -240,6 +240,8 @@ func New(cronSpec string, hours MarketHours) (*TradeCron, error) {
 // on a trading day according to the schedule. The time portion of the schedule is ignored when
 // evaluating this function.
 func (tc *TradeCron) IsTradeDay(forDate time.Time) bool {
+	forDate = forDate.In(tc.marketStatus.tz)
+
 	startOfDay := time.Date(forDate.Year(), forDate.Month(), forDate.Day(), 0, 0, 0, 0, tc.marketStatus.tz)
 	previousDay := startOfDay.AddDate(0, 0, -1)
 	previousDay = time.Date(previousDay.Year(), previousDay.Month(), previousDay.Day(), 23, 59, 59, 999_999_999, tc.marketStatus.tz)
@@ -251,6 +253,11 @@ func (tc *TradeCron) IsTradeDay(forDate time.Time) bool {
 
 // Next returns the next tradeable date.
 func (tc *TradeCron) Next(forDate time.Time) time.Time {
+	// Normalize to the market timezone: all schedule arithmetic below
+	// (time-of-day comparisons, calendar-day boundaries) is defined in
+	// market time, not the caller's wall clock.
+	forDate = forDate.In(tc.marketStatus.tz)
+
 	var checkDate time.Time
 
 	nextDate := tc.Schedule.Next(forDate)
@@ -294,6 +301,15 @@ func (tc *TradeCron) Next(forDate time.Time) time.Time {
 		dateOnly := time.Date(forDate.Year(), forDate.Month(), forDate.Day(), 0, 0, 0, 0, tc.marketStatus.tz)
 		if firstTradingDayOfThisMonth.After(dateOnly) || firstTradingDayOfThisMonth.Equal(dateOnly) {
 			checkDate = firstTradingDayOfThisMonth
+
+			// When forDate falls on the first trading day itself, the
+			// scheduled firing may already have passed (sequential
+			// iteration calls Next with lastFire+1ns); advance to the
+			// next month rather than firing again the following day.
+			firstTradingDay := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), nextDate.Hour(), nextDate.Minute(), nextDate.Second(), nextDate.Nanosecond(), nextDate.Location())
+			if nextDate.After(firstTradingDay) {
+				checkDate = tc.marketStatus.NextFirstTradingDayOfMonth(forDate)
+			}
 		} else {
 			checkDate = tc.marketStatus.NextFirstTradingDayOfMonth(forDate)
 
@@ -330,6 +346,17 @@ func (tc *TradeCron) Next(forDate time.Time) time.Time {
 		dateOnly := time.Date(forDate.Year(), forDate.Month(), forDate.Day(), 0, 0, 0, 0, tc.marketStatus.tz)
 		if firstTradingDayOfThisQuarter.After(dateOnly) || firstTradingDayOfThisQuarter.Equal(dateOnly) {
 			checkDate = firstTradingDayOfThisQuarter
+
+			// Same already-fired guard as AtMonthBegin: a forDate on the
+			// quarter's first trading day after the firing time must
+			// advance to the next quarter, not the next trading day.
+			firstTradingDay := time.Date(checkDate.Year(), checkDate.Month(), checkDate.Day(), nextDate.Hour(), nextDate.Minute(), nextDate.Second(), nextDate.Nanosecond(), nextDate.Location())
+			if nextDate.After(firstTradingDay) {
+				nextQ := nextQuarterFirstMonth(forDate)
+				checkDate = tc.marketStatus.NextFirstTradingDayOfMonth(
+					time.Date(nextQ.Year(), nextQ.Month(), 1, 23, 59, 59, 999_999_999, tc.marketStatus.tz).AddDate(0, 0, -1),
+				)
+			}
 		} else {
 			nextQuarterStart := nextQuarterFirstMonth(forDate)
 			checkDate = tc.marketStatus.NextFirstTradingDayOfMonth(

--- a/tradecron/tradecron_test.go
+++ b/tradecron/tradecron_test.go
@@ -125,6 +125,100 @@ var _ = Describe("TradeCron", func() {
 		})
 	})
 
+	Describe("@monthbegin sequential iteration", func() {
+		BeforeEach(func() {
+			tradecron.SetMarketHolidays(nil)
+		})
+
+		It("advances to next month once the current month-begin firing has passed", func() {
+			tc, err := tradecron.New("@monthbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Jun 1, 2025 is a Sunday; the first trading day is Mon Jun 2.
+			// The engine iterates Next(lastFire + 1ns) after each firing.
+			fired := time.Date(2025, time.June, 2, 9, 30, 0, 0, nyc)
+			got := tc.Next(fired.Add(time.Nanosecond))
+
+			// The next firing is July's first trading day (Tue Jul 1),
+			// NOT the next trading day of June.
+			want := time.Date(2025, time.July, 1, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("reports only the month's first trading day as a trade day", func() {
+			tc, err := tradecron.New("@monthbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Mon Jun 2, 2025 is the first trading day of June.
+			Expect(tc.IsTradeDay(time.Date(2025, time.June, 2, 0, 0, 0, 0, nyc))).To(BeTrue())
+			// Tue Jun 3 must not fire.
+			Expect(tc.IsTradeDay(time.Date(2025, time.June, 3, 0, 0, 0, 0, nyc))).To(BeFalse())
+		})
+	})
+
+	Describe("@quarterbegin sequential iteration", func() {
+		BeforeEach(func() {
+			tradecron.SetMarketHolidays(nil)
+		})
+
+		It("advances to next quarter once the current quarter-begin firing has passed", func() {
+			tc, err := tradecron.New("@quarterbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Tue Apr 1, 2025 is the first trading day of Q2.
+			fired := time.Date(2025, time.April, 1, 9, 30, 0, 0, nyc)
+			got := tc.Next(fired.Add(time.Nanosecond))
+
+			// Next firing is Q3's first trading day (Tue Jul 1), NOT Apr 2.
+			want := time.Date(2025, time.July, 1, 9, 30, 0, 0, nyc)
+			Expect(got).To(Equal(want))
+		})
+
+		It("reports only the quarter's first trading day as a trade day", func() {
+			tc, err := tradecron.New("@quarterbegin", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tc.IsTradeDay(time.Date(2025, time.April, 1, 0, 0, 0, 0, nyc))).To(BeTrue())
+			Expect(tc.IsTradeDay(time.Date(2025, time.April, 2, 0, 0, 0, 0, nyc))).To(BeFalse())
+		})
+	})
+
+	Describe("timezone normalization", func() {
+		BeforeEach(func() {
+			tradecron.SetMarketHolidays(nil)
+		})
+
+		It("evaluates market hours in Eastern time regardless of the input zone", func() {
+			status := tradecron.NewMarketStatus(&tradecron.RegularHours)
+
+			// Mon Jun 2, 2025 18:00 UTC == 14:00 ET -- market is open.
+			Expect(status.IsMarketOpen(time.Date(2025, time.June, 2, 18, 0, 0, 0, time.UTC))).To(BeTrue())
+			// Mon Jun 2, 2025 12:00 UTC == 08:00 ET -- before the open.
+			Expect(status.IsMarketOpen(time.Date(2025, time.June, 2, 12, 0, 0, 0, time.UTC))).To(BeFalse())
+		})
+
+		It("evaluates the trading calendar in Eastern time regardless of the input zone", func() {
+			status := tradecron.NewMarketStatus(&tradecron.RegularHours)
+
+			// Sat Jun 7, 2025 01:00 UTC == Fri Jun 6 21:00 ET -- Friday is a market day.
+			Expect(status.IsMarketDay(time.Date(2025, time.June, 7, 1, 0, 0, 0, time.UTC))).To(BeTrue())
+			// Sun Jun 8, 2025 12:00 UTC == Sun 08:00 ET -- weekend.
+			Expect(status.IsMarketDay(time.Date(2025, time.June, 8, 12, 0, 0, 0, time.UTC))).To(BeFalse())
+		})
+
+		It("computes Next from a UTC wall clock correctly", func() {
+			tc, err := tradecron.New("@daily", tradecron.RegularHours)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Mon Jun 2, 2025 15:00 UTC == 11:00 ET, after the open.
+			got := tc.Next(time.Date(2025, time.June, 2, 15, 0, 0, 0, time.UTC))
+
+			// Next open is Tue Jun 3 09:30 ET.
+			want := time.Date(2025, time.June, 3, 9, 30, 0, 0, nyc)
+			Expect(got.Equal(want)).To(BeTrue(), "got %s want %s", got, want)
+		})
+	})
+
 	Describe("@quarterbegin", func() {
 		BeforeEach(func() {
 			tradecron.SetMarketHolidays(nil)


### PR DESCRIPTION
Sweep of engine, portfolio, brokers, data, signals, tradecron, study, and cli packages. Highlights: @monthbegin/@quarterbegin double-firing, intraday daily-data lookahead, child-strategy dividend attribution, wash-sale and lot-selection accounting, windowed metric correctness (MWRR, Calmar family, PSR, K-Ratio, benchmark flows), broker fill double-counting and token-refresh deadlocks, and trading-day vs calendar-day handling in technical indicators.

Every fix verified by tests that fail against the pre-fix code; see CHANGELOG for the user-visible list.