### PR TITLE
feat(engine,portfolio): record and persist prediction annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Predictions now capture the annotations the strategy recorded during the prediction run; they are available on `Prediction()` and stored in a new `predicted_annotations` table in the output file.
+
+### Changed
+
+- The backtest output file schema version is now 7; files written by earlier releases must be regenerated to be read.
+
 ## [0.12.1] - 2026-07-14
 
 ### Changed

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -229,7 +229,7 @@ for _, holding := range pred.Holdings {
 }
 ```
 
-The `backtest` and `report` commands show the predicted trades and resulting holdings at the end of the summary report. The prediction is persisted in the backtest's SQLite output in three dedicated tables: `prediction` (the predicted trade date), `predicted_transactions` (the trades the strategy would place), and `predicted_holdings` (the resulting positions). Portfolios restored with `portfolio.FromSQLite` expose it through the same `Prediction()` method.
+The `backtest` and `report` commands show the predicted trades and resulting holdings at the end of the summary report. The prediction is persisted in the backtest's SQLite output in four dedicated tables: `prediction` (the predicted trade date), `predicted_transactions` (the trades the strategy would place), `predicted_holdings` (the resulting positions), and `predicted_annotations` (the key-value annotations the strategy recorded during the prediction run). Portfolios restored with `portfolio.FromSQLite` expose it through the same `Prediction()` method.
 
 The engine clones the current portfolio, advances the date to the next scheduled trade, and forward-fills any data gaps by copying the last available prices forward day-by-day. The strategy is completely unaware it is a prediction run.
 

--- a/docs/portfolio.md
+++ b/docs/portfolio.md
@@ -381,7 +381,7 @@ for ast, qty := range p.Holdings() {
 }
 ```
 
-After a backtest, `p.Prediction()` returns the trades the strategy would place on the next scheduled trade date and the holdings that would result. The engine records it automatically at the end of every backtest, and it round-trips through the SQLite output (in the `prediction`, `predicted_transactions`, and `predicted_holdings` tables). It returns nil when no prediction has been recorded. See [Previewing upcoming trades](engine.md#previewing-upcoming-trades) for details.
+After a backtest, `p.Prediction()` returns the trades the strategy would place on the next scheduled trade date, the holdings that would result, and the annotations the strategy recorded during the prediction run. The engine records it automatically at the end of every backtest, and it round-trips through the SQLite output (in the `prediction`, `predicted_transactions`, `predicted_holdings`, and `predicted_annotations` tables). It returns nil when no prediction has been recorded. See [Previewing upcoming trades](engine.md#previewing-upcoming-trades) for details.
 
 ## Short position lifecycle
 

--- a/engine/backtest.go
+++ b/engine/backtest.go
@@ -582,6 +582,7 @@ func (e *Engine) Backtest(ctx context.Context, start, end time.Time) (portfolio.
 func (e *Engine) recordPrediction(ctx context.Context, acct portfolio.PortfolioManager) error {
 	predictedDate := e.schedule.Next(e.currentDate)
 	baseTxnCount := len(acct.Transactions())
+	baseAnnCount := len(acct.Annotations())
 
 	predicted, err := e.PredictedPortfolio(ctx)
 	if err != nil {
@@ -593,6 +594,12 @@ func (e *Engine) recordPrediction(ctx context.Context, acct portfolio.PortfolioM
 	allTxns := predicted.Transactions()
 	predictedTxns := make([]portfolio.Transaction, len(allTxns)-baseTxnCount)
 	copy(predictedTxns, allTxns[baseTxnCount:])
+
+	// The same holds for annotations: entries past the pre-prediction
+	// count were recorded by the strategy during the prediction run.
+	allAnns := predicted.Annotations()
+	predictedAnns := make([]portfolio.Annotation, len(allAnns)-baseAnnCount)
+	copy(predictedAnns, allAnns[baseAnnCount:])
 
 	holdings := predicted.Holdings()
 
@@ -617,6 +624,7 @@ func (e *Engine) recordPrediction(ctx context.Context, acct portfolio.PortfolioM
 		Date:         predictedDate,
 		Transactions: predictedTxns,
 		Holdings:     predictedHoldings,
+		Annotations:  predictedAnns,
 	})
 
 	return nil

--- a/engine/doc.go
+++ b/engine/doc.go
@@ -190,7 +190,8 @@
 //	}
 //
 // The prediction is persisted to the SQLite output in the prediction,
-// predicted_transactions, and predicted_holdings tables.
+// predicted_transactions, predicted_holdings, and predicted_annotations
+// tables.
 //
 // PredictedPortfolio can also be called directly after a backtest or during
 // live operation:

--- a/engine/predicted_portfolio_test.go
+++ b/engine/predicted_portfolio_test.go
@@ -278,11 +278,20 @@ var _ = Describe("PredictedPortfolio", func() {
 		Expect(pred.Holdings[0].Quantity).To(BeNumerically(">", 0))
 		Expect(pred.Holdings[0].MarketValue).To(BeNumerically(">", 0))
 
+		// The strategy annotates once per Compute; only the prediction
+		// run's entry belongs to the prediction, not the backtest's.
+		Expect(pred.Annotations).To(HaveLen(1), "prediction should include only annotations recorded during the prediction run")
+		Expect(pred.Annotations[0].Key).To(Equal("action"))
+		Expect(pred.Annotations[0].Value).To(Equal("buy SPY"))
+
 		// The prediction must not leak into the account's actual state.
 		for _, tx := range result.Transactions() {
 			Expect(tx.Date.After(backtestEnd)).To(BeFalse(),
 				"account transaction log should not contain predicted trades")
 		}
+
+		Expect(result.Annotations()).To(HaveLen(1),
+			"account annotation log should not contain predicted annotations")
 
 		// The prediction survives a round-trip through the SQLite output.
 		acct, ok := result.(*portfolio.Account)
@@ -300,6 +309,9 @@ var _ = Describe("PredictedPortfolio", func() {
 		Expect(restoredPred.Transactions).To(HaveLen(len(pred.Transactions)))
 		Expect(restoredPred.Holdings).To(HaveLen(len(pred.Holdings)))
 		Expect(restoredPred.Holdings[0].Asset.Ticker).To(Equal("SPY"))
+		Expect(restoredPred.Annotations).To(HaveLen(1))
+		Expect(restoredPred.Annotations[0].Key).To(Equal("action"))
+		Expect(restoredPred.Annotations[0].Value).To(Equal("buy SPY"))
 	})
 
 	It("returns error when no schedule is set", func() {

--- a/portfolio/prediction.go
+++ b/portfolio/prediction.go
@@ -45,6 +45,12 @@ type Prediction struct {
 	// Holdings are the positions the portfolio would hold after the
 	// predicted trades execute, sorted by ticker then FIGI.
 	Holdings []PredictedHolding
+
+	// Annotations are the key-value entries the strategy recorded during
+	// the prediction run, in the order they were recorded. Only Key and
+	// Value are persisted to the SQLite output; Timestamp and BatchID
+	// refer to the transient prediction clone and are not restored.
+	Annotations []Annotation
 }
 
 // SetPrediction stores the outcome of a prediction run on the account.

--- a/portfolio/sqlite.go
+++ b/portfolio/sqlite.go
@@ -32,7 +32,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = "6"
+const schemaVersion = "7"
 
 const dateFormat = "2006-01-02"
 
@@ -138,6 +138,11 @@ CREATE TABLE predicted_holdings (
     asset_figi   TEXT NOT NULL,
     quantity     REAL NOT NULL,
     market_value REAL NOT NULL
+);
+
+CREATE TABLE predicted_annotations (
+    key   TEXT NOT NULL,
+    value TEXT NOT NULL
 );
 `
 
@@ -630,6 +635,18 @@ func (a *Account) writePrediction(tx *sql.Tx) error {
 		}
 	}
 
+	annStmt, err := tx.Prepare("INSERT INTO predicted_annotations (key, value) VALUES (?, ?)")
+	if err != nil {
+		return fmt.Errorf("prepare predicted_annotations: %w", err)
+	}
+	defer annStmt.Close()
+
+	for _, ann := range a.prediction.Annotations {
+		if _, err := annStmt.Exec(ann.Key, ann.Value); err != nil {
+			return fmt.Errorf("insert predicted_annotation: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -730,6 +747,26 @@ func (a *Account) readPrediction(db *sql.DB) error {
 		return err
 	}
 
+	annRows, err := db.Query("SELECT key, value FROM predicted_annotations ORDER BY rowid")
+	if err != nil {
+		return fmt.Errorf("query predicted_annotations: %w", err)
+	}
+	defer annRows.Close()
+
+	for annRows.Next() {
+		var ann Annotation
+
+		if err := annRows.Scan(&ann.Key, &ann.Value); err != nil {
+			return fmt.Errorf("scan predicted_annotation: %w", err)
+		}
+
+		pred.Annotations = append(pred.Annotations, ann)
+	}
+
+	if err := annRows.Err(); err != nil {
+		return err
+	}
+
 	a.prediction = pred
 
 	return nil
@@ -760,7 +797,7 @@ func (a *Account) readAnnotations(db *sql.DB) error {
 }
 
 // FromSQLite restores an Account from a SQLite database at the given path.
-// The database must have been created by ToSQLite with schema_version "6".
+// The database must have been created by ToSQLite with schema_version "7".
 // Fields that require a live broker or price DataFrame (broker, prices,
 // registeredMetrics) are not restored.
 func FromSQLite(path string) (*Account, error) {

--- a/portfolio/sqlite_test.go
+++ b/portfolio/sqlite_test.go
@@ -328,6 +328,10 @@ var _ = Describe("SQLite", func() {
 					{Asset: bnd, Quantity: 5, MarketValue: 400},
 					{Asset: spy, Quantity: 10, MarketValue: 5000},
 				},
+				Annotations: []portfolio.Annotation{
+					{Timestamp: predictedDate, Key: "momentum", Value: "0.42"},
+					{Timestamp: predictedDate, Key: "bond_fraction", Value: "0.10"},
+				},
 			})
 
 			path := filepath.Join(tmpDir, "prediction.db")
@@ -359,6 +363,14 @@ var _ = Describe("SQLite", func() {
 			Expect(pred.Holdings[1].Asset).To(Equal(spy))
 			Expect(pred.Holdings[1].Quantity).To(Equal(10.0))
 			Expect(pred.Holdings[1].MarketValue).To(Equal(5000.0))
+
+			// Only Key and Value round-trip; Timestamp and BatchID refer to
+			// the transient prediction clone and are not persisted.
+			Expect(pred.Annotations).To(HaveLen(2))
+			Expect(pred.Annotations[0].Key).To(Equal("momentum"))
+			Expect(pred.Annotations[0].Value).To(Equal("0.42"))
+			Expect(pred.Annotations[1].Key).To(Equal("bond_fraction"))
+			Expect(pred.Annotations[1].Value).To(Equal("0.10"))
 		})
 
 		It("restores a nil prediction when none was stored", func() {
@@ -483,7 +495,7 @@ var _ = Describe("SQLite", func() {
 
 			var schemaVer string
 			Expect(db.QueryRow(`SELECT value FROM metadata WHERE key='schema_version'`).Scan(&schemaVer)).To(Succeed())
-			Expect(schemaVer).To(Equal("6"))
+			Expect(schemaVer).To(Equal("7"))
 
 			var total int
 			Expect(db.QueryRow(`SELECT COUNT(*) FROM positions_daily`).Scan(&total)).To(Succeed())


### PR DESCRIPTION
Predictions now capture the annotations the strategy recorded during the prediction run.

- `Prediction` gains an `Annotations []Annotation` field, harvested in `recordPrediction` from the prediction clone's annotation log using the same pre-run count trick as predicted transactions.
- Annotations are persisted to a new `predicted_annotations (key, value)` table alongside `predicted_transactions` and `predicted_holdings`, and restored by `FromSQLite`. Only key and value are persisted; timestamp and batch ID refer to the transient prediction clone.
- The snapshot schema version is now 7; files written by earlier releases must be regenerated to be read.